### PR TITLE
Update to new wgpu

### DIFF
--- a/examples/custom_object.py
+++ b/examples/custom_object.py
@@ -83,12 +83,10 @@ camera = gfx.NDCCamera()  # This material does not actually use the camera
 
 
 def animate():
-    physical_size = canvas.get_physical_size()
-    camera.set_viewport_size(*physical_size)
     renderer.render(scene, camera)
 
 
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(animate)
     app.exec_()
     canvas.closeEvent = lambda *args: app.quit()

--- a/examples/depth_clipping.py
+++ b/examples/depth_clipping.py
@@ -57,15 +57,9 @@ for plane in (plane1, plane2, plane3, plane4):
 
 
 def animate():
-    # would prefer to do this in a resize event only
-    logical_size = canvas.get_logical_size()
-    camera.set_viewport_size(*logical_size)
-    # actually render the scene
     renderer.render(scene, camera)
-    # Request new frame
-    canvas.request_draw()
 
 
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(animate)
     app.exec_()

--- a/examples/geometry_cube.py
+++ b/examples/geometry_cube.py
@@ -16,11 +16,14 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
+im = imageio.imread("imageio:bricks.jpg").astype(np.float32) / 255
 im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
-tex = gfx.Texture(im, dim=2, usage="sampled").get_view(filter="linear")
+tex = gfx.Texture(im, dim=2, usage="sampled").get_view(
+    filter="linear", address_mode="repeat"
+)
 
 geometry = gfx.BoxGeometry(200, 200, 200)
+geometry.texcoords.data[:] *= 2  # smaller bricks
 material = gfx.MeshBasicMaterial(map=tex, clim=(0.2, 0.8))
 cube = gfx.Mesh(geometry, material)
 scene.add(cube)
@@ -30,8 +33,6 @@ camera.position.z = 400
 
 
 def animate():
-    # cube.rotation.x += 0.005
-    # cube.rotation.y += 0.01
     rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.0005, 0.001))
     cube.rotation.multiply(rot)
 

--- a/examples/geometry_cube.py
+++ b/examples/geometry_cube.py
@@ -16,8 +16,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-# todo: don't reduce image size, its needed now because a 1MB buffer size limit that has been fixed, but not yet in our build
-im = imageio.imread("imageio:chelsea.png")[:250, :250, :].astype(np.float32) / 255
+im = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
 im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
 tex = gfx.Texture(im, dim=2, usage="sampled").get_view(filter="linear")
 
@@ -31,22 +30,15 @@ camera.position.z = 400
 
 
 def animate():
-    # would prefer to do this in a resize event only
-    physical_size = canvas.get_physical_size()
-    camera.set_viewport_size(*physical_size)
-
     # cube.rotation.x += 0.005
     # cube.rotation.y += 0.01
     rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.0005, 0.001))
     cube.rotation.multiply(rot)
 
-    # actually render the scene
     renderer.render(scene, camera)
-
-    # Request new frame
     canvas.request_draw()
 
 
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(animate)
     app.exec_()

--- a/examples/geometry_cubes.py
+++ b/examples/geometry_cubes.py
@@ -27,6 +27,9 @@ for i, cube in enumerate(cubes):
     cube.position.set(350 - i * 100, 0, 0)
     scene.add(cube)
 
+background = gfx.Background(gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+scene.add(background)
+
 camera = gfx.PerspectiveCamera(70, 16 / 9)
 camera.position.z = 500
 

--- a/examples/geometry_cubes.py
+++ b/examples/geometry_cubes.py
@@ -16,7 +16,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:chelsea.png")[:250, :250, :].astype(np.float32) / 255
+im = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
 im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
 tex = gfx.Texture(im, dim=2, usage="sampled").get_view(filter="linear")
 
@@ -32,23 +32,16 @@ camera.position.z = 500
 
 
 def animate():
-    # would prefer to do this in a resize event only
-    physical_size = canvas.get_physical_size()
-    camera.set_viewport_size(*physical_size)
-
     for i, cube in enumerate(cubes):
         rot = gfx.linalg.Quaternion().set_from_euler(
             gfx.linalg.Euler(0.0005 * i, 0.001 * i)
         )
         cube.rotation.multiply(rot)
 
-    # actually render the scene
     renderer.render(scene, camera)
-
-    # Request new frame
     canvas.request_draw()
 
 
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(animate)
     app.exec_()

--- a/examples/geometry_plane.py
+++ b/examples/geometry_plane.py
@@ -38,10 +38,6 @@ t = time.time()
 def animate():
     global t
 
-    # would prefer to do this in a resize event only
-    physical_size = canvas.get_physical_size()
-    camera.set_viewport_size(*physical_size)
-
     if time.time() - t > 0.05:
         # Read next frame, rewind if we reach the end
         t = time.time()
@@ -53,10 +49,7 @@ def animate():
             tex.update_range((0, 0, 0), tex.size)
             material.dirty = 1
 
-    # actually render the scene
     renderer.render(scene, camera)
-
-    # Request new frame
     canvas.request_draw()
 
 

--- a/examples/image_plus_points.py
+++ b/examples/image_plus_points.py
@@ -18,7 +18,7 @@ scene = gfx.Scene()
 
 # %% add image
 
-im = imageio.imread("imageio:astronaut.png")[::2, ::2, :]
+im = imageio.imread("imageio:astronaut.png")
 im = np.concatenate([im, 255 * np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)  # yuk!
 
 tex = gfx.Texture(im, dim=2, usage="sampled")
@@ -50,15 +50,9 @@ camera.position.set(256, 256, 0)
 
 
 def animate():
-    # would prefer to do this in a resize event only
-    logical_size = canvas.get_logical_size()
-    camera.set_viewport_size(*logical_size)
-    # actually render the scene
     renderer.render(scene, camera)
-    # Request new frame
-    canvas.request_draw()
 
 
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(animate)
     app.exec_()

--- a/examples/integration_qt.py
+++ b/examples/integration_qt.py
@@ -22,7 +22,7 @@ class Main(QtWidgets.QWidget):
         self._camera = gfx.OrthographicCamera(110, 110)
 
         # Hook up the animate callback
-        self._canvas.draw_frame = self.animate
+        self._canvas.request_draw(self.animate)
 
         layout = QtWidgets.QHBoxLayout()
         self.setLayout(layout)
@@ -40,8 +40,6 @@ class Main(QtWidgets.QWidget):
         self._canvas.update()
 
     def animate(self):
-        psize = self._canvas.get_physical_size()
-        self._camera.set_viewport_size(*psize)
         self._renderer.render(self._scene, self._camera)
 
 

--- a/examples/line_basic.py
+++ b/examples/line_basic.py
@@ -44,14 +44,10 @@ camera.position.set(300, 250, 0)
 
 
 def animate():
-    # would prefer to do this in a resize event only
-    lsize = canvas.get_logical_size()
-    camera.set_viewport_size(*lsize)
     renderer.render(scene, camera)
-    canvas.request_draw()
 
 
 if __name__ == "__main__":
     renderer_svg.render(scene, camera)
-    canvas.draw_frame = animate
+    canvas.request_draw(animate)
     app.exec_()

--- a/examples/line_performance.py
+++ b/examples/line_performance.py
@@ -32,14 +32,6 @@ camera = gfx.OrthographicCamera(110, 110)
 camera.position.set(50, 0, 0)
 
 
-def animate():
-    # would prefer to do this in a resize event only
-    lsize = canvas.get_logical_size()
-    camera.set_viewport_size(*lsize)
-    renderer.render(scene, camera)
-    canvas.request_draw()
-
-
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(lambda: renderer.render(scene, camera))
     app.exec_()

--- a/examples/line_segments.py
+++ b/examples/line_segments.py
@@ -30,14 +30,6 @@ scene.add(line)
 camera = gfx.ScreenCoordsCamera()
 
 
-def animate():
-    # would prefer to do this in a resize event only
-    lsize = canvas.get_logical_size()
-    camera.set_viewport_size(*lsize)
-    renderer.render(scene, camera)
-    canvas.request_draw()
-
-
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(lambda: renderer.render(scene, camera))
     app.exec_()

--- a/examples/line_thick.py
+++ b/examples/line_thick.py
@@ -39,14 +39,6 @@ for line in [line1, line2, line3, line4]:
 camera = gfx.ScreenCoordsCamera()
 
 
-def animate():
-    # would prefer to do this in a resize event only
-    lsize = canvas.get_logical_size()
-    camera.set_viewport_size(*lsize)
-    renderer.render(scene, camera)
-    canvas.request_draw()
-
-
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(lambda: renderer.render(scene, camera))
     app.exec_()

--- a/examples/points_basic.py
+++ b/examples/points_basic.py
@@ -21,14 +21,6 @@ scene.add(points)
 camera = gfx.NDCCamera()
 
 
-def animate():
-    # would prefer to do this in a resize event only
-    psize = canvas.get_physical_size()
-    camera.set_viewport_size(*psize)
-    renderer.render(scene, camera)
-    canvas.request_draw()
-
-
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(lambda: renderer.render(scene, camera))
     app.exec_()

--- a/examples/points_basic.py
+++ b/examples/points_basic.py
@@ -18,6 +18,8 @@ material = gfx.PointsMaterial(size=10, color=(0, 1, 0.5, 0.7))
 points = gfx.Points(geometry, material)
 scene.add(points)
 
+scene.add(gfx.Background(gfx.BackgroundMaterial((0.04, 0.0, 0, 1), (0, 0.0, 0.04, 1))))
+
 camera = gfx.NDCCamera()
 
 

--- a/examples/skybox.py
+++ b/examples/skybox.py
@@ -4,7 +4,6 @@ Example with a skybox background.
 Inspired by https://github.com/gfx-rs/wgpu-rs/blob/master/examples/skybox/main.rs
 """
 
-
 import numpy as np
 import imageio
 import pygfx as gfx
@@ -12,18 +11,14 @@ import pygfx as gfx
 from PyQt5 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
-# Read images
-# The order of the images here is determined by how the GPU samples cube textures.
-images = []
-# base_url = "https://raw.githubusercontent.com/imageio/imageio-binaries/master/images/"
-base_url = "C:/dev/pylib/imageio-binaries/images/"
-for suffix in ("posx", "negx", "posy", "negy", "posz", "negz"):
-    im = imageio.imread(base_url + "meadow_" + suffix + ".jpg")
-    im = np.concatenate([im, 255 * np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
-    images.append(im)
+# Read the image
+# The order of the images is already correct for GPU cubemap texture sampling
+im = imageio.imread("imageio:meadow_cube.jpg")
+im = np.concatenate([im, 255 * np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
 
 # Turn it into a 3D image (a 4d nd array)
-cubemap_image = np.concatenate(images, 0).reshape(-1, *images[0].shape)
+width = height = im.shape[1]
+im.shape = -1, width, height, 4
 
 app = QtWidgets.QApplication([])
 canvas = WgpuCanvas()
@@ -31,8 +26,8 @@ renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
 # Create cubemap texture
-tex_size = images[0].shape[0], images[0].shape[1], 6
-tex = gfx.Texture(cubemap_image, dim=2, size=tex_size, usage="sampled")
+tex_size = width, height, 6
+tex = gfx.Texture(im, dim=2, size=tex_size, usage="sampled")
 view = tex.get_view(view_dim="cube", layer_range=range(6))
 
 # And the background image with the cube texture

--- a/examples/skybox.py
+++ b/examples/skybox.py
@@ -21,7 +21,7 @@ base_url = "C:/dev/pylib/imageio-binaries/images/"
 for suffix in ("negx", "negy", "negz", "posx", "posy", "posz"):
     im = imageio.imread(base_url + "meadow_" + suffix + ".jpg")
     im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
-    im = im[::3, ::3, :]  # todo: don't reduce size when we can use >1MB buffers
+    im = im[::3, ::3, :]  # todo: ? prevent TooManyObjects error
     images.append(im)
 
 # Turn it into a 3D image (a 4d nd array)
@@ -44,26 +44,19 @@ cube = gfx.Mesh(geometry, material)
 scene.add(cube)
 
 camera = gfx.PerspectiveCamera(70)
-camera.position.z = 400
+camera.position.z = 0
 
 
 def animate():
-    # would prefer to do this in a resize event only
-    physical_size = canvas.get_physical_size()
-    camera.set_viewport_size(*physical_size)
-
     # cube.rotation.x += 0.005
     # cube.rotation.y += 0.01
     rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.0005, 0.001))
     cube.rotation.multiply(rot)
 
-    # actually render the scene
     renderer.render(scene, camera)
-
-    # Request new frame
     canvas.request_draw()
 
 
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(animate)
     app.exec_()

--- a/examples/skybox.py
+++ b/examples/skybox.py
@@ -1,11 +1,9 @@
 """
-Example showing a single geometric cube.
+Example with a skybox background.
 
 Inspired by https://github.com/gfx-rs/wgpu-rs/blob/master/examples/skybox/main.rs
 """
 
-# todo: not working ATM, a Rust assertion fails in _update_texture(),
-# let's wait til the next release of wgpu-native and try again
 
 import numpy as np
 import imageio
@@ -28,7 +26,6 @@ for suffix in ("posx", "negx", "posy", "negy", "posz", "negz"):
 cubemap_image = np.concatenate(images, 0).reshape(-1, *images[0].shape)
 
 app = QtWidgets.QApplication([])
-
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()

--- a/examples/volume_slice1.py
+++ b/examples/volume_slice1.py
@@ -49,17 +49,6 @@ def scroll(degrees):
     canvas.request_draw()
 
 
-def animate():
-    global t
-
-    # would prefer to do this in a resize event only
-    physical_size = canvas.get_physical_size()
-    camera.set_viewport_size(*physical_size)
-
-    # actually render the scene
-    renderer.render(scene, camera)
-
-
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(lambda: renderer.render(scene, camera))
     app.exec_()

--- a/examples/volume_slice2.py
+++ b/examples/volume_slice2.py
@@ -26,12 +26,13 @@ renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
 vol = imageio.volread("imageio:stent.npz")
+vol[:, 30:-30, 30:-30] = vol.mean()
 nslices = vol.shape[0]
 index = nslices // 2
 
 tex_size = tuple(reversed(vol.shape))
 tex = gfx.Texture(vol, dim=2, size=tex_size, usage="sampled")
-view = tex.get_view(filter="linear", view_dim="2d", layer_range=(index, index + 1))
+view = tex.get_view(filter="linear", view_dim="2d", layer_range=range(index, index + 1))
 
 geometry = gfx.PlaneGeometry(200, 200, 12, 12)
 material = gfx.MeshBasicMaterial(map=view, clim=(0, 255))
@@ -46,23 +47,15 @@ def scroll(degrees):
     global index
     index = index + int(degrees / 15)
     index = max(0, min(nslices - 1, index))
-    view = tex.get_view(filter="linear", view_dim="2d", layer_range=(index, index + 1))
+    print(index)
+    view = tex.get_view(
+        filter="linear", view_dim="2d", layer_range=range(index, index + 1)
+    )
     material.map = view
     material.dirty = 1
     canvas.request_draw()
 
 
-def animate():
-    global t
-
-    # would prefer to do this in a resize event only
-    physical_size = canvas.get_physical_size()
-    camera.set_viewport_size(*physical_size)
-
-    # actually render the scene
-    renderer.render(scene, camera)
-
-
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(lambda: renderer.render(scene, camera))
     app.exec_()

--- a/examples/volume_slice2.py
+++ b/examples/volume_slice2.py
@@ -26,7 +26,6 @@ renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
 vol = imageio.volread("imageio:stent.npz")
-vol[:, 30:-30, 30:-30] = vol.mean()
 nslices = vol.shape[0]
 index = nslices // 2
 
@@ -47,7 +46,6 @@ def scroll(degrees):
     global index
     index = index + int(degrees / 15)
     index = max(0, min(nslices - 1, index))
-    print(index)
     view = tex.get_view(
         filter="linear", view_dim="2d", layer_range=range(index, index + 1)
     )

--- a/examples/volume_slice3.py
+++ b/examples/volume_slice3.py
@@ -23,7 +23,7 @@ canvas = WgpuCanvasWithScroll()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-vol = imageio.volread("imageio:stent.npz")[::2, ::2, ::2]
+vol = imageio.volread("imageio:stent.npz")
 nslices = vol.shape[0]
 index = nslices // 2
 
@@ -54,17 +54,6 @@ def scroll(degrees):
     canvas.request_draw()
 
 
-def animate():
-    global t
-
-    # would prefer to do this in a resize event only
-    physical_size = canvas.get_physical_size()
-    camera.set_viewport_size(*physical_size)
-
-    # actually render the scene
-    renderer.render(scene, camera)
-
-
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    canvas.request_draw(lambda: renderer.render(scene, camera))
     app.exec_()

--- a/pygfx/datawrappers/__init__.py
+++ b/pygfx/datawrappers/__init__.py
@@ -1,4 +1,4 @@
 # flake8: noqa
 
-from ._buffer import BaseBuffer, Buffer
-from ._texture import BaseTexture, Texture, TextureView
+from ._buffer import Buffer
+from ._texture import Texture, TextureView

--- a/pygfx/datawrappers/_buffer.py
+++ b/pygfx/datawrappers/_buffer.py
@@ -21,8 +21,10 @@ class Buffer:
             with "|". See wgpu.BufferUsage.
         nbytes (int): The number of bytes. If data is given, it is derived.
         nitems (int): The number of items. If data is given, it is derived.
-        vertex_format (str): The format to use when used as a vertex buffer.
-            If data is given, it is derived. Must be a value from wgpu.VertexFormat.
+        format (str): The format to use when used as a vertex buffer.
+            Must be a value from wgpu.VertexFormat. By default it is
+            derived from the data. Set when data is not given or when
+            you want to overload the derived value.
     """
 
     def __init__(
@@ -88,8 +90,11 @@ class Buffer:
 
     @property
     def data(self):
-        """ The data for this buffer as originally provided. Can be None if
-        the data only exists on the GPU.
+        """ The data for this buffer. Can be None if the data only
+        exists on the GPU.
+
+        Note: the data is the same reference that was given to instantiate this object,
+        but this may change.
         """
         return self._data
 

--- a/pygfx/datawrappers/_buffer.py
+++ b/pygfx/datawrappers/_buffer.py
@@ -1,23 +1,28 @@
-import ctypes
+import numpy as np
 
 import wgpu
 
+STRUCT_FORMAT_ALIASES = {"c": "B", "l": "i", "L": "I"}
 
-class BaseBuffer:
-    """ A base buffer class that does not make assumptions on the kind
-    of array (numpy, ctypes or otherwise).
+
+class Buffer:
+    """ A buffer object represents a piece of memory to the GPU, that can be
+    used as index buffer, vertex buffer, uniform buffer, or storage buffer.
+    You can provide (and update data for it), or use it as a placeholder
+    for a buffer with no representation on the CPU.
 
     Parameters:
-        data (array): Array data. Optional. If not given, nbytes and nitems
-            must be provided, and format if used as an index or vertex buffer.
+        data (array, optional): Array data of any type that supports the
+            buffer-protocol, (e.g. a bytes or numpy array). If not given
+            or None, nbytes and nitems must be provided. The data is
+            copied if it's float64 or not contiguous.
         usage (str): The way(s) that the texture will be used. E.g. "INDEX"
             "VERTEX", "UNIFORM". Multiple values can be given separated
             with "|". See wgpu.BufferUsage.
         nbytes (int): The number of bytes. If data is given, it is derived.
         nitems (int): The number of items. If data is given, it is derived.
         vertex_format (str): The format to use when used as a vertex buffer.
-            If data is given, it is derived. Must be a value from
-            wgpu.VertexFormat.
+            If data is given, it is derived. Must be a value from wgpu.VertexFormat.
     """
 
     def __init__(
@@ -33,16 +38,23 @@ class BaseBuffer:
 
         # Get nbytes
         if data is not None:
+            mem = memoryview(data)
+            if mem.format == "d":
+                raise ValueError("Float64 data is not supported, use float32 instead.")
+            # if not mem.contiguous or mem.format == "d":
+            #     format = "f" if mmemformat == "d" else mem.format
+            #     x = np.empty(mem.shape, format)
+            #     x[:] = mem
+            #     mem = memoryview(x)
             self._data = data
-            self._nbytes = self._nbytes_from_data(data)
-            self._nitems = self._nitems_from_data(data, nitems)
+            self._mem = mem
+            self._nbytes = mem.nbytes
+            self._nitems = mem.shape[0] if mem.shape else 1
             self._pending_uploads.append((0, self._nitems))
-            if nbytes is not None:
-                if nbytes != self._nbytes:
-                    raise ValueError("Given nbytes does not match size of given data.")
-            if nitems is not None:
-                if nitems != self._nitems:
-                    raise ValueError("Given nitems does not match shape of given data.")
+            if nbytes is not None and nbytes != self._nbytes:
+                raise ValueError("Given nbytes does not match size of given data.")
+            if nitems is not None and nitems != self._nitems:
+                raise ValueError("Given nitems does not match shape of given data.")
         elif nbytes is not None and nitems is not None:
             self._nbytes = int(nbytes)
             self._nitems = int(nitems)
@@ -75,6 +87,20 @@ class BaseBuffer:
         return self._usage
 
     @property
+    def data(self):
+        """ The data for this buffer as originally provided. Can be None if
+        the data only exists on the GPU.
+        """
+        return self._data
+
+    @property
+    def mem(self):
+        """ The data for this buffer as a memoryview. Can be None if
+        the data only exists on the GPU.
+        """
+        return self._mem
+
+    @property
     def nbytes(self):
         """ The number of bytes in the buffer.
         """
@@ -93,7 +119,7 @@ class BaseBuffer:
         if self._format is not None:
             return self._format
         elif self.data is not None:
-            self._format = self._format_from_data(self.data)
+            self._format = format_from_memoryview(self.mem, self.usage)
             return self._format
         else:
             raise ValueError("Buffer has no data nor format.")
@@ -110,13 +136,6 @@ class BaseBuffer:
         assert offset >= 0
         assert offset + nbytes <= self.nbytes
         self._vertex_byte_range = offset, nbytes
-
-    @property
-    def data(self):
-        """ The data for this buffer as given when instantiated. Can
-        be None if the data only exists on the GPU.
-        """
-        return self._data
 
     def update_range(self, offset=0, size=2 ** 50):
         """ Mark a certain range of the data for upload to the GPU. The
@@ -142,105 +161,88 @@ class BaseBuffer:
         self._pending_uploads.append((offset, size))
         # todo: this can be smarter, we have logic for chunking in the morph tool
 
-    # To implement in subclasses
-
-    def _nbytes_from_data(self, data):
-        raise NotImplementedError()
-
-    def _nitems_from_data(self, data, nitems):
-        raise NotImplementedError()
-
-    def _format_from_data(self, data):
-        raise NotImplementedError()
-
-    def _renderer_copy_data_to_ctypes_object(self, ob, offset, size):
-        """ Allows renderer to efficiently copy the data.
+    def _get_subdata(self, offset, size):
+        """ Return subdata as a contiguous array.
         """
-        raise NotImplementedError()
-
-
-class Buffer(BaseBuffer):  # numpy-based
-    """ A class that wraps a (GPU) buffer object, optionally providing
-    data for it. You can also use it as a placeholder for a buffer with
-    no representation on the CPU.
-    """
-
-    def _nbytes_from_data(self, data):
-        return data.nbytes
-
-    def _nitems_from_data(self, data, nitems):
-        if data.shape:
-            return data.shape[0]
+        # If this is a full range, this is easy
+        if offset == 0 and size == self.nitems and self.mem.contiguous:
+            return self.mem
+        # Get a numpy array, because memoryviews do not support nd slicing
+        if isinstance(self.data, np.ndarray):
+            arr = self.data
+        elif not self.mem.c_contiguous:
+            raise ValueError(
+                "Non-contiguous texture data is only supported for numpy array."
+            )
         else:
-            return 1
+            arr = np.frombuffer(self.mem, self.mem.format).reshape(self.mem.shape)
+        # Slice it
+        sub_arr = arr[offset:size]
+        return memoryview(np.ascontiguousarray(sub_arr))
 
-    def _format_from_data(self, data):
-        if "INDEX" in self.usage:
 
-            key = str(data.dtype)
-            mapping = {
-                "int16": wgpu.IndexFormat.uint16,
-                "uint16": wgpu.IndexFormat.uint16,
-                "int32": wgpu.IndexFormat.uint32,
-                "uint32": wgpu.IndexFormat.uint32,
-            }
-            try:
-                return mapping[key]
-            except KeyError:
-                raise TypeError(
-                    "Need dtype (u)int16 or (u)int32 for index data, not '{dtype}'."
+def format_from_memoryview(mem, usage):
+
+    if "INDEX" in usage:
+
+        format = str(mem.format)
+        format = STRUCT_FORMAT_ALIASES.get(format, format)
+        mapping = {
+            "h": wgpu.IndexFormat.uint16,
+            "H": wgpu.IndexFormat.uint16,
+            "i": wgpu.IndexFormat.uint32,
+            "I": wgpu.IndexFormat.uint32,
+        }
+        try:
+            return mapping[format]
+        except KeyError:
+            raise TypeError(
+                f"Need 16bit or 32bit signed/unsigned int (hHiI) for index data, not '{format}'."
+            )
+
+    else:  # if "VERTEX" in self.usage:
+
+        shape = mem.shape
+        if len(shape) == 1:
+            shape = shape + (1,)
+        assert len(shape) == 2
+        format = str(mem.format)
+        format = STRUCT_FORMAT_ALIASES.get(format, format)
+        key = format, shape[-1]
+        mapping = {
+            ("f", 1): wgpu.VertexFormat.float,
+            ("f", 2): wgpu.VertexFormat.float2,
+            ("f", 3): wgpu.VertexFormat.float3,
+            ("f", 4): wgpu.VertexFormat.float4,
+            #
+            ("e", 2): wgpu.VertexFormat.half2,
+            ("e", 4): wgpu.VertexFormat.half4,
+            #
+            ("b", 2): wgpu.VertexFormat.char2,
+            ("b", 4): wgpu.VertexFormat.char4,
+            ("B", 2): wgpu.VertexFormat.uchar2,
+            ("B", 4): wgpu.VertexFormat.uchar4,
+            #
+            ("h", 2): wgpu.VertexFormat.short2,
+            ("h", 4): wgpu.VertexFormat.short4,
+            ("I", 2): wgpu.VertexFormat.ushort2,
+            ("I", 4): wgpu.VertexFormat.ushort4,
+            #
+            ("i", 1): wgpu.VertexFormat.int,
+            ("i", 2): wgpu.VertexFormat.int2,
+            ("i", 3): wgpu.VertexFormat.int3,
+            ("i", 4): wgpu.VertexFormat.int4,
+            #
+            ("I", 1): wgpu.VertexFormat.uint,
+            ("I", 2): wgpu.VertexFormat.uint2,
+            ("I", 3): wgpu.VertexFormat.uint3,
+            ("I", 4): wgpu.VertexFormat.uint4,
+        }
+        try:
+            return mapping[key]
+        except KeyError:
+            if format in ("d", "float64"):
+                raise ValueError(
+                    "64-bit float is not supported, use 32-bit float instead"
                 )
-
-        else:  # if "VERTEX" in self.usage:
-
-            shape = data.shape
-            if len(shape) == 1:
-                shape = shape + (1,)
-            assert len(shape) == 2
-            key = str(data.dtype), shape[-1]
-            mapping = {
-                ("float32", 1): wgpu.VertexFormat.float,
-                ("float32", 2): wgpu.VertexFormat.float2,
-                ("float32", 3): wgpu.VertexFormat.float3,
-                ("float32", 4): wgpu.VertexFormat.float4,
-                #
-                ("float16", 2): wgpu.VertexFormat.half2,
-                ("float16", 4): wgpu.VertexFormat.half4,
-                #
-                ("int8", 2): wgpu.VertexFormat.char2,
-                ("int8", 4): wgpu.VertexFormat.char4,
-                ("uint8", 2): wgpu.VertexFormat.uchar2,
-                ("uint8", 4): wgpu.VertexFormat.uchar4,
-                #
-                ("int16", 2): wgpu.VertexFormat.short2,
-                ("int16", 4): wgpu.VertexFormat.short4,
-                ("uint16", 2): wgpu.VertexFormat.ushort2,
-                ("uint16", 4): wgpu.VertexFormat.ushort4,
-                #
-                ("int32", 1): wgpu.VertexFormat.int,
-                ("int32", 2): wgpu.VertexFormat.int2,
-                ("int32", 3): wgpu.VertexFormat.int3,
-                ("int32", 4): wgpu.VertexFormat.int4,
-                #
-                ("uint32", 1): wgpu.VertexFormat.uint,
-                ("uint32", 2): wgpu.VertexFormat.uint2,
-                ("uint32", 3): wgpu.VertexFormat.uint3,
-                ("uint32", 4): wgpu.VertexFormat.uint4,
-            }
-            try:
-                return mapping[key]
-            except KeyError:
-                if data.dtype == "float64":
-                    raise ValueError(
-                        "64-bit float is not supported, use 32-bit float instead"
-                    )
-                raise ValueError(f"Invalid dtype/shape for vertex data: {key}")
-
-    def _renderer_copy_data_to_ctypes_object(self, ob, offset, size):
-        nbytes_per_item = self._nbytes // self._nitems
-        byte_offset = offset * nbytes_per_item
-        byte_size = size * nbytes_per_item
-        assert byte_size == ctypes.sizeof(ob)
-        ctypes.memmove(
-            ctypes.addressof(ob), self.data.ctypes.data + byte_offset, byte_size,
-        )
+            raise ValueError(f"Invalid format/shape for vertex data: {key}")

--- a/pygfx/datawrappers/_buffer.py
+++ b/pygfx/datawrappers/_buffer.py
@@ -225,8 +225,8 @@ def format_from_memoryview(mem, usage):
             #
             ("h", 2): wgpu.VertexFormat.short2,
             ("h", 4): wgpu.VertexFormat.short4,
-            ("I", 2): wgpu.VertexFormat.ushort2,
-            ("I", 4): wgpu.VertexFormat.ushort4,
+            ("H", 2): wgpu.VertexFormat.ushort2,
+            ("H", 4): wgpu.VertexFormat.ushort4,
             #
             ("i", 1): wgpu.VertexFormat.int,
             ("i", 2): wgpu.VertexFormat.int2,

--- a/pygfx/datawrappers/_texture.py
+++ b/pygfx/datawrappers/_texture.py
@@ -22,10 +22,9 @@ class Texture:
             If not given or None, it is derived from dim and the shape of
             the data. By creating a 2D array with ``depth > 1``, a view can
             be created with format 'd2_array' or 'cube'.
-        format (enum str): the GPU format of texture. If not given or None,
-            it is derived from the given data dtype. Otherwise, provide a
-            value from wgpu.TextureFormat.
-            THIS IS NOT TRUE. we need to decide what happens with uint8
+        format (enum str): the GPU format of texture. Must be a value from
+            wgpu.TextureFormat. By default it is derived from the data. Set when
+            data is not given or when you want to overload the derived value.
     """
 
     def __init__(self, data=None, *, dim, usage="SAMPLED", size=None, format=None):
@@ -92,8 +91,11 @@ class Texture:
 
     @property
     def data(self):
-        """ The data for this texture as originally provided. Can be None if the
-        data only exists on the GPU.
+        """ The data for this texture. Can be None if the data only
+        exists on the GPU.
+
+        Note: the data is the same reference that was given to
+        instantiate this object, but this may change.
         """
         return self._data
 

--- a/pygfx/materials/__init__.py
+++ b/pygfx/materials/__init__.py
@@ -11,3 +11,4 @@ from ._line import (
     LineArrowMaterial,
 )
 from ._volume import MeshVolumeSliceMaterial
+from ._background import BackgroundMaterial, BackgroundImageMaterial

--- a/pygfx/materials/_background.py
+++ b/pygfx/materials/_background.py
@@ -108,13 +108,11 @@ class BackgroundMaterial(Material):
         self.dirty = True
 
 
-# todo: needs a way to orient the skybox (by default the world is in the x-z plane, with +y pointing up)
-
-
 class BackgroundImageMaterial(BackgroundMaterial):
     """ A background material that displays an image. If map is a 2D
     texture view, it is used as a static background. If it is a cube
     texture view, (on a NxMx6 texture) it is used as a skybox.
+    Use the Background object's transform to orient the image.
     """
 
     def __init__(self, map=None):

--- a/pygfx/materials/_background.py
+++ b/pygfx/materials/_background.py
@@ -1,0 +1,133 @@
+from pyshader import Struct, vec4
+
+from ._base import Material
+from ..utils import array_from_shadertype
+from ..datawrappers import Buffer
+
+# todo: in ThreeJS you can simply set a CubeTexture as the scene.background
+# we could do that, and the scene could use these objects automatically.
+# Or just leave it like this. I kinda like it.
+
+
+class BackgroundMaterial(Material):
+    """ A background material that draws the background is a uniform color
+    or in a gradient.
+    """
+
+    uniform_type = Struct(
+        color_bottom_left=vec4,
+        color_bottom_right=vec4,
+        color_top_left=vec4,
+        color_top_right=vec4,
+    )
+
+    def __init__(self, *colors):
+        super().__init__()
+
+        self.uniform_buffer = Buffer(
+            array_from_shadertype(self.uniform_type), usage="UNIFORM"
+        )
+
+        self.set_color(*colors)
+
+    def set_color(self, *colors):
+        """ Set the background color. If one color is given, it will be used
+        as a uniform color. If two colors are given, it will be used for
+        the botton and top. If four colors are given, it will be used for the
+        four corners.
+        """
+        if len(colors) == 0:
+            self.color_bottom_left = (0, 0, 0, 1)
+            self.color_bottom_right = (0, 0, 0, 1)
+            self.color_top_left = (0, 0, 0, 1)
+            self.color_top_right = (0, 0, 0, 1)
+        elif len(colors) == 1:
+            self.color_bottom_left = colors[0]
+            self.color_bottom_right = colors[0]
+            self.color_top_left = colors[0]
+            self.color_top_right = colors[0]
+        elif len(colors) == 2:
+            self.color_bottom_left = colors[0]
+            self.color_bottom_right = colors[0]
+            self.color_top_left = colors[1]
+            self.color_top_right = colors[1]
+        elif len(colors) == 4:
+            self.color_bottom_left = colors[0]
+            self.color_bottom_right = colors[1]
+            self.color_top_left = colors[2]
+            self.color_top_right = colors[3]
+        else:
+            raise ValueError("Need 1, 2 or 4 colors.")
+
+    @property
+    def color_bottom_left(self):
+        """ The color in the bottom left corner.
+        """
+        return self.uniform_buffer.data["color_bottom_left"]
+
+    @color_bottom_left.setter
+    def color_bottom_left(self, color):
+        self.uniform_buffer.data["color_bottom_left"] = color
+        self.uniform_buffer.update_range(0, 1)
+        self.dirty = True
+
+    @property
+    def color_bottom_right(self):
+        """ The color in the bottom right corner.
+        """
+        return self.uniform_buffer.data["color_bottom_right"]
+
+    @color_bottom_right.setter
+    def color_bottom_right(self, color):
+        self.uniform_buffer.data["color_bottom_right"] = color
+        self.uniform_buffer.update_range(0, 1)
+        self.dirty = True
+
+    @property
+    def color_top_left(self):
+        """ The color in the top left corner.
+        """
+        return self.uniform_buffer.data["color_top_left"]
+
+    @color_top_left.setter
+    def color_top_left(self, color):
+        self.uniform_buffer.data["color_top_left"] = color
+        self.uniform_buffer.update_range(0, 1)
+        self.dirty = True
+
+    @property
+    def color_top_right(self):
+        """ The color in the top right corner.
+        """
+        return self.uniform_buffer.data["color_top_right"]
+
+    @color_top_right.setter
+    def color_top_right(self, color):
+        self.uniform_buffer.data["color_top_right"] = color
+        self.uniform_buffer.update_range(0, 1)
+        self.dirty = True
+
+
+# todo: needs a way to orient the skybox (by default the world is in the x-z plane, with +y pointing up)
+
+
+class BackgroundImageMaterial(BackgroundMaterial):
+    """ A background material that displays an image. If map is a 2D
+    texture view, it is used as a static background. If it is a cube
+    texture view, (on a NxMx6 texture) it is used as a skybox.
+    """
+
+    def __init__(self, map=None):
+        super().__init__()
+        self.map = map
+
+    @property
+    def map(self):
+        """ The texture map specifying the background image
+        """
+        return self._map
+
+    @map.setter
+    def map(self, map):
+        self._map = map
+        self.dirty = True

--- a/pygfx/objects/__init__.py
+++ b/pygfx/objects/__init__.py
@@ -2,7 +2,7 @@
 
 from ._base import WorldObject
 from ._group import Group
-from ._scene import Scene
+from ._scene import Scene, Background
 from ._points import Points
 from ._line import Line
 from ._mesh import Mesh

--- a/pygfx/objects/_scene.py
+++ b/pygfx/objects/_scene.py
@@ -6,3 +6,13 @@ class Scene(WorldObject):
     It hold certain attributes that relate to the scene, such as the background color,
     fog, and environment map. Camera's and lights can also be part of a scene.
     """
+
+
+class Background(WorldObject):
+    """ An object representing a scene background.
+    Can be e.g. a gradient, a static image or a skybox.
+    """
+
+    def __init__(self, material):
+        super().__init__()
+        self.material = material

--- a/pygfx/renderers/wgpu/__init__.py
+++ b/pygfx/renderers/wgpu/__init__.py
@@ -6,3 +6,4 @@ from . import meshrender
 from . import pointsrender
 from . import linerender
 from . import volumerender
+from . import backgroundrender

--- a/pygfx/renderers/wgpu/backgroundrender.py
+++ b/pygfx/renderers/wgpu/backgroundrender.py
@@ -1,0 +1,156 @@
+import wgpu  # only for flags/enums
+import pyshader
+from pyshader import python2shader
+from pyshader import vec3, vec4
+
+from . import register_wgpu_render_function, stdinfo_uniform_type
+from ...objects import Background
+from ...materials import BackgroundMaterial, BackgroundImageMaterial
+from ...datawrappers import Texture, TextureView
+
+
+@python2shader
+def vertex_shader_simple(
+    index: (pyshader.RES_INPUT, "VertexId", "i32"),
+    out_pos: (pyshader.RES_OUTPUT, "Position", vec4),
+    v_texcoord: (pyshader.RES_OUTPUT, 0, vec3),
+    u_stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
+):
+    # Define positions at the four corners of the viewport, at the largest depth
+    positions = [
+        vec4(-1.0, -1.0, 1.0, 1.0),
+        vec4(+1.0, -1.0, 1.0, 1.0),
+        vec4(-1.0, +1.0, 1.0, 1.0),
+        vec4(+1.0, +1.0, 1.0, 1.0),
+    ]
+    # Select the current position
+    ndc_pos = positions[index]
+    # Store positions and the view direction in the world
+    out_pos = ndc_pos  # noqa - shader output
+    v_texcoord = vec3(ndc_pos.xy * 0.5 + 0.5, 0.0)  # noqa - shader output
+
+
+@python2shader
+def fragment_shader_gradient(
+    v_texcoord: (pyshader.RES_INPUT, 0, vec3),
+    u_background: (pyshader.RES_UNIFORM, (0, 1), BackgroundMaterial.uniform_type),
+    out_color: (pyshader.RES_OUTPUT, 0, vec4),
+):
+    f = v_texcoord.xy
+    color = (
+        u_background.color_bottom_left * (1.0 - f.x) * (1.0 - f.y)
+        + u_background.color_bottom_right * f.x * (1.0 - f.y)
+        + u_background.color_top_left * (1.0 - f.x) * f.y
+        + u_background.color_top_right * f.x * f.y
+    )
+    out_color = color  # noqa - shader output
+
+
+@python2shader
+def vertex_shader_skybox(
+    index: (pyshader.RES_INPUT, "VertexId", "i32"),
+    out_pos: (pyshader.RES_OUTPUT, "Position", vec4),
+    v_texcoord: (pyshader.RES_OUTPUT, 0, vec3),
+    u_stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
+):
+    # Define positions at the four corners of the viewport, at the largest depth
+    positions = [
+        vec4(-1.0, -1.0, 1.0, 1.0),
+        vec4(+1.0, -1.0, 1.0, 1.0),
+        vec4(-1.0, +1.0, 1.0, 1.0),
+        vec4(+1.0, +1.0, 1.0, 1.0),
+    ]
+    # Select the current position, and create another pos just behind it
+    ndc_pos1 = positions[index]
+    ndc_pos2 = vec4(ndc_pos1.xy, ndc_pos1.z + 0.1, ndc_pos1.z)
+    # Project both points to world coordinates
+    inv_proj = matrix_inverse(u_stdinfo.projection_transform * u_stdinfo.cam_transform)
+    wpos1 = inv_proj * ndc_pos1
+    wpos2 = inv_proj * ndc_pos2
+    wpos1 = wpos1.xyzw / wpos1.w
+    wpos2 = wpos2.xyzw / wpos2.w
+    # Store positions and the view direction in the world
+    out_pos = ndc_pos1  # noqa - shader output
+    v_texcoord = wpos2.xyz - wpos1.xyz  # noqa - shader output
+
+
+@python2shader
+def fragment_shader_tex_rgba(
+    v_texcoord: (pyshader.RES_INPUT, 0, vec3),
+    s_sam: (pyshader.RES_SAMPLER, (0, 2), ""),
+    t_tex: (pyshader.RES_TEXTURE, (0, 3), "undecided"),
+    out_color: (pyshader.RES_OUTPUT, 0, vec4),
+):
+    color = vec4(t_tex.sample(s_sam, v_texcoord.xyz))
+    out_color = color / 255.0  # noqa - shader output
+
+
+@python2shader
+def fragment_shader_tex_gray(
+    v_texcoord: (pyshader.RES_INPUT, 0, vec3),
+    s_sam: (pyshader.RES_SAMPLER, (0, 2), ""),
+    t_tex: (pyshader.RES_TEXTURE, (0, 3), "undecided"),
+    out_color: (pyshader.RES_OUTPUT, 0, vec4),
+):
+    color = vec4(t_tex.sample(s_sam, v_texcoord.xyz))
+    out_color = color  # noqa - shader output
+
+
+@register_wgpu_render_function(Background, BackgroundMaterial)
+def background_renderer(wobject, render_info):
+
+    material = wobject.material
+    vertex_shader = vertex_shader_simple
+    fragment_shader = fragment_shader_tex_rgba
+    bindings0 = {
+        0: (wgpu.BindingType.uniform_buffer, render_info.stdinfo),
+        1: (wgpu.BindingType.uniform_buffer, material.uniform_buffer),
+    }
+
+    if isinstance(material, BackgroundImageMaterial) and material.map is not None:
+        if isinstance(material.map, Texture):
+            raise TypeError("material.map is a Texture, but must be a TextureView")
+        elif not isinstance(material.map, TextureView):
+            raise TypeError("material.map must be a TextureView")
+        bindings0[2] = wgpu.BindingType.sampler, material.map
+        bindings0[3] = wgpu.BindingType.sampled_texture, material.map
+        # Select shader
+        if material.map.view_dim == "cube":
+            vertex_shader = vertex_shader_skybox
+            tex_info = "cube "
+        elif material.map.view_dim == "2d":
+            vertex_shader = vertex_shader_simple
+            tex_info = "2d "
+        else:
+            raise ValueError(
+                "BackgroundImageMaterial should have map with texture view 2d or cube."
+            )
+        if "rgba" in material.map.format:
+            fragment_shader = fragment_shader_tex_rgba
+        else:
+            fragment_shader = fragment_shader_tex_gray
+        # Use a version of the shader for float textures if necessary
+        if "float" in material.map.format:
+            tex_info += "f32"
+        else:
+            tex_info += "i32"
+        if not hasattr(fragment_shader, "shader_version_" + tex_info):
+            func = fragment_shader.input
+            tex_anno = func.__annotations__["t_tex"]
+            func.__annotations__["t_tex"] = tex_anno[:2] + (tex_info,)
+            setattr(fragment_shader, "shader_version_" + tex_info, python2shader(func))
+            func.__annotations__["t_tex"] = tex_anno
+        fragment_shader = getattr(fragment_shader, "shader_version_" + tex_info)
+    else:
+        vertex_shader = vertex_shader_simple
+        fragment_shader = fragment_shader_gradient
+
+    return [
+        {
+            "vertex_shader": vertex_shader,
+            "fragment_shader": fragment_shader,
+            "primitive_topology": wgpu.PrimitiveTopology.triangle_strip,
+            "indices": 4,
+            "bindings0": bindings0,
+        }
+    ]

--- a/pygfx/renderers/wgpu/backgroundrender.py
+++ b/pygfx/renderers/wgpu/backgroundrender.py
@@ -64,7 +64,7 @@ def vertex_shader_skybox(
     ndc_pos1 = positions[index]
     ndc_pos2 = vec4(ndc_pos1.xy, ndc_pos1.z + 0.1, ndc_pos1.z)
     # Project both points to world coordinates
-    inv_proj = matrix_inverse(u_stdinfo.projection_transform * u_stdinfo.cam_transform)
+    inv_proj = matrix_inverse(u_stdinfo.projection_transform * u_stdinfo.cam_transform *  u_stdinfo.world_transform)
     wpos1 = inv_proj * ndc_pos1
     wpos2 = inv_proj * ndc_pos2
     wpos1 = wpos1.xyzw / wpos1.w

--- a/pygfx/renderers/wgpu/backgroundrender.py
+++ b/pygfx/renderers/wgpu/backgroundrender.py
@@ -64,7 +64,11 @@ def vertex_shader_skybox(
     ndc_pos1 = positions[index]
     ndc_pos2 = vec4(ndc_pos1.xy, ndc_pos1.z + 0.1, ndc_pos1.z)
     # Project both points to world coordinates
-    inv_proj = matrix_inverse(u_stdinfo.projection_transform * u_stdinfo.cam_transform *  u_stdinfo.world_transform)
+    inv_proj = matrix_inverse(
+        u_stdinfo.projection_transform
+        * u_stdinfo.cam_transform
+        * u_stdinfo.world_transform
+    )
     wpos1 = inv_proj * ndc_pos1
     wpos2 = inv_proj * ndc_pos2
     wpos1 = wpos1.xyzw / wpos1.w

--- a/pygfx/renderers/wgpu/linerender.py
+++ b/pygfx/renderers/wgpu/linerender.py
@@ -34,6 +34,7 @@ from ...materials import (
 # But a hybrid approach may be viable: the current approach using VertexId,
 # but preparing some data in a buffer.
 
+# todo: we can learn about dashing, unfolding and more at http://jcgt.org/published/0002/02/08/paper.pdf
 
 # %% Shaders
 

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -6,7 +6,7 @@ from pyshader import vec2, vec4
 from . import register_wgpu_render_function, stdinfo_uniform_type
 from ...objects import Mesh
 from ...materials import MeshBasicMaterial
-from ...datawrappers import BaseBuffer, BaseTexture, TextureView
+from ...datawrappers import Buffer, Texture, TextureView
 
 
 @python2shader
@@ -76,7 +76,7 @@ def mesh_renderer(wobject, render_info):
 
     # Use index buffer if present on the geometry
     index_buffer = getattr(geometry, "index", None)
-    index_buffer = index_buffer if isinstance(index_buffer, BaseBuffer) else None
+    index_buffer = index_buffer if isinstance(index_buffer, Buffer) else None
 
     # Collect vertex buffers
     vertex_buffers = []
@@ -91,7 +91,7 @@ def mesh_renderer(wobject, render_info):
 
     # Collect texture and sampler
     if material.map is not None:
-        if isinstance(material.map, BaseTexture):
+        if isinstance(material.map, Texture):
             raise TypeError("material.map is a Texture, but must be a TextureView")
         elif not isinstance(material.map, TextureView):
             raise TypeError("material.map must be a TextureView")

--- a/pygfx/renderers/wgpu/volumerender.py
+++ b/pygfx/renderers/wgpu/volumerender.py
@@ -6,7 +6,7 @@ from pyshader import vec3, vec4
 from . import register_wgpu_render_function, stdinfo_uniform_type
 from ...objects import Mesh
 from ...materials import MeshVolumeSliceMaterial
-from ...datawrappers import BaseBuffer, BaseTexture, TextureView
+from ...datawrappers import Buffer, Texture, TextureView
 
 
 @python2shader
@@ -55,7 +55,7 @@ def mesh_slice_renderer(wobject, render_info):
 
     # Use index buffer if present on the geometry
     index_buffer = getattr(geometry, "index", None)
-    index_buffer = index_buffer if isinstance(index_buffer, BaseBuffer) else None
+    index_buffer = index_buffer if isinstance(index_buffer, Buffer) else None
 
     # Collect vertex buffers
     vertex_buffers = []
@@ -70,7 +70,7 @@ def mesh_slice_renderer(wobject, render_info):
 
     # Collect texture and sampler
     if material.map is not None:
-        if isinstance(material.map, BaseTexture):
+        if isinstance(material.map, Texture):
             raise TypeError("material.map is a Texture, but must be a TextureView")
         elif not isinstance(material.map, TextureView):
             raise TypeError("material.map must be a TextureView")

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ with open(f"{NAME}/__init__.py") as fh:
 
 runtime_deps = [
     "numpy",
-    "wgpu>=0.2.0",
-    "pyshader>=0.6.0",
+    "wgpu>=0.3.0",
+    "pyshader>=0.6.1",
 ]
 
 


### PR DESCRIPTION
* [x] Update the way we update buffers and texturs (new wgpu API).
* [x] Refactor Buffer and Texture classes to use memoryviews, no more BaseBuffer and a numpy-specific Buffer.
* [x] Update depth texture size by comparing with the render texture view.
* [x] Set camera viewport in the renderer, so it does not have to be done in each example.
* [x] Use full-res images in the examples (no more silly 1MB limit)
* [x] Clean up examples.
* [x]  Make skybox and volume_slice2 example work. (DONE, not committed yet, needs cleaning up)
