### PR TITLE
Orbit and PanZoom camera controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 Pipfile
 Pipfile.lock
 .vscode
+pyproject.toml
+poetry.lock
 
 # Special for this repo
 nogit/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,3 +9,5 @@ twine
 
 # examples
 PyQt5
+imageio
+imageio-ffmpeg

--- a/examples/axes_helper.py
+++ b/examples/axes_helper.py
@@ -1,0 +1,34 @@
+"""
+Example showing the axes helper.
+"""
+
+import pygfx as gfx
+
+from PyQt5 import QtWidgets
+from wgpu.gui.qt import WgpuCanvas
+
+
+app = QtWidgets.QApplication([])
+
+canvas = WgpuCanvas()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+background = gfx.Background(gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+scene.add(background)
+
+scene.add(gfx.AxesHelper(size=10))
+
+camera = gfx.PerspectiveCamera(70, 16 / 9)
+camera.position.set(50, 50, 50)
+camera.look_at(gfx.linalg.Vector3())
+
+
+def animate():
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec_()

--- a/examples/multi_slice.py
+++ b/examples/multi_slice.py
@@ -29,7 +29,7 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
             app.setOverrideCursor(QtCore.Qt.BlankCursor)
 
     def mouseReleaseEvent(self, event):  # noqa: N802
-        if self.drag.get("button") == event.button():
+        if self.drag and self.drag.get("button") == event.button():
             self.drag = None
             app.restoreOverrideCursor()
 
@@ -86,8 +86,8 @@ for axis in [0, 1, 2]:
         plane.rotation.set_from_euler(gfx.linalg.Euler(0.5 * np.pi))
     scene.add(plane)
 
-camera = gfx.OrthographicCamera(200, 200)
-camera.position.set(50, 50, 50)
+camera = gfx.PerspectiveCamera(70, 16 / 9)
+camera.position.set(125, 125, 125)
 camera.look_at(gfx.linalg.Vector3())
 controls = gfx.OrbitControls(camera.position.clone(), up=gfx.linalg.Vector3(0, 0, 1))
 

--- a/examples/multi_slice.py
+++ b/examples/multi_slice.py
@@ -21,7 +21,7 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         self.drag = None
 
     def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(event.angleDelta().y() * 0.125)
+        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
 
     def mousePressEvent(self, event):  # noqa: N802
         button = event.button()
@@ -91,10 +91,13 @@ for axis in [0, 1, 2]:
         plane.rotation.set_from_euler(gfx.linalg.Euler(0.5 * np.pi))
     # else: XY plane
 
-camera = gfx.PerspectiveCamera(70, 16 / 9)
+# camera = gfx.PerspectiveCamera(70, 16 / 9)
+camera = gfx.OrthographicCamera(200, 200)
 camera.position.set(125, 125, 125)
 camera.look_at(gfx.linalg.Vector3())
-controls = gfx.OrbitControls(camera.position.clone(), up=gfx.linalg.Vector3(0, 0, 1))
+controls = gfx.OrbitControls(
+    camera.position.clone(), up=gfx.linalg.Vector3(0, 0, 1), zoom_changes_distance=False
+)
 
 
 def animate():

--- a/examples/multi_slice.py
+++ b/examples/multi_slice.py
@@ -33,27 +33,26 @@ for axis in [0, 1, 2]:
     # we could reuse the same plane geometry for all slices here
     geometry = gfx.PlaneGeometry(200, 200, 1, 1)
     if axis == 0:  # YZ plane
-        texcoords = np.array([
-            [0.5, 0., 0],
-            [0.5, 1., 0],
-            [0.5, 0., nslices],
-            [0.5, 1., nslices],
-        ], dtype=np.float32)
+        texcoords = np.array(
+            [[0.5, 0.0, 0], [0.5, 1.0, 0], [0.5, 0.0, nslices], [0.5, 1.0, nslices],],
+            dtype=np.float32,
+        )
     elif axis == 1:  # XZ plane
-        texcoords = np.array([
-            [0., 0.5, 0],
-            [1., 0.5, 0],
-            [0., 0.5, nslices],
-            [1., 0.5, nslices],
-        ], dtype=np.float32)
+        texcoords = np.array(
+            [[0.0, 0.5, 0], [1.0, 0.5, 0], [0.0, 0.5, nslices], [1.0, 0.5, nslices],],
+            dtype=np.float32,
+        )
     elif axis == 2:  # XY plane (default)
         z_idx = nslices / 2
-        texcoords = np.array([
-            [0., 0., z_idx],
-            [1., 0., z_idx],
-            [0., 1., z_idx],
-            [1., 1., z_idx],
-        ], dtype=np.float32)
+        texcoords = np.array(
+            [
+                [0.0, 0.0, z_idx],
+                [1.0, 0.0, z_idx],
+                [0.0, 1.0, z_idx],
+                [1.0, 1.0, z_idx],
+            ],
+            dtype=np.float32,
+        )
     print(texcoords)
     geometry.texcoords = gfx.Buffer(texcoords, usage="vertex|storage")
 
@@ -66,6 +65,8 @@ for axis in [0, 1, 2]:
     elif axis == 1:  # XZ plane
         plane.rotation.set_from_axis_angle(gfx.linalg.Vector3(1, 0, 0), 0.5 * np.pi)
     scene.add(plane)
+
+    # TODO: also add a mesh slice for each plane
 
 camera = gfx.OrthographicCamera(200, 200)
 camera.position.set(50, 50, 50)

--- a/examples/multi_slice.py
+++ b/examples/multi_slice.py
@@ -1,0 +1,89 @@
+"""
+Render slices through a volume, by creating a 3D texture, and sample it in the shader.
+Simple, fast and subpixel!
+"""
+
+import imageio
+import numpy as np
+import pygfx as gfx
+
+from PyQt5 import QtWidgets
+from wgpu.gui.qt import WgpuCanvas
+
+
+app = QtWidgets.QApplication([])
+
+canvas = WgpuCanvas()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+background = gfx.Background(gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+scene.add(background)
+
+scene.add(gfx.AxesHelper(size=10))
+
+vol = imageio.volread("imageio:stent.npz")
+tex = gfx.Texture(vol, dim=3, usage="sampled")
+view = tex.get_view(filter="linear")
+
+for axis in [0, 1, 2]:
+    nslices = vol.shape[0]
+
+    # TODO: if we could set the slicing plane on the material parametrically
+    # we could reuse the same plane geometry for all slices here
+    geometry = gfx.PlaneGeometry(200, 200, 1, 1)
+    if axis == 0:  # YZ plane
+        texcoords = np.array([
+            [0.5, 0., 0],
+            [0.5, 1., 0],
+            [0.5, 0., nslices],
+            [0.5, 1., nslices],
+        ], dtype=np.float32)
+    elif axis == 1:  # XZ plane
+        texcoords = np.array([
+            [0., 0.5, 0],
+            [1., 0.5, 0],
+            [0., 0.5, nslices],
+            [1., 0.5, nslices],
+        ], dtype=np.float32)
+    elif axis == 2:  # XY plane (default)
+        z_idx = nslices / 2
+        texcoords = np.array([
+            [0., 0., z_idx],
+            [1., 0., z_idx],
+            [0., 1., z_idx],
+            [1., 1., z_idx],
+        ], dtype=np.float32)
+    print(texcoords)
+    geometry.texcoords = gfx.Buffer(texcoords, usage="vertex|storage")
+
+    material = gfx.MeshVolumeSliceMaterial(map=view, clim=(0, 255))
+    plane = gfx.Mesh(geometry, material)
+
+    # by default the plane is in XY plane
+    if axis == 0:  # YZ plane
+        plane.rotation.set_from_axis_angle(gfx.linalg.Vector3(0, 1, 0), 0.5 * np.pi)
+    elif axis == 1:  # XZ plane
+        plane.rotation.set_from_axis_angle(gfx.linalg.Vector3(1, 0, 0), 0.5 * np.pi)
+    scene.add(plane)
+
+camera = gfx.OrthographicCamera(200, 200)
+camera.position.set(50, 50, 50)
+camera.look_at(gfx.linalg.Vector3())
+
+
+def animate():
+    # global index
+    # index = index + degrees / 30
+    # index = max(0, min(nslices - 1, index))
+    # geometry.texcoords.data[:, 2] = index / nslices
+    # geometry.texcoords.update_range(0, geometry.texcoords.nitems)
+    # material.dirty = 1  # todo: we should not have to mark the *material* dirty!
+
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec_()

--- a/examples/multi_slice.py
+++ b/examples/multi_slice.py
@@ -12,13 +12,14 @@ from wgpu.gui.qt import WgpuCanvas
 
 class WgpuCanvasWithInputEvents(WgpuCanvas):
     _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
+    _speed = {"pan": 1.0, "rotate": 0.02}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.drag = None
 
     def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(event.angleDelta().y())
+        controls.zoom(event.angleDelta().y() * 0.125)
 
     def mousePressEvent(self, event):  # noqa: N802
         button = event.button()
@@ -38,7 +39,8 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         if not self.drag:
             return
         pos = event.x(), event.y()
-        delta = tuple(pos[i] - self.drag["start"][i] for i in range(2))
+        speed = self._speed[self.drag["mode"]]
+        delta = tuple((pos[i] - self.drag["start"][i]) * speed for i in range(2))
         getattr(controls, self.drag["mode"])(*delta)
         self.drag["start"] = pos
 

--- a/examples/multi_slice.py
+++ b/examples/multi_slice.py
@@ -24,6 +24,7 @@ scene.add(gfx.AxesHelper(size=10))
 vol = imageio.volread("imageio:stent.npz")
 tex = gfx.Texture(vol, dim=3, usage="sampled")
 view = tex.get_view(filter="linear")
+material = gfx.MeshVolumeSliceMaterial(map=view, clim=(0, 255))
 
 for axis in [0, 1, 2]:
     nslices = vol.shape[0]
@@ -58,7 +59,6 @@ for axis in [0, 1, 2]:
     print(texcoords)
     geometry.texcoords = gfx.Buffer(texcoords, usage="vertex|storage")
 
-    material = gfx.MeshVolumeSliceMaterial(map=view, clim=(0, 255))
     plane = gfx.Mesh(geometry, material)
 
     # by default the plane is in XY plane

--- a/examples/multi_slice.py
+++ b/examples/multi_slice.py
@@ -71,13 +71,13 @@ texcoords = {
     1: [[0, 0.5, 0], [1, 0.5, 0], [0, 0.5, 1], [1, 0.5, 1]],
     2: [[0, 0, 0.5], [1, 0, 0.5], [0, 1, 0.5], [1, 1, 0.5]],
 }
-shape = {
+sizes = {
     0: (vol.shape[1], vol.shape[0]),  # YZ plane
     1: (vol.shape[2], vol.shape[0]),  # XZ plane
     2: (vol.shape[2], vol.shape[1]),  # XY plane (default)
 }
 for axis in [0, 1, 2]:
-    geometry = gfx.PlaneGeometry(*shape[axis], 1, 1)
+    geometry = gfx.PlaneGeometry(*sizes[axis], 1, 1)
     geometry.texcoords = gfx.Buffer(
         np.array(texcoords[axis], dtype="f4"), usage="vertex|storage"
     )

--- a/examples/multi_slice.py
+++ b/examples/multi_slice.py
@@ -21,12 +21,13 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         controls.zoom(event.angleDelta().y())
 
     def mousePressEvent(self, event):  # noqa: N802
-        pos = event.x(), event.y()
         button = event.button()
         mode = self._drag_modes.get(button, None)
-        if mode and not self.drag:
-            self.drag = {"mode": mode, "button": button, "start": pos}
-            app.setOverrideCursor(QtCore.Qt.BlankCursor)
+        if self.drag or not mode:
+            return
+        pos = event.x(), event.y()
+        self.drag = {"mode": mode, "button": button, "start": pos}
+        app.setOverrideCursor(QtCore.Qt.BlankCursor)
 
     def mouseReleaseEvent(self, event):  # noqa: N802
         if self.drag and self.drag.get("button") == event.button():
@@ -34,11 +35,12 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
             app.restoreOverrideCursor()
 
     def mouseMoveEvent(self, event):  # noqa: N802
-        if self.drag:
-            pos = event.x(), event.y()
-            delta = tuple(pos[i] - self.drag["start"][i] for i in range(2))
-            getattr(controls, self.drag["mode"])(*delta)
-            self.drag["start"] = pos
+        if not self.drag:
+            return
+        pos = event.x(), event.y()
+        delta = tuple(pos[i] - self.drag["start"][i] for i in range(2))
+        getattr(controls, self.drag["mode"])(*delta)
+        self.drag["start"] = pos
 
 
 app = QtWidgets.QApplication([])

--- a/examples/multi_slice.py
+++ b/examples/multi_slice.py
@@ -6,74 +6,95 @@ import imageio
 import numpy as np
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PyQt5 import QtWidgets, QtCore
 from wgpu.gui.qt import WgpuCanvas
+
+
+class WgpuCanvasWithInputEvents(WgpuCanvas):
+    _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.drag = None
+
+    def wheelEvent(self, event):  # noqa: N802
+        controls.zoom(event.angleDelta().y())
+
+    def mousePressEvent(self, event):  # noqa: N802
+        pos = event.x(), event.y()
+        button = event.button()
+        mode = self._drag_modes.get(button, None)
+        if mode and not self.drag:
+            self.drag = {"mode": mode, "button": button, "start": pos}
+            app.setOverrideCursor(QtCore.Qt.BlankCursor)
+
+    def mouseReleaseEvent(self, event):  # noqa: N802
+        if self.drag.get("button") == event.button():
+            self.drag = None
+            app.restoreOverrideCursor()
+
+    def mouseMoveEvent(self, event):  # noqa: N802
+        if self.drag:
+            pos = event.x(), event.y()
+            delta = tuple(pos[i] - self.drag["start"][i] for i in range(2))
+            getattr(controls, self.drag["mode"])(*delta)
+            self.drag["start"] = pos
 
 
 app = QtWidgets.QApplication([])
 
-canvas = WgpuCanvas()
+canvas = WgpuCanvasWithInputEvents()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
 background = gfx.Background(gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
 scene.add(background)
 
-scene.add(gfx.AxesHelper(size=10))
+scene.add(gfx.AxesHelper(size=50))
 
 vol = imageio.volread("imageio:stent.npz")
 tex = gfx.Texture(vol, dim=3, usage="sampled")
 view = tex.get_view(filter="linear")
 material = gfx.MeshVolumeSliceMaterial(map=view, clim=(0, 255))
 
-for axis in [0, 1, 2]:
-    nslices = vol.shape[0]
+# TODO: also add a mesh slice for each plane
 
-    # TODO: if we could set the slicing plane on the material parametrically
-    # we could reuse the same plane geometry for all slices here
-    # TODO: there seems to be a problem with the texcoords... only one plane looks correct
-    # TODO: why is the third axis not in [0..1] range?
-    # TODO: also add a mesh slice for each plane
-    geometry = gfx.PlaneGeometry(200, 200, 1, 1)
+for axis in [0, 1, 2]:
     if axis == 0:  # YZ plane
+        geometry = gfx.PlaneGeometry(vol.shape[1], vol.shape[0], 1, 1)
         texcoords = np.array(
-            [[0.5, 0.0, 0], [0.5, 1.0, 0], [0.5, 0.0, nslices], [0.5, 1.0, nslices],],
-            dtype=np.float32,
+            [[0.5, 0, 0], [0.5, 1, 0], [0.5, 0, 1], [0.5, 1, 1]], dtype=np.float32,
         )
     elif axis == 1:  # XZ plane
+        geometry = gfx.PlaneGeometry(vol.shape[2], vol.shape[0], 1, 1)
         texcoords = np.array(
-            [[0.0, 0.5, 0], [1.0, 0.5, 0], [0.0, 0.5, nslices], [1.0, 0.5, nslices],],
-            dtype=np.float32,
+            [[0, 0.5, 0], [1, 0.5, 0], [0, 0.5, 1], [1, 0.5, 1]], dtype=np.float32,
         )
     elif axis == 2:  # XY plane (default)
-        z_idx = nslices / 2
+        geometry = gfx.PlaneGeometry(vol.shape[2], vol.shape[1], 1, 1)
         texcoords = np.array(
-            [
-                [0.0, 0.0, z_idx],
-                [1.0, 0.0, z_idx],
-                [0.0, 1.0, z_idx],
-                [1.0, 1.0, z_idx],
-            ],
-            dtype=np.float32,
+            [[0, 0, 0.5], [1, 0, 0.5], [0, 1, 0.5], [1, 1, 0.5]], dtype=np.float32,
         )
-    print(texcoords)
     geometry.texcoords = gfx.Buffer(texcoords, usage="vertex|storage")
 
     plane = gfx.Mesh(geometry, material)
 
     # by default the plane is in XY plane
     if axis == 0:  # YZ plane
-        plane.rotation.set_from_axis_angle(gfx.linalg.Vector3(0, 1, 0), 0.5 * np.pi)
+        plane.rotation.set_from_euler(gfx.linalg.Euler(0.5 * np.pi, 0.5 * np.pi))
     elif axis == 1:  # XZ plane
-        plane.rotation.set_from_axis_angle(gfx.linalg.Vector3(1, 0, 0), 0.5 * np.pi)
+        plane.rotation.set_from_euler(gfx.linalg.Euler(0.5 * np.pi))
     scene.add(plane)
 
 camera = gfx.OrthographicCamera(200, 200)
 camera.position.set(50, 50, 50)
 camera.look_at(gfx.linalg.Vector3())
+controls = gfx.OrbitControls(camera.position.clone(), up=gfx.linalg.Vector3(0, 0, 1))
 
 
 def animate():
+    # todo: should the control set it directly?
+    controls.update_camera(camera)
     renderer.render(scene, camera)
     canvas.request_draw()
 

--- a/examples/multi_slice.py
+++ b/examples/multi_slice.py
@@ -1,6 +1,5 @@
 """
-Render slices through a volume, by creating a 3D texture, and sample it in the shader.
-Simple, fast and subpixel!
+Slice a volume and a mesh through the three primary planes (XY, XZ, YZ)
 """
 
 import imageio
@@ -31,6 +30,9 @@ for axis in [0, 1, 2]:
 
     # TODO: if we could set the slicing plane on the material parametrically
     # we could reuse the same plane geometry for all slices here
+    # TODO: there seems to be a problem with the texcoords... only one plane looks correct
+    # TODO: why is the third axis not in [0..1] range?
+    # TODO: also add a mesh slice for each plane
     geometry = gfx.PlaneGeometry(200, 200, 1, 1)
     if axis == 0:  # YZ plane
         texcoords = np.array(
@@ -66,21 +68,12 @@ for axis in [0, 1, 2]:
         plane.rotation.set_from_axis_angle(gfx.linalg.Vector3(1, 0, 0), 0.5 * np.pi)
     scene.add(plane)
 
-    # TODO: also add a mesh slice for each plane
-
 camera = gfx.OrthographicCamera(200, 200)
 camera.position.set(50, 50, 50)
 camera.look_at(gfx.linalg.Vector3())
 
 
 def animate():
-    # global index
-    # index = index + degrees / 30
-    # index = max(0, min(nslices - 1, index))
-    # geometry.texcoords.data[:, 2] = index / nslices
-    # geometry.texcoords.update_range(0, geometry.texcoords.nitems)
-    # material.dirty = 1  # todo: we should not have to mark the *material* dirty!
-
     renderer.render(scene, camera)
     canvas.request_draw()
 

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -15,9 +15,6 @@ class OrbitControls:
     _v = gfx.linalg.Vector3()
     _origin = gfx.linalg.Vector3()
     _orbit_up = gfx.linalg.Vector3(0, 1, 0)
-    _q1 = gfx.linalg.Quaternion()
-    _q2 = gfx.linalg.Quaternion()
-    _e = gfx.linalg.Euler()
     _s = gfx.linalg.Spherical()
 
     def __init__(
@@ -45,7 +42,9 @@ class OrbitControls:
         self.target = target
         self.up = up
         self.rotation.set_from_rotation_matrix(self._m.look_at(eye, target, up))
-        self._up_quat = gfx.linalg.Quaternion().set_from_unit_vectors(self.up, self._orbit_up)
+        self._up_quat = gfx.linalg.Quaternion().set_from_unit_vectors(
+            self.up, self._orbit_up
+        )
         self._up_quat_inv = self._up_quat.clone().inverse()
         return self
 
@@ -72,7 +71,9 @@ class OrbitControls:
         # back to camera up
         self._v.apply_quaternion(self._up_quat_inv)
         # compute new rotation
-        self.rotation.set_from_rotation_matrix(self._m.look_at(self._v, self._origin, self.up))
+        self.rotation.set_from_rotation_matrix(
+            self._m.look_at(self._v, self._origin, self.up)
+        )
         return self
 
     def zoom(self, delta: float) -> "OrbitControls":
@@ -120,7 +121,7 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         if self.pan:
             controls.pan(*delta)
         else:
-            controls.rotate(*(delta * .02))
+            controls.rotate(*(delta * 0.02))
         self.mouse_start = mouse_end
 
     def keyPressEvent(self, event):  # noqa: N802

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -95,9 +95,7 @@ def animate():
         )
         cube.rotation.multiply(rot)
 
-    rot, pos = controls.get_view()
-    camera.rotation.copy(rot)
-    camera.position.copy(pos)
+    controls.update_camera(camera)
 
     renderer.render(scene, camera)
     canvas.request_draw()

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -86,7 +86,7 @@ class OrbitControls:
         position = (
             gfx.linalg.Vector3(0, 0, self.distance)
             .apply_quaternion(self.rotation)
-            .sub(self.target)
+            .add(self.target)
         )
         return self.rotation, position
 
@@ -151,7 +151,8 @@ background = gfx.Background(gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
 scene.add(background)
 
 camera = gfx.PerspectiveCamera(70, 16 / 9)
-controls = OrbitControls(gfx.linalg.Vector3(500, 500, 500))
+camera.position.set(500, 500, 500)
+controls = OrbitControls(camera.position.clone())
 
 
 def animate():

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -36,7 +36,7 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
     def mouseReleaseEvent(self, event):  # noqa: N802
         if self.drag.get("button") == event.button():
             # stop when the initiating button is released
-            self.drag = {}
+            self.drag = None
             QtWidgets.QApplication.instance().restoreOverrideCursor()
 
     def mouseMoveEvent(self, event):  # noqa: N802

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -34,7 +34,7 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         QtWidgets.QApplication.instance().setOverrideCursor(QtCore.Qt.BlankCursor)
 
     def mouseReleaseEvent(self, event):  # noqa: N802
-        if self.drag.get("button") == event.button():
+        if self.drag and self.drag.get("button") == event.button():
             # stop when the initiating button is released
             self.drag = None
             QtWidgets.QApplication.instance().restoreOverrideCursor()

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -136,6 +136,8 @@ canvas = WgpuCanvasWithInputEvents()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
+scene.add(gfx.AxesHelper(size=250))
+
 im = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
 im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
 tex = gfx.Texture(im, dim=2, usage="sampled").get_view(filter="linear")
@@ -144,14 +146,14 @@ material = gfx.MeshBasicMaterial(map=tex, clim=(0.2, 0.8))
 geometry = gfx.BoxGeometry(100, 100, 100)
 cubes = [gfx.Mesh(geometry, material) for i in range(8)]
 for i, cube in enumerate(cubes):
-    cube.position.set(350 - i * 100, 0, 0)
+    cube.position.set(350 - i * 100, 150, 0)
     scene.add(cube)
 
 background = gfx.Background(gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
 scene.add(background)
 
 camera = gfx.PerspectiveCamera(70, 16 / 9)
-camera.position.set(500, 500, 500)
+camera.position.set(0, 0, 500)
 controls = OrbitControls(camera.position.clone())
 
 

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -24,27 +24,23 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         button = event.button()
         mode = self._drag_modes.get(button, None)
         if self.drag or not mode:
-            return  # drag is already initiated, or unknown button pressed
-        self.drag = {
-            "mode": mode,
-            "button": button,
-            "start": (event.x(), event.y()),
-        }
-        QtWidgets.QApplication.instance().setOverrideCursor(QtCore.Qt.BlankCursor)
+            return
+        pos = event.x(), event.y()
+        self.drag = {"mode": mode, "button": button, "start": pos}
+        app.setOverrideCursor(QtCore.Qt.BlankCursor)
 
     def mouseReleaseEvent(self, event):  # noqa: N802
         if self.drag and self.drag.get("button") == event.button():
-            # stop when the initiating button is released
             self.drag = None
-            QtWidgets.QApplication.instance().restoreOverrideCursor()
+            app.restoreOverrideCursor()
 
     def mouseMoveEvent(self, event):  # noqa: N802
         if not self.drag:
             return
-        mouse_end = (event.x(), event.y())
-        delta = tuple(mouse_end[i] - self.drag["start"][i] for i in range(2))
+        pos = event.x(), event.y()
+        delta = tuple(pos[i] - self.drag["start"][i] for i in range(2))
         getattr(controls, self.drag["mode"])(*delta)
-        self.drag["start"] = mouse_end
+        self.drag["start"] = pos
 
 
 app = QtWidgets.QApplication([])

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -1,0 +1,90 @@
+"""
+Example showing multiple rotating cubes. This also tests the depth buffer.
+"""
+
+import numpy as np
+import imageio
+import pygfx as gfx
+
+from PyQt5 import QtWidgets
+from wgpu.gui.qt import WgpuCanvas
+
+
+rotate_start = None
+camera = gfx.PerspectiveCamera(70, 16 / 9)
+
+
+class WgpuCanvasWithInputEvents(WgpuCanvas):
+    def wheelEvent(self, event):  # noqa: N802
+        # degrees = event.angleDelta().y() / 8
+        pass
+
+    def mousePressEvent(self, event):  # noqa: N802
+        global rotate_start
+        pos = event.windowPos()
+        rotate_start = np.array([pos.x(), pos.y()])
+
+    def mouseReleaseEvent(self, event):  # noqa: N802
+        global rotate_start
+        rotate_start = None
+
+    def mouseMoveEvent(self, event):  # noqa: N802
+        global rotate_start
+        rotate_speed = 1.0
+        pos = event.windowPos()
+        rotate_end = np.array([pos.x(), pos.y()])
+        delta = (rotate_end - rotate_start) * rotate_speed
+        delta[1] *= -1  # flip y axis
+        angles = 2 * np.pi * delta / self.height() * -1  # invert direction
+        global camera
+        rot = gfx.linalg.Quaternion().set_from_euler(
+            gfx.linalg.Euler(angles[1], angles[0])
+        )
+        camera.rotation.multiply(rot)
+        rotate_start = rotate_end
+
+    def keyPressEvent(self, event):  # noqa: N802
+        pass
+
+    def keyReleaseEvent(self, event):  # noqa: N802
+        pass
+
+
+app = QtWidgets.QApplication([])
+
+canvas = WgpuCanvasWithInputEvents()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+im = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
+im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
+tex = gfx.Texture(im, dim=2, usage="sampled").get_view(filter="linear")
+
+material = gfx.MeshBasicMaterial(map=tex, clim=(0.2, 0.8))
+geometry = gfx.BoxGeometry(100, 100, 100)
+cubes = [gfx.Mesh(geometry, material) for i in range(8)]
+for i, cube in enumerate(cubes):
+    cube.position.set(350 - i * 100, 0, 0)
+    scene.add(cube)
+
+background = gfx.Background(gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+scene.add(background)
+
+
+camera.position.z = 500
+
+
+def animate():
+    for i, cube in enumerate(cubes):
+        rot = gfx.linalg.Quaternion().set_from_euler(
+            gfx.linalg.Euler(0.0005 * i, 0.001 * i)
+        )
+        cube.rotation.multiply(rot)
+
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec_()

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -50,7 +50,7 @@ class OrbitControls:
 
     def pan(self, x: float, y: float) -> "OrbitControls":
         self._v.set(x, y, 0).apply_quaternion(self.rotation)
-        self.target.add(self._v)
+        self.target.sub(self._v)
         return self
 
     def rotate(self, x: float, y: float) -> "OrbitControls":
@@ -92,6 +92,8 @@ class OrbitControls:
 
 
 class WgpuCanvasWithInputEvents(WgpuCanvas):
+    _flip_y = np.array([1, -1])
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.mouse_start = None
@@ -116,7 +118,7 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         global controls
         pos = event.windowPos()
         mouse_end = np.array([pos.x(), pos.y()])
-        delta = mouse_end - self.mouse_start
+        delta = (mouse_end - self.mouse_start) * self._flip_y
         if self.pan:
             controls.pan(*delta)
         else:

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -35,11 +35,13 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
             "button": button,
             "start": np.array([pos.x(), pos.y()]),
         }
+        QtWidgets.QApplication.instance().setOverrideCursor(QtCore.Qt.BlankCursor)
 
     def mouseReleaseEvent(self, event):  # noqa: N802
         if self.drag.get("button") == event.button():
             # stop when the initiating button is released
             self.drag = {}
+            QtWidgets.QApplication.instance().restoreOverrideCursor()
 
     def mouseMoveEvent(self, event):  # noqa: N802
         if not self.drag:

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -161,6 +161,7 @@ def animate():
         )
         cube.rotation.multiply(rot)
 
+    # for some reason, y axis appears to be rendered upside down?
     rot, pos = controls.get_view()
     camera.rotation.copy(rot)
     camera.position.copy(pos)

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -12,13 +12,14 @@ from wgpu.gui.qt import WgpuCanvas
 
 class WgpuCanvasWithInputEvents(WgpuCanvas):
     _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
+    _speed = {"pan": 1.0, "rotate": 0.02}
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.drag = None
 
     def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(event.angleDelta().y())
+        controls.zoom(event.angleDelta().y() * 0.125)
 
     def mousePressEvent(self, event):  # noqa: N802
         button = event.button()
@@ -38,7 +39,8 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         if not self.drag:
             return
         pos = event.x(), event.y()
-        delta = tuple(pos[i] - self.drag["start"][i] for i in range(2))
+        speed = self._speed[self.drag["mode"]]
+        delta = tuple((pos[i] - self.drag["start"][i]) * speed for i in range(2))
         getattr(controls, self.drag["mode"])(*delta)
         self.drag["start"] = pos
 

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -18,7 +18,6 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         self.drag = None
 
     def wheelEvent(self, event):  # noqa: N802
-        global controls
         controls.zoom(event.angleDelta().y())
 
     def mousePressEvent(self, event):  # noqa: N802
@@ -44,7 +43,6 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
             return
         mouse_end = (event.x(), event.y())
         delta = tuple(mouse_end[i] - self.drag["start"][i] for i in range(2))
-        global controls
         getattr(controls, self.drag["mode"])(*delta)
         self.drag["start"] = mouse_end
 

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -45,10 +45,7 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         mouse_end = (event.x(), event.y())
         delta = tuple(mouse_end[i] - self.drag["start"][i] for i in range(2))
         global controls
-        if self.drag["mode"] == "pan":
-            controls.pan(*delta)
-        elif self.drag["mode"] == "rotate":
-            controls.rotate(*delta)
+        getattr(controls, self.drag["mode"])(*delta)
         self.drag["start"] = mouse_end
 
     def keyPressEvent(self, event):  # noqa: N802

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -48,12 +48,6 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         getattr(controls, self.drag["mode"])(*delta)
         self.drag["start"] = mouse_end
 
-    def keyPressEvent(self, event):  # noqa: N802
-        pass
-
-    def keyReleaseEvent(self, event):  # noqa: N802
-        pass
-
 
 app = QtWidgets.QApplication([])
 

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -14,6 +14,56 @@ rotate_start = None
 camera = gfx.PerspectiveCamera(70, 16 / 9)
 
 
+class OrbitControls:
+    _m = gfx.linalg.Matrix4()
+    _v = gfx.linalg.Vector3()
+    _q1 = gfx.linalg.Quaternion()
+    _q2 = gfx.linalg.Quaternion()
+    _e = gfx.linalg.Euler()
+
+    def __init__(self, eye: gfx.linalg.Vector3, target: gfx.linalg.Vector3, up: gfx.linalg.Vector3) -> None:
+        self.rotation = gfx.linalg.Quaternion()
+        self.look_at(eye, target, up)
+
+    def look_at(self, eye: gfx.linalg.Vector3, target: gfx.linalg.Vector3, up: gfx.linalg.Vector3) -> "OrbitControls":
+        self.rotation.set_from_rotation_matrix(self._m.look_at(eye, target, up))
+        self.target = target
+        self.distance = eye.distance_to(target)
+        return self
+
+    def pan(self, x: float, y: float) -> "OrbitControls":
+        self._v.set(-x, y).apply_quaternion(self.rotation)
+        self.target.add(self._v)
+        return self
+
+    def rotate(self, cur_x: float, cur_y: float, prev_x: float, prev_y: float) -> "OrbitControls":
+        self._q1.set_from_euler(self._e.set(-cur_x, cur_y, 0))
+        self._q2.set_from_euler(self._e.set(-prev_x, prev_y, 0))
+        self._q2.inverse()
+        self._q1.multiply(self._q2)
+        if self._q1.length() < 1e-6:
+            return
+        self.rotation.multiply(self._q1)
+        self.rotation.normalize()
+        return self
+
+    def zoom(self, delta: float) -> "OrbitControls":
+        self.distance += delta
+        if self.distance < 0:
+            self.distance = 0
+        return self
+
+    @property
+    def position(self) -> None:
+        # TODO
+        pass
+    
+    @property
+    def rotation(self) -> None:
+        # TODO
+        pass
+
+
 class WgpuCanvasWithInputEvents(WgpuCanvas):
     def wheelEvent(self, event):  # noqa: N802
         # degrees = event.angleDelta().y() / 8

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -83,13 +83,12 @@ class OrbitControls:
         return self
 
     def get_view(self) -> (gfx.linalg.Vector3, gfx.linalg.Vector3):
-        rot = self.rotation.clone()
-        pos = (
+        position = (
             gfx.linalg.Vector3(0, 0, self.distance)
-            .apply_quaternion(rot)
+            .apply_quaternion(self.rotation)
             .sub(self.target)
         )
-        return rot, pos
+        return self.rotation, position
 
 
 class WgpuCanvasWithInputEvents(WgpuCanvas):
@@ -152,8 +151,7 @@ background = gfx.Background(gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
 scene.add(background)
 
 camera = gfx.PerspectiveCamera(70, 16 / 9)
-camera.position.z = 500
-controls = OrbitControls(camera.position.clone())
+controls = OrbitControls(gfx.linalg.Vector3(500, 500, 500))
 
 
 def animate():

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -20,9 +20,9 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
     def wheelEvent(self, event):  # noqa: N802
         dim = self.width(), self.height()
         pos = event.x(), event.y()
-        delta = event.angleDelta().y() * 0.00125
+        zoom_multiplier = 2 ** (event.angleDelta().y() * 0.0015)
         view = camera.right - camera.left, camera.top - camera.bottom
-        controls.zoom_to_point(delta, pos, dim, view)
+        controls.zoom_to_point(zoom_multiplier, pos, dim, view)
 
     def mousePressEvent(self, event):  # noqa: N802
         button = event.button()

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -18,7 +18,7 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         self.drag = None
 
     def wheelEvent(self, event):  # noqa: N802
-        dim = self.width(), self.height()
+        dim = self.get_logical_size()
         pos = event.x(), event.y()
         zoom_multiplier = 2 ** (event.angleDelta().y() * 0.0015)
         view = camera.right - camera.left, camera.top - camera.bottom

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -18,22 +18,10 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         self.drag = None
 
     def wheelEvent(self, event):  # noqa: N802
-        # compute current mouse position relative to widget center
         dim = self.width(), self.height()
         pos = event.x(), event.y()
-        fracpos = tuple((pos[i] - dim[i] * 0.5) / dim[i] for i in range(2))
-        view_old = camera.right - camera.left, camera.top - camera.bottom
-        relpos_old = tuple(fracpos[i] * view_old[i] for i in range(2))
-        # apply zoom and compute change in dimensions of camera frustum
-        controls.zoom(event.angleDelta().y())
-        controls.update_camera(camera)
-        camera.update_bounds()
-        view = camera.right - camera.left, camera.top - camera.bottom
-        # compute new mouse position relative to widget center
-        relpos = tuple(fracpos[i] * view[i] for i in range(2))
-        # compute delta and pan accordingly
-        delta = tuple(relpos[i] - relpos_old[i] for i in range(2))
-        controls.pan(*delta)
+        delta = event.angleDelta().y() * 0.00125
+        controls.zoom_to_point(delta, pos, dim, camera)
 
     def mousePressEvent(self, event):  # noqa: N802
         button = event.button()
@@ -80,7 +68,7 @@ scene.add(plane)
 
 camera = gfx.OrthographicCamera(512, 512)
 camera.position.set(0, 0, 500)
-controls = gfx.OrbitControls(camera.position.clone(), zoom="zoom")
+controls = gfx.PanZoomControls(camera.position.clone())
 
 
 def animate():

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -21,7 +21,8 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         dim = self.width(), self.height()
         pos = event.x(), event.y()
         delta = event.angleDelta().y() * 0.00125
-        controls.zoom_to_point(delta, pos, dim, camera)
+        view = camera.right - camera.left, camera.top - camera.bottom
+        controls.zoom_to_point(delta, pos, dim, view)
 
     def mousePressEvent(self, event):  # noqa: N802
         button = event.button()

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -19,16 +19,16 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
 
     def wheelEvent(self, event):  # noqa: N802
         # compute current mouse position relative to widget center
-        dim = (self.width(), self.height())
-        pos = (event.x(), event.y())
+        dim = self.width(), self.height()
+        pos = event.x(), event.y()
         fracpos = tuple((pos[i] - dim[i] * 0.5) / dim[i] for i in range(2))
-        view_old = (camera.right - camera.left, camera.top - camera.bottom)
+        view_old = camera.right - camera.left, camera.top - camera.bottom
         relpos_old = tuple(fracpos[i] * view_old[i] for i in range(2))
         # apply zoom and compute change in dimensions of camera frustum
         controls.zoom(event.angleDelta().y())
         controls.update_camera(camera)
         camera.update_bounds()
-        view = (camera.right - camera.left, camera.top - camera.bottom)
+        view = camera.right - camera.left, camera.top - camera.bottom
         # compute new mouse position relative to widget center
         relpos = tuple(fracpos[i] * view[i] for i in range(2))
         # compute delta and pan accordingly
@@ -39,27 +39,23 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         button = event.button()
         mode = self._drag_modes.get(button, None)
         if self.drag or not mode:
-            return  # drag is already initiated, or unknown button pressed
-        self.drag = {
-            "mode": mode,
-            "button": button,
-            "start": (event.x(), event.y()),
-        }
-        QtWidgets.QApplication.instance().setOverrideCursor(QtCore.Qt.BlankCursor)
+            return
+        pos = event.x(), event.y()
+        self.drag = {"mode": mode, "button": button, "start": pos}
+        app.setOverrideCursor(QtCore.Qt.BlankCursor)
 
     def mouseReleaseEvent(self, event):  # noqa: N802
         if self.drag and self.drag.get("button") == event.button():
-            # stop when the initiating button is released
             self.drag = None
-            QtWidgets.QApplication.instance().restoreOverrideCursor()
+            app.restoreOverrideCursor()
 
     def mouseMoveEvent(self, event):  # noqa: N802
         if not self.drag:
             return
-        mouse_end = (event.x(), event.y())
-        delta = tuple(mouse_end[i] - self.drag["start"][i] for i in range(2))
+        pos = event.x(), event.y()
+        delta = tuple(pos[i] - self.drag["start"][i] for i in range(2))
         getattr(controls, self.drag["mode"])(*delta)
-        self.drag["start"] = mouse_end
+        self.drag["start"] = pos
 
 
 app = QtWidgets.QApplication([])

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -18,7 +18,6 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         self.drag = None
 
     def wheelEvent(self, event):  # noqa: N802
-        global controls, camera
         # compute current mouse position relative to widget center
         dim = (self.width(), self.height())
         pos = (event.x(), event.y())
@@ -59,7 +58,6 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
             return
         mouse_end = (event.x(), event.y())
         delta = tuple(mouse_end[i] - self.drag["start"][i] for i in range(2))
-        global controls
         getattr(controls, self.drag["mode"])(*delta)
         self.drag["start"] = mouse_end
 

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -1,0 +1,101 @@
+"""
+Example showing orbit camera controls.
+"""
+
+import numpy as np
+import imageio
+import pygfx as gfx
+
+from PyQt5 import QtWidgets, QtCore
+from wgpu.gui.qt import WgpuCanvas
+
+
+class WgpuCanvasWithInputEvents(WgpuCanvas):
+    _drag_modes = {QtCore.Qt.RightButton: "pan"}
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.drag = None
+
+    def wheelEvent(self, event):  # noqa: N802
+        global controls, camera
+        # compute current mouse position relative to widget center
+        dim = (self.width(), self.height())
+        pos = (event.x(), event.y())
+        fracpos = tuple((pos[i] - dim[i] * 0.5) / dim[i] for i in range(2))
+        view_old = (camera.right - camera.left, camera.top - camera.bottom)
+        relpos_old = tuple(fracpos[i] * view_old[i] for i in range(2))
+        # apply zoom and compute change in dimensions of camera frustum
+        controls.zoom(event.angleDelta().y())
+        controls.update_camera(camera)
+        camera.update_bounds()
+        view = (camera.right - camera.left, camera.top - camera.bottom)
+        # compute new mouse position relative to widget center
+        relpos = tuple(fracpos[i] * view[i] for i in range(2))
+        # compute delta and pan accordingly
+        delta = tuple(relpos[i] - relpos_old[i] for i in range(2))
+        controls.pan(*delta)
+
+    def mousePressEvent(self, event):  # noqa: N802
+        button = event.button()
+        mode = self._drag_modes.get(button, None)
+        if self.drag or not mode:
+            return  # drag is already initiated, or unknown button pressed
+        self.drag = {
+            "mode": mode,
+            "button": button,
+            "start": (event.x(), event.y()),
+        }
+        QtWidgets.QApplication.instance().setOverrideCursor(QtCore.Qt.BlankCursor)
+
+    def mouseReleaseEvent(self, event):  # noqa: N802
+        if self.drag and self.drag.get("button") == event.button():
+            # stop when the initiating button is released
+            self.drag = None
+            QtWidgets.QApplication.instance().restoreOverrideCursor()
+
+    def mouseMoveEvent(self, event):  # noqa: N802
+        if not self.drag:
+            return
+        mouse_end = (event.x(), event.y())
+        delta = tuple(mouse_end[i] - self.drag["start"][i] for i in range(2))
+        global controls
+        getattr(controls, self.drag["mode"])(*delta)
+        self.drag["start"] = mouse_end
+
+
+app = QtWidgets.QApplication([])
+canvas = WgpuCanvasWithInputEvents()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+axes = gfx.AxesHelper(size=250)
+scene.add(axes)
+
+background = gfx.Background(gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+scene.add(background)
+
+im = imageio.imread("imageio:astronaut.png")
+im = np.concatenate([im, 255 * np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)  # yuk!
+tex = gfx.Texture(im, dim=2, usage="sampled")
+geometry = gfx.PlaneGeometry(512, 512)
+material = gfx.MeshBasicMaterial(map=tex.get_view(filter="linear"), clim=(0, 255))
+plane = gfx.Mesh(geometry, material)
+plane.scale.y = -1
+scene.add(plane)
+
+camera = gfx.OrthographicCamera(512, 512)
+camera.position.set(0, 0, 500)
+controls = gfx.OrbitControls(camera.position.clone(), zoom="zoom")
+
+
+def animate():
+    controls.update_camera(camera)
+
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec_()

--- a/examples/volume_slice3.py
+++ b/examples/volume_slice3.py
@@ -31,9 +31,7 @@ tex = gfx.Texture(vol, dim=3, usage="sampled")
 view = tex.get_view(filter="linear")
 
 geometry = gfx.PlaneGeometry(200, 200, 1, 1)
-texcoords = np.hstack(
-    [geometry.texcoords.data, np.ones((4, 1), np.float32) * nslices / 2]
-)
+texcoords = np.hstack([geometry.texcoords.data, np.ones((4, 1), np.float32) * 0.5])
 geometry.texcoords = gfx.Buffer(texcoords, usage="vertex|storage")
 
 material = gfx.MeshVolumeSliceMaterial(map=view, clim=(0, 255))

--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -7,6 +7,7 @@ from .objects import *
 from .geometries import *
 from .materials import *
 from .cameras import *
+from .helpers import *
 
 from .renderers import *
 

--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -8,6 +8,7 @@ from .geometries import *
 from .materials import *
 from .cameras import *
 from .helpers import *
+from .controls import *
 
 from .renderers import *
 

--- a/pygfx/cameras/_orthographic.py
+++ b/pygfx/cameras/_orthographic.py
@@ -17,14 +17,12 @@ class OrthographicCamera(Camera):
 
     def __init__(self, width=1, height=1, near=-1000, far=1000):
         super().__init__()
-        self.width = float(width)
-        self.height = float(height)
         self.near = float(near)
         self.far = float(far)
         assert self.near < self.far
         self.zoom = 1
         self._maintain_aspect = True
-        self._view_aspect = 1
+        self.set_viewport_size(width, height)
         self.update_projection_matrix()
 
     def __repr__(self) -> str:
@@ -33,29 +31,35 @@ class OrthographicCamera(Camera):
         )
 
     def set_viewport_size(self, width, height):
-        self._view_aspect = width / height
+        self.width = float(width)
+        self.height = float(height)
+        self._view_aspect = self.width / self.height
+        self.update_bounds()
 
-    def update_projection_matrix(self):
+    def update_bounds(self):
         # Get the reference width / height
+        # TODO: when can this lead to a change? unclear to me
         width = self.width / self.zoom
         height = self.height / self.zoom
-        # Increase eihter the width or height, depending on the view size
+        # Increase either the width or height, depending on the view size
         aspect = width / height
         if aspect < self._view_aspect:
             width *= self._view_aspect / aspect
         else:
             height *= aspect / self._view_aspect
         # Calculate bounds
-        top = +0.5 * height
-        bottom = -0.5 * height
-        left = -0.5 * width
-        right = +0.5 * width
+        self.top = +0.5 * height
+        self.bottom = -0.5 * height
+        self.left = -0.5 * width
+        self.right = +0.5 * width
+
+    def update_projection_matrix(self):
         # Set matrices
         # The linalg ortho projection puts xyz in the range -1..1, but
         # in the coordinate system of wgpu (and this lib) the depth is
         # expressed in 0..1, so we also correct for that.
         self.projection_matrix.make_orthographic(
-            left, right, top, bottom, self.near, self.far
+            self.left, self.right, self.top, self.bottom, self.near, self.far
         )
         self.projection_matrix.premultiply(
             Matrix4(1, 0, 0.0, 0, 0, 1, 0.0, 0, 0.0, 0.0, 0.5, 0.0, 0, 0, 0.5, 1)

--- a/pygfx/cameras/_orthographic.py
+++ b/pygfx/cameras/_orthographic.py
@@ -33,20 +33,8 @@ class OrthographicCamera(Camera):
     def set_viewport_size(self, width, height):
         self.width = float(width)
         self.height = float(height)
-        self._view_aspect = self.width / self.height
-        self.update_bounds()
-
-    def update_bounds(self):
-        # Get the reference width / height
-        # TODO: when can this lead to a change? unclear to me
         width = self.width / self.zoom
         height = self.height / self.zoom
-        # Increase either the width or height, depending on the view size
-        aspect = width / height
-        if aspect < self._view_aspect:
-            width *= self._view_aspect / aspect
-        else:
-            height *= aspect / self._view_aspect
         # Calculate bounds
         self.top = +0.5 * height
         self.bottom = -0.5 * height

--- a/pygfx/cameras/_orthographic.py
+++ b/pygfx/cameras/_orthographic.py
@@ -17,12 +17,16 @@ class OrthographicCamera(Camera):
 
     def __init__(self, width=1, height=1, near=-1000, far=1000):
         super().__init__()
+        # These width and height represent the view-pane in world coordinates
+        # and has little to do with the canvas/viewport size.
+        self.width = float(width)
+        self.height = float(height)
         self.near = float(near)
         self.far = float(far)
         assert self.near < self.far
         self.zoom = 1
         self._maintain_aspect = True
-        self.set_viewport_size(width, height)
+        self.set_viewport_size(1, 1)
         self.update_projection_matrix()
 
     def __repr__(self) -> str:
@@ -31,10 +35,16 @@ class OrthographicCamera(Camera):
         )
 
     def set_viewport_size(self, width, height):
-        self.width = float(width)
-        self.height = float(height)
+        self._view_aspect = width / height
+
         width = self.width / self.zoom
         height = self.height / self.zoom
+        # Increase eihter the width or height, depending on the view size
+        aspect = width / height
+        if aspect < self._view_aspect:
+            width *= self._view_aspect / aspect
+        else:
+            height *= aspect / self._view_aspect
         # Calculate bounds
         self.top = +0.5 * height
         self.bottom = -0.5 * height

--- a/pygfx/cameras/_orthographic.py
+++ b/pygfx/cameras/_orthographic.py
@@ -46,8 +46,8 @@ class OrthographicCamera(Camera):
         else:
             height *= aspect / self._view_aspect
         # Calculate bounds
-        top = -0.5 * height
-        bottom = +0.5 * height
+        top = +0.5 * height
+        bottom = -0.5 * height
         left = -0.5 * width
         right = +0.5 * width
         # Set matrices

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -47,8 +47,8 @@ class PerspectiveCamera(Camera):
         else:
             height *= self.aspect / self._view_aspect
         # Calculate bounds
-        top = -0.5 * height
-        bottom = +0.5 * height
+        top = +0.5 * height
+        bottom = -0.5 * height
         left = -0.5 * width
         right = +0.5 * width
         # Set matrices

--- a/pygfx/controls/__init__.py
+++ b/pygfx/controls/__init__.py
@@ -1,3 +1,4 @@
 # flake8: noqa
 
 from ._orbit import OrbitControls
+from ._panzoom import PanZoomControls

--- a/pygfx/controls/__init__.py
+++ b/pygfx/controls/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa
+
+from ._orbit import OrbitControls

--- a/pygfx/controls/_orbit.py
+++ b/pygfx/controls/_orbit.py
@@ -1,0 +1,76 @@
+"""
+Example showing orbit camera controls.
+"""
+
+from ..linalg import Vector3, Matrix4, Quaternion, Spherical
+
+
+class OrbitControls:
+    _m = Matrix4()
+    _v = Vector3()
+    _origin = Vector3()
+    _orbit_up = Vector3(0, 1, 0)
+    _s = Spherical()
+
+    def __init__(
+        self, eye: Vector3 = None, target: Vector3 = None, up: Vector3 = None,
+    ) -> None:
+        self.rotation = Quaternion()
+        if eye is None:
+            eye = Vector3(50.0, 50.0, 50.0)
+        if target is None:
+            target = Vector3()
+        if up is None:
+            up = Vector3(0.0, 1.0, 0.0)
+        self.look_at(eye, target, up)
+
+    def look_at(self, eye: Vector3, target: Vector3, up: Vector3,) -> "OrbitControls":
+        self.distance = eye.distance_to(target)
+        self.target = target
+        self.up = up
+        self.rotation.set_from_rotation_matrix(self._m.look_at(eye, target, up))
+        self._up_quat = Quaternion().set_from_unit_vectors(self.up, self._orbit_up)
+        self._up_quat_inv = self._up_quat.clone().inverse()
+        return self
+
+    def pan(self, x: float, y: float) -> "OrbitControls":
+        self._v.set(x, y, 0).apply_quaternion(self.rotation)
+        self.target.sub(self._v)
+        return self
+
+    def rotate(self, x: float, y: float) -> "OrbitControls":
+        # (implicit target=(0,0,0))
+        # offset
+        self._v.set(0, 0, self.distance).apply_quaternion(self.rotation)
+        # to neutral up
+        self._v.apply_quaternion(self._up_quat)
+        # to spherical
+        self._s.set_from_vector3(self._v)
+        # apply delta
+        self._s.theta -= x
+        self._s.phi += y
+        # clip
+        self._s.make_safe()
+        # back to cartesian
+        self._v.set_from_spherical(self._s)
+        # back to camera up
+        self._v.apply_quaternion(self._up_quat_inv)
+        # compute new rotation
+        self.rotation.set_from_rotation_matrix(
+            self._m.look_at(self._v, self._origin, self.up)
+        )
+        return self
+
+    def zoom(self, delta: float) -> "OrbitControls":
+        self.distance -= delta
+        if self.distance < 0:
+            self.distance = 0
+        return self
+
+    def get_view(self) -> (Vector3, Vector3):
+        position = (
+            Vector3(0, 0, self.distance)
+            .apply_quaternion(self.rotation)
+            .add(self.target)
+        )
+        return self.rotation, position

--- a/pygfx/controls/_orbit.py
+++ b/pygfx/controls/_orbit.py
@@ -9,11 +9,7 @@ class OrbitControls:
     _s = Spherical()
 
     def __init__(
-        self,
-        eye: Vector3 = None,
-        target: Vector3 = None,
-        up: Vector3 = None,
-        zoom: str = "distance",
+        self, eye: Vector3 = None, target: Vector3 = None, up: Vector3 = None,
     ) -> None:
         self.rotation = Quaternion()
         if eye is None:
@@ -23,12 +19,6 @@ class OrbitControls:
         if up is None:
             up = Vector3(0.0, 1.0, 0.0)
         self.look_at(eye, target, up)
-        self.rotate_speed = 0.02
-        self.zoom_speed = 0.125
-        self.pan_speed = 1.0
-        self.zoom_type = zoom
-        self.zoom_ = 1.0
-        self.min_zoom = 0.0001
 
     def look_at(self, eye: Vector3, target: Vector3, up: Vector3) -> "OrbitControls":
         self.distance = eye.distance_to(target)
@@ -40,13 +30,11 @@ class OrbitControls:
         return self
 
     def pan(self, x: float, y: float) -> "OrbitControls":
-        self._v.set(x, -y, 0).multiply_scalar(self.pan_speed).apply_quaternion(
-            self.rotation
-        )
+        self._v.set(x, -y, 0).apply_quaternion(self.rotation)
         self.target.sub(self._v)
         return self
 
-    def rotate(self, x: float, y: float) -> "OrbitControls":
+    def rotate(self, theta: float, phi: float) -> "OrbitControls":
         # offset
         self._v.set(0, 0, self.distance).apply_quaternion(self.rotation)
         # to neutral up
@@ -54,8 +42,8 @@ class OrbitControls:
         # to spherical
         self._s.set_from_vector3(self._v)
         # apply delta
-        self._s.theta -= x * self.rotate_speed
-        self._s.phi -= y * self.rotate_speed
+        self._s.theta -= theta
+        self._s.phi -= phi
         # clip
         self._s.make_safe()
         # back to cartesian
@@ -69,29 +57,19 @@ class OrbitControls:
         return self
 
     def zoom(self, delta: float) -> "OrbitControls":
-        if self.zoom_type == "distance":
-            self.distance -= delta * self.zoom_speed
-            if self.distance < 0:
-                self.distance = 0
-        elif self.zoom_type == "zoom":
-            delta = delta * self.zoom_speed * 0.01
-            if self.zoom_ < 1.0:
-                delta *= self.zoom_
-            self.zoom_ += delta
-            if self.zoom_ < self.min_zoom:
-                self.zoom_ = self.min_zoom
+        self.distance -= delta
+        if self.distance < 0:
+            self.distance = 0
         return self
 
-    def get_view(self) -> (Vector3, Vector3, float):
-        # returns (rotation, position, zoom)
+    def get_view(self) -> (Vector3, Vector3):
         self._v.set(0, 0, self.distance).apply_quaternion(self.rotation).add(
             self.target
         )
-        return self.rotation, self._v, self.zoom_
+        return self.rotation, self._v
 
-    def update_camera(self, camera: "Camera") -> None:
-        rot, pos, zoom = self.get_view()
+    def update_camera(self, camera: "Camera") -> "OrbitControls":
+        rot, pos = self.get_view()
         camera.rotation.copy(rot)
         camera.position.copy(pos)
-        if self.zoom_type == "zoom":
-            camera.zoom = zoom
+        return self

--- a/pygfx/controls/_orbit.py
+++ b/pygfx/controls/_orbit.py
@@ -74,3 +74,8 @@ class OrbitControls:
             .add(self.target)
         )
         return self.rotation, position
+
+    def update_camera(self, camera: "Camera") -> None:
+        rot, pos = self.get_view()
+        camera.rotation.copy(rot)
+        camera.position.copy(pos)

--- a/pygfx/controls/_panzoom.py
+++ b/pygfx/controls/_panzoom.py
@@ -56,23 +56,21 @@ class PanZoomControls:
         delta: float,
         mouse: Tuple[float, float],
         canvas: Tuple[float, float],
-        camera: "OrthographicCamera",
+        view: Tuple[float, float],
     ) -> "PanZoomControls":
         # convert current mouse position to fractions relative to widget center
         # (fracpos x and y range becomes [-50%, 50%])
         fracpos = tuple((mouse[i] - canvas[i] * 0.5) / canvas[i] for i in range(2))
-        # compute current viewport dimensions
-        view_old = camera.right - camera.left, camera.top - camera.bottom
         # this gives us the relative position of the mouse in viewport space
-        relpos_old = tuple(fracpos[i] * view_old[i] for i in range(2))
+        relpos_old = tuple(fracpos[i] * view[i] for i in range(2))
         # now apply the zoom delta
+        zoom_old = self.zoom_
         self.zoom(delta)
-        self.update_camera(camera)
         # compute the new viewport dimensions
-        camera.update_bounds()
-        view = camera.right - camera.left, camera.top - camera.bottom
+        zoom_ratio = zoom_old / self.zoom_
+        view_new = tuple(view[i] * zoom_ratio for i in range(2))
         # and the new relative position of the mouse in viewport space
-        relpos = tuple(fracpos[i] * view[i] for i in range(2))
+        relpos = tuple(fracpos[i] * view_new[i] for i in range(2))
         # finally compute the delta and pan accordingly to compensate
         # such that the point under the mouse stays under the mouse
         delta = tuple(relpos[i] - relpos_old[i] for i in range(2))

--- a/pygfx/controls/_panzoom.py
+++ b/pygfx/controls/_panzoom.py
@@ -26,7 +26,7 @@ class PanZoomControls:
         if up is None:
             up = Vector3(0.0, 1.0, 0.0)
         self.look_at(eye, target, up)
-        self.zoom_ = zoom
+        self.zoom_value = zoom
         self.min_zoom = min_zoom
 
     def look_at(self, eye: Vector3, target: Vector3, up: Vector3) -> "PanZoomControls":
@@ -43,12 +43,8 @@ class PanZoomControls:
         self.target.sub(self._v)
         return self
 
-    def zoom(self, delta: float) -> "PanZoomControls":
-        if self.zoom_ < 1.0:
-            delta *= self.zoom_
-        self.zoom_ += delta
-        if self.zoom_ < self.min_zoom:
-            self.zoom_ = self.min_zoom
+    def zoom(self, multiplier: float) -> "PanZoomControls":
+        self.zoom_value = max(self.min_zoom, float(multiplier) * self.zoom_value)
         return self
 
     def zoom_to_point(
@@ -64,10 +60,10 @@ class PanZoomControls:
         # this gives us the relative position of the mouse in viewport space
         relpos_old = tuple(fracpos[i] * view[i] for i in range(2))
         # now apply the zoom delta
-        zoom_old = self.zoom_
+        zoom_old = self.zoom_value
         self.zoom(delta)
         # compute the new viewport dimensions
-        zoom_ratio = zoom_old / self.zoom_
+        zoom_ratio = zoom_old / self.zoom_value
         view_new = tuple(view[i] * zoom_ratio for i in range(2))
         # and the new relative position of the mouse in viewport space
         relpos = tuple(fracpos[i] * view_new[i] for i in range(2))
@@ -81,7 +77,7 @@ class PanZoomControls:
         self._v.set(0, 0, self.distance).apply_quaternion(self.rotation).add(
             self.target
         )
-        return self.rotation, self._v, self.zoom_
+        return self.rotation, self._v, self.zoom_value
 
     def update_camera(self, camera: "Camera") -> "PanZoomControls":
         rot, pos, zoom = self.get_view()

--- a/pygfx/controls/_panzoom.py
+++ b/pygfx/controls/_panzoom.py
@@ -1,0 +1,93 @@
+from typing import Tuple
+
+from ..linalg import Vector3, Matrix4, Quaternion, Spherical
+
+
+class PanZoomControls:
+    _m = Matrix4()
+    _v = Vector3()
+    _origin = Vector3()
+    _orbit_up = Vector3(0, 1, 0)
+    _s = Spherical()
+
+    def __init__(
+        self,
+        eye: Vector3 = None,
+        target: Vector3 = None,
+        up: Vector3 = None,
+        zoom: float = 1.0,
+        min_zoom: float = 0.0001,
+    ) -> None:
+        self.rotation = Quaternion()
+        if eye is None:
+            eye = Vector3(50.0, 50.0, 50.0)
+        if target is None:
+            target = Vector3()
+        if up is None:
+            up = Vector3(0.0, 1.0, 0.0)
+        self.look_at(eye, target, up)
+        self.zoom_ = zoom
+        self.min_zoom = min_zoom
+
+    def look_at(self, eye: Vector3, target: Vector3, up: Vector3) -> "PanZoomControls":
+        self.distance = eye.distance_to(target)
+        self.target = target
+        self.up = up
+        self.rotation.set_from_rotation_matrix(self._m.look_at(eye, target, up))
+        self._up_quat = Quaternion().set_from_unit_vectors(self.up, self._orbit_up)
+        self._up_quat_inv = self._up_quat.clone().inverse()
+        return self
+
+    def pan(self, x: float, y: float) -> "PanZoomControls":
+        self._v.set(x, -y, 0).apply_quaternion(self.rotation)
+        self.target.sub(self._v)
+        return self
+
+    def zoom(self, delta: float) -> "PanZoomControls":
+        if self.zoom_ < 1.0:
+            delta *= self.zoom_
+        self.zoom_ += delta
+        if self.zoom_ < self.min_zoom:
+            self.zoom_ = self.min_zoom
+        return self
+
+    def zoom_to_point(
+        self,
+        delta: float,
+        mouse: Tuple[float, float],
+        canvas: Tuple[float, float],
+        camera: "OrthographicCamera",
+    ) -> "PanZoomControls":
+        # convert current mouse position to fractions relative to widget center
+        # (fracpos x and y range becomes [-50%, 50%])
+        fracpos = tuple((mouse[i] - canvas[i] * 0.5) / canvas[i] for i in range(2))
+        # compute current viewport dimensions
+        view_old = camera.right - camera.left, camera.top - camera.bottom
+        # this gives us the relative position of the mouse in viewport space
+        relpos_old = tuple(fracpos[i] * view_old[i] for i in range(2))
+        # now apply the zoom delta
+        self.zoom(delta)
+        self.update_camera(camera)
+        # compute the new viewport dimensions
+        camera.update_bounds()
+        view = camera.right - camera.left, camera.top - camera.bottom
+        # and the new relative position of the mouse in viewport space
+        relpos = tuple(fracpos[i] * view[i] for i in range(2))
+        # finally compute the delta and pan accordingly to compensate
+        # such that the point under the mouse stays under the mouse
+        delta = tuple(relpos[i] - relpos_old[i] for i in range(2))
+        self.pan(*delta)
+        return self
+
+    def get_view(self) -> (Vector3, Vector3, float):
+        self._v.set(0, 0, self.distance).apply_quaternion(self.rotation).add(
+            self.target
+        )
+        return self.rotation, self._v, self.zoom_
+
+    def update_camera(self, camera: "Camera") -> "PanZoomControls":
+        rot, pos, zoom = self.get_view()
+        camera.rotation.copy(rot)
+        camera.position.copy(pos)
+        camera.zoom = zoom
+        return self

--- a/pygfx/helpers/__init__.py
+++ b/pygfx/helpers/__init__.py
@@ -1,0 +1,3 @@
+# flake8: noqa
+
+from ._axes import AxesHelper

--- a/pygfx/helpers/_axes.py
+++ b/pygfx/helpers/_axes.py
@@ -9,17 +9,26 @@ class AxesHelper(Group):
 
         self.size = size
 
-        positions = np.array([
-            [[0, 0, 0, 1], [1, 0, 0, 1]],
-            [[0, 0, 0, 1], [0, 1, 0, 1]],
-            [[0, 0, 0, 1], [0, 0, 1, 1]],
-        ], dtype=np.float32) * self.size
+        positions = (
+            np.array(
+                [
+                    [[0, 0, 0, 1], [1, 0, 0, 1]],
+                    [[0, 0, 0, 1], [0, 1, 0, 1]],
+                    [[0, 0, 0, 1], [0, 0, 1, 1]],
+                ],
+                dtype=np.float32,
+            )
+            * self.size
+        )
 
-        colors = np.array([
-            [1, 0.6, 0, 1],  # x is orange-ish
-            [0.6, 1, 0, 1],  # y is yellow-ish
-            [0, 0.6, 1, 1],  # z is blue-ish
-        ], dtype=np.float32)
+        colors = np.array(
+            [
+                [1, 0.6, 0, 1],  # x is orange-ish
+                [0.6, 1, 0, 1],  # y is yellow-ish
+                [0, 0.6, 1, 1],  # z is blue-ish
+            ],
+            dtype=np.float32,
+        )
 
         for pos, color in zip(positions, colors):
             geometry = Geometry(positions=pos)

--- a/pygfx/helpers/_axes.py
+++ b/pygfx/helpers/_axes.py
@@ -1,0 +1,29 @@
+import numpy as np
+
+from .. import Geometry, Group, Line, LineSegmentMaterial
+
+
+class AxesHelper(Group):
+    def __init__(self, size=1.0, thickness=6.0):
+        super().__init__()
+
+        self.size = size
+
+        positions = np.array([
+            [[0, 0, 0, 1], [1, 0, 0, 1]],
+            [[0, 0, 0, 1], [0, 1, 0, 1]],
+            [[0, 0, 0, 1], [0, 0, 1, 1]],
+        ], dtype=np.float32) * self.size
+
+        colors = np.array([
+            [1, 0.6, 0, 1],  # x is orange-ish
+            [0.6, 1, 0, 1],  # y is yellow-ish
+            [0, 0.6, 1, 1],  # z is blue-ish
+        ], dtype=np.float32)
+
+        for pos, color in zip(positions, colors):
+            geometry = Geometry(positions=pos)
+            material = LineSegmentMaterial(thickness=thickness, color=color)
+            self.add(Line(geometry, material))
+        # TODO: draw each axis with a different color using vertex coloring
+        # instead of three subnodes

--- a/pygfx/linalg/spherical.py
+++ b/pygfx/linalg/spherical.py
@@ -34,3 +34,4 @@ class Spherical:
         self.phi = max(self._eps, min(math.pi - self._eps, self.phi))
         # restrict theta to (0, 2*pi)
         self.theta = self.theta % self._2pi
+        return self

--- a/pygfx/linalg/spherical.py
+++ b/pygfx/linalg/spherical.py
@@ -1,7 +1,36 @@
+import math
+
+
 class Spherical:
+    _2pi = 2 * math.pi
+    _eps = 0.000001
+
     def __init__(
         self, radius: float = 1.0, phi: float = 0.0, theta: float = 0.0
     ) -> None:
         self.radius = radius
         self.phi = phi
         self.theta = theta
+
+    def set_from_vector3(self, v: "Vector3") -> "Spherical":
+        return self.set_from_cartesian_coords(v.x, v.y, v.z)
+
+    def set_from_cartesian_coords(self, x: float, y: float, z: float) -> "Spherical":
+        self.radius = math.sqrt(x ** 2 + y ** 2 + z ** 2)
+        if self.radius == 0:
+            self.theta, self.phi = 0, 0
+        else:
+            self.theta = math.atan2(x, z)
+            y /= self.radius
+            if y < -1:
+                y = -1
+            elif y > 1:
+                y = 1
+            self.phi = math.acos(y)
+        return self
+
+    def make_safe(self) -> "Spherical":
+        # restrict phi to (epsilon, pi-epsilon)
+        self.phi = max(self._eps, min(math.pi - self._eps, self.phi))
+        # restrict theta to (0, 2*pi)
+        self.theta = self.theta % self._2pi

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -20,6 +20,8 @@ class WorldObject:
         self.rotation = Quaternion()
         self.scale = Vector3(1, 1, 1)
 
+        self.up = Vector3(0, 1, 0)
+
         self.matrix = Matrix4()
         self.matrix_world = Matrix4()
         self.matrix_world_dirty = True
@@ -77,3 +79,13 @@ class WorldObject:
         if update_children:
             for child in self._children:
                 child.update_matrix_world()
+
+    def look_at(self, target: Vector3):
+        self.update_matrix_world(update_parents=True, update_children=False)
+        v = Vector3().set_from_matrix_position(self.matrix_world)
+        m = Matrix4().look_at(v, target, self.up)
+        self.rotation.set_from_rotation_matrix(m)
+        if self.parent:
+            m.extract_rotation(self.parent.matrix_world)
+            q = Quaternion().set_from_rotation_matrix(m)
+            self.rotation.premultiply(q.inverse())

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -12,6 +12,10 @@ class WorldObject:
     into a single empty world object.
     """
 
+    _v = Vector3()
+    _m = Matrix4()
+    _q = Quaternion()
+
     def __init__(self):
         self.parent = None
         self._children = []
@@ -82,10 +86,10 @@ class WorldObject:
 
     def look_at(self, target: Vector3):
         self.update_matrix_world(update_parents=True, update_children=False)
-        v = Vector3().set_from_matrix_position(self.matrix_world)
-        m = Matrix4().look_at(v, target, self.up)
-        self.rotation.set_from_rotation_matrix(m)
+        self._v.set_from_matrix_position(self.matrix_world)
+        self._m.look_at(self._v, target, self.up)
+        self.rotation.set_from_rotation_matrix(self._m)
         if self.parent:
-            m.extract_rotation(self.parent.matrix_world)
-            q = Quaternion().set_from_rotation_matrix(m)
-            self.rotation.premultiply(q.inverse())
+            self._m.extract_rotation(self.parent.matrix_world)
+            self._q.set_from_rotation_matrix(self._m)
+            self.rotation.premultiply(self._q.inverse())


### PR DESCRIPTION
Ready to merge!

Changes:

* Orbit and panzoom camera controls
  * Right mouse button drag to pan
  * Left mouse button drag to rotate
  * Mouse wheel to zoom
  * Tuneable speeds for panning, zooming and rotating
  * Choose between zooming based on camera distance or zoom
  * Came up with an API that allows the user to remain in control over state flow and GUI glue
* Had to revise the orthographic camera control flow a little bit; previously, it would autonomously (i.e. without user input) zoom if you set ` zoom != 1`
* WorldObject.look_at utility
* Implement more functions on Spherical linalg class
* While debugging the above, I also:
  * Added an AxesHelper to debug coordinate systems
    * Since linesegments don't support vertex coloring yet, I had to create three separate objects to be able to set different colors on each axis
  * Fixed a bug in perspective and orthographic camera (top/bottom were flipped)
* Orbit camera example:

![orbit](https://user-images.githubusercontent.com/1882046/88551287-fcfb1400-d022-11ea-96f2-e300bebdc227.gif)

* Panzoom (zoom-to-mouse!) camera example:

![panzoom](https://user-images.githubusercontent.com/1882046/88642616-ff13b000-d0c0-11ea-828c-7f6978b7e453.gif)

* Multi-slice example:

![multislice](https://user-images.githubusercontent.com/1882046/88801379-ea5f1700-d1a9-11ea-9cdb-b368bc0d1616.gif)
