### PR TITLE
Fix panning for camera controls

### DIFF
--- a/examples/multi_slice.py
+++ b/examples/multi_slice.py
@@ -33,6 +33,10 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
     def mouseReleaseEvent(self, event):  # noqa: N802
         if self._mode and self._mode == self._drag_modes.get(event.button(), None):
             self._mode = None
+            drag_stop = (
+                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
+            )
+            drag_stop()
             app.restoreOverrideCursor()
 
     def mouseMoveEvent(self, event):  # noqa: N802

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -12,37 +12,33 @@ from wgpu.gui.qt import WgpuCanvas
 
 class WgpuCanvasWithInputEvents(WgpuCanvas):
     _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
-    _speed = {"pan": 1.0, "rotate": 0.02}
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.drag = None
+    _mode = None
 
     def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(event.angleDelta().y() * 0.125)
+        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
 
     def mousePressEvent(self, event):  # noqa: N802
-        button = event.button()
-        mode = self._drag_modes.get(button, None)
-        if self.drag or not mode:
+        mode = self._drag_modes.get(event.button(), None)
+        if self._mode or not mode:
             return
-        pos = event.x(), event.y()
-        self.drag = {"mode": mode, "button": button, "start": pos}
-        app.setOverrideCursor(QtCore.Qt.BlankCursor)
+        self._mode = mode
+        drag_start = (
+            controls.pan_start if self._mode == "pan" else controls.rotate_start
+        )
+        drag_start((event.x(), event.y()), self.get_logical_size(), camera)
+        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
 
     def mouseReleaseEvent(self, event):  # noqa: N802
-        if self.drag and self.drag.get("button") == event.button():
-            self.drag = None
+        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
+            self._mode = None
             app.restoreOverrideCursor()
 
     def mouseMoveEvent(self, event):  # noqa: N802
-        if not self.drag:
-            return
-        pos = event.x(), event.y()
-        speed = self._speed[self.drag["mode"]]
-        delta = tuple((pos[i] - self.drag["start"][i]) * speed for i in range(2))
-        getattr(controls, self.drag["mode"])(*delta)
-        self.drag["start"] = pos
+        if self._mode is not None:
+            drag_move = (
+                controls.pan_move if self._mode == "pan" else controls.rotate_move
+            )
+            drag_move((event.x(), event.y()))
 
 
 app = QtWidgets.QApplication([])

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -31,6 +31,10 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
     def mouseReleaseEvent(self, event):  # noqa: N802
         if self._mode and self._mode == self._drag_modes.get(event.button(), None):
             self._mode = None
+            drag_stop = (
+                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
+            )
+            drag_stop()
             app.restoreOverrideCursor()
 
     def mouseMoveEvent(self, event):  # noqa: N802

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -31,6 +31,7 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
     def mouseReleaseEvent(self, event):  # noqa: N802
         if self._mode and self._mode == self._drag_modes.get(event.button(), None):
             self._mode = None
+            controls.pan_stop()
             app.restoreOverrideCursor()
 
     def mouseMoveEvent(self, event):  # noqa: N802

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -12,39 +12,30 @@ from wgpu.gui.qt import WgpuCanvas
 
 class WgpuCanvasWithInputEvents(WgpuCanvas):
     _drag_modes = {QtCore.Qt.RightButton: "pan"}
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.drag = None
+    _mode = None
 
     def wheelEvent(self, event):  # noqa: N802
-        dim = self.get_logical_size()
-        pos = event.x(), event.y()
         zoom_multiplier = 2 ** (event.angleDelta().y() * 0.0015)
-        view = camera.right - camera.left, camera.top - camera.bottom
-        controls.zoom_to_point(zoom_multiplier, pos, dim, view)
+        controls.zoom_to_point(
+            zoom_multiplier, (event.x(), event.y()), self.get_logical_size(), camera
+        )
 
     def mousePressEvent(self, event):  # noqa: N802
-        button = event.button()
-        mode = self._drag_modes.get(button, None)
-        if self.drag or not mode:
+        mode = self._drag_modes.get(event.button(), None)
+        if self._mode or not mode:
             return
-        pos = event.x(), event.y()
-        self.drag = {"mode": mode, "button": button, "start": pos}
-        app.setOverrideCursor(QtCore.Qt.BlankCursor)
+        self._mode = mode
+        controls.pan_start((event.x(), event.y()), self.get_logical_size(), camera)
+        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
 
     def mouseReleaseEvent(self, event):  # noqa: N802
-        if self.drag and self.drag.get("button") == event.button():
-            self.drag = None
+        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
+            self._mode = None
             app.restoreOverrideCursor()
 
     def mouseMoveEvent(self, event):  # noqa: N802
-        if not self.drag:
-            return
-        pos = event.x(), event.y()
-        delta = tuple(pos[i] - self.drag["start"][i] for i in range(2))
-        getattr(controls, self.drag["mode"])(*delta)
-        self.drag["start"] = pos
+        if self._mode is not None:
+            controls.pan_move((event.x(), event.y()))
 
 
 app = QtWidgets.QApplication([])

--- a/pygfx/cameras/_orthographic.py
+++ b/pygfx/cameras/_orthographic.py
@@ -39,7 +39,7 @@ class OrthographicCamera(Camera):
         # The reference view plane is scaled with the zoom factor
         width = self.width / self.zoom
         height = self.height / self.zoom
-        # Increase eihter the width or height, depending on the viewport shape
+        # Increase either the width or height, depending on the viewport shape
         aspect = width / height
         if aspect < self._view_aspect:
             width *= self._view_aspect / aspect

--- a/pygfx/cameras/_orthographic.py
+++ b/pygfx/cameras/_orthographic.py
@@ -17,7 +17,7 @@ class OrthographicCamera(Camera):
 
     def __init__(self, width=1, height=1, near=-1000, far=1000):
         super().__init__()
-        # These width and height represent the view-pane in world coordinates
+        # These width and height represent the view-plane in world coordinates
         # and has little to do with the canvas/viewport size.
         self.width = float(width)
         self.height = float(height)
@@ -36,28 +36,30 @@ class OrthographicCamera(Camera):
 
     def set_viewport_size(self, width, height):
         self._view_aspect = width / height
-
+        # The reference view plane is scaled with the zoom factor
         width = self.width / self.zoom
         height = self.height / self.zoom
-        # Increase eihter the width or height, depending on the view size
+        # Increase eihter the width or height, depending on the viewport shape
         aspect = width / height
         if aspect < self._view_aspect:
             width *= self._view_aspect / aspect
         else:
             height *= aspect / self._view_aspect
-        # Calculate bounds
-        self.top = +0.5 * height
-        self.bottom = -0.5 * height
-        self.left = -0.5 * width
-        self.right = +0.5 * width
+        # Store the size if the visible view plane in world coordinates
+        self.visible_world_size = width, height
 
     def update_projection_matrix(self):
+        w, h = self.visible_world_size
+        bottom = -0.5 * h
+        top = +0.5 * h
+        left = -0.5 * w
+        right = +0.5 * w
         # Set matrices
         # The linalg ortho projection puts xyz in the range -1..1, but
         # in the coordinate system of wgpu (and this lib) the depth is
         # expressed in 0..1, so we also correct for that.
         self.projection_matrix.make_orthographic(
-            self.left, self.right, self.top, self.bottom, self.near, self.far
+            left, right, top, bottom, self.near, self.far
         )
         self.projection_matrix.premultiply(
             Matrix4(1, 0, 0.0, 0, 0, 1, 0.0, 0, 0.0, 0.0, 0.5, 0.0, 0, 0, 0.5, 1)

--- a/pygfx/controls/_orbit.py
+++ b/pygfx/controls/_orbit.py
@@ -1,12 +1,35 @@
-from ..linalg import Vector3, Matrix4, Quaternion, Spherical
+from typing import Tuple
+
+from ..linalg import Vector3, Vector4, Matrix4, Quaternion, Spherical
 
 
 # todo: maybe make an OrbitOrthoControls for ortho cameras, instead of this zoom param?
 
 
+def get_screen_vectors_in_world_cords(center_world, canvas_size, camera):
+    """ Given a reference center location (in 3D world coordinates)
+    Get the vectors corresponding to the x and y direction in screen coordinates.
+    These vectors are scaled so that they can simply be multiplied with the
+    delta x and delta y.
+    """
+    center = Vector4(center_world.x, center_world.y, center_world.z, 1)
+    center.apply_matrix4(camera.matrix_world_inverse)
+    center.apply_matrix4(camera.projection_matrix)
+    pos1 = Vector4(100, 0, center.z / center.w, 1)
+    pos2 = Vector4(0, 100, center.z / center.w, 1)
+    for p in (pos1, pos2):
+        p.apply_matrix4(camera.projection_matrix_inverse)
+        p.apply_matrix4(camera.matrix_world)
+    pos1 = Vector3(pos1.x / pos1.w, pos1.y / pos1.w, pos1.z / pos1.w)
+    pos2 = Vector3(pos2.x / pos2.w, pos2.y / pos2.w, pos2.z / pos2.w)
+    pos1.multiply_scalar(0.02 / canvas_size[0])
+    pos2.multiply_scalar(0.02 / canvas_size[1])
+    return pos1, pos2  # now they're vecs, really
+
+
 class OrbitControls:
     _m = Matrix4()
-    _v = Vector3()
+    _v = Vector3()  # todo: euhm, this vector is shared between all instances? :P
     _origin = Vector3()
     _orbit_up = Vector3(0, 1, 0)
     _s = Spherical()
@@ -32,6 +55,10 @@ class OrbitControls:
         self.min_zoom = min_zoom
         self._initial_distance = self.distance
 
+        # State info used during a pan or rotate operation
+        self._pan_info = None
+        self._rotate_info = None
+
     def look_at(self, eye: Vector3, target: Vector3, up: Vector3) -> "OrbitControls":
         self.distance = eye.distance_to(target)
         self.target = target
@@ -41,12 +68,39 @@ class OrbitControls:
         self._up_quat_inv = self._up_quat.clone().inverse()
         return self
 
-    def pan(self, x: float, y: float) -> "OrbitControls":
-        self._v.set(x, -y, 0).apply_quaternion(self.rotation)
-        self.target.sub(self._v)
+    def pan(self, vec3: Vector3) -> "OrbitControls":
+        """ Pan in 3D world coordinates.
+        """
+        self.target.add(vec3)
         return self
 
+    def pan_start(
+        self, pos: Tuple[float, float], canvas_size: Tuple[float, float], camera
+    ):
+        """ Start a panning operation based (2D) screen coordinates.
+        """
+        vecx, vecy = get_screen_vectors_in_world_cords(self.target, canvas_size, camera)
+        self._pan_info = {"last": pos, "vecx": vecx, "vecy": vecy}
+
+    def pan_stop(self):
+        self._pan_info = None
+
+    def pan_move(self, pos: Tuple[float, float]):
+        """ Pan the center of rotation, based on a (2D) screen location. Call pan_start first.
+        """
+        if self._pan_info is None:
+            return
+        delta = tuple((pos[i] - self._pan_info["last"][i]) for i in range(2))
+        self.pan(self._pan_info["vecx"].clone().multiply_scalar(-delta[0]))
+        self.pan(self._pan_info["vecy"].clone().multiply_scalar(+delta[1]))
+        # todo: this should really be:
+        # controls.pan(self._drag["vecx"] * delta[0] + self._drag["vecy"] * delta[1])
+        self._pan_info["last"] = pos
+
     def rotate(self, theta: float, phi: float) -> "OrbitControls":
+        """ Rotate using angles (in radians). theta and phi are also known
+        as azimuth and elevation.
+        """
         # offset
         self._v.set(0, 0, self.distance).apply_quaternion(self.rotation)
         # to neutral up
@@ -68,10 +122,29 @@ class OrbitControls:
         )
         return self
 
+    def rotate_start(self, pos, canvas_size, camera):
+        """ Start a rotation operation based (2D) screen coordinates.
+        """
+        self._rotate_info = {"last": pos}
+
+    def rotate_stop(self):
+        self._rotate_info = None
+
+    def rotate_move(self, pos, speed=0.0175):
+        """ Rotate, based on a (2D) screen location. Call rotate_start first.
+        The speed is 1 degree per pixel by default.
+        """
+        if self._rotate_info is None:
+            return
+        delta = tuple((pos[i] - self._rotate_info["last"][i]) for i in range(2))
+        delta = tuple(delta[i] * speed for i in range(2))
+        self.rotate(*delta)
+        self._rotate_info["last"] = pos
+
     def zoom(self, multiplier: float) -> "OrbitControls":
         self.zoom_value = max(self.min_zoom, float(multiplier) * self.zoom_value)
         if self.zoom_changes_distance:
-            self.distance = self._initial_distance * self.zoom_value
+            self.distance = self._initial_distance / self.zoom_value
         return self
 
     def get_view(self) -> (Vector3, Vector3):

--- a/pygfx/controls/_panzoom.py
+++ b/pygfx/controls/_panzoom.py
@@ -1,6 +1,7 @@
 from typing import Tuple
 
 from ..linalg import Vector3, Matrix4, Quaternion, Spherical
+from ._orbit import get_screen_vectors_in_world_cords
 
 
 class PanZoomControls:
@@ -29,6 +30,9 @@ class PanZoomControls:
         self.zoom_value = zoom
         self.min_zoom = min_zoom
 
+        # State info used during a pan or rotate operation
+        self._pan_info = None
+
     def look_at(self, eye: Vector3, target: Vector3, up: Vector3) -> "PanZoomControls":
         self.distance = eye.distance_to(target)
         self.target = target
@@ -38,39 +42,53 @@ class PanZoomControls:
         self._up_quat_inv = self._up_quat.clone().inverse()
         return self
 
-    def pan(self, x: float, y: float) -> "PanZoomControls":
-        self._v.set(x, -y, 0).apply_quaternion(self.rotation)
-        self.target.sub(self._v)
+    def pan(self, vec3: Vector3) -> "PanZoomControls":
+        """ Pan in 3D world coordinates.
+        """
+        self.target.add(vec3)
         return self
+
+    def pan_start(
+        self, pos: Tuple[float, float], canvas_size: Tuple[float, float], camera
+    ):
+        # Using this function may be a bit overkill. We can also simply
+        # get the ortho cameras world_size (camera.visible_world_size).
+        # However, now the panzoom controls work with a perspecive camera ...
+        vecx, vecy = get_screen_vectors_in_world_cords(self.target, canvas_size, camera)
+        self._pan_info = {"last": pos, "vecx": vecx, "vecy": vecy}
+
+    def pan_stop(self):
+        self._pan_info = None
+
+    def pan_move(self, pos: Tuple[float, float]):
+        """ Pan the camera, based on a (2D) screen location. Call pan_start first.
+        """
+        if self._pan_info is None:
+            return
+        delta = tuple((pos[i] - self._pan_info["last"][i]) for i in range(2))
+        self.pan(self._pan_info["vecx"].clone().multiply_scalar(-delta[0]))
+        self.pan(self._pan_info["vecy"].clone().multiply_scalar(+delta[1]))
+        self._pan_info["last"] = pos
 
     def zoom(self, multiplier: float) -> "PanZoomControls":
         self.zoom_value = max(self.min_zoom, float(multiplier) * self.zoom_value)
         return self
 
     def zoom_to_point(
-        self,
-        delta: float,
-        mouse: Tuple[float, float],
-        canvas: Tuple[float, float],
-        view: Tuple[float, float],
+        self, multiplier: float, pos, canvas_size, camera,
     ) -> "PanZoomControls":
-        # convert current mouse position to fractions relative to widget center
-        # (fracpos x and y range becomes [-50%, 50%])
-        fracpos = tuple((mouse[i] - canvas[i] * 0.5) / canvas[i] for i in range(2))
-        # this gives us the relative position of the mouse in viewport space
-        relpos_old = tuple(fracpos[i] * view[i] for i in range(2))
-        # now apply the zoom delta
+
+        # Apply zoom
         zoom_old = self.zoom_value
-        self.zoom(delta)
-        # compute the new viewport dimensions
-        zoom_ratio = zoom_old / self.zoom_value
-        view_new = tuple(view[i] * zoom_ratio for i in range(2))
-        # and the new relative position of the mouse in viewport space
-        relpos = tuple(fracpos[i] * view_new[i] for i in range(2))
-        # finally compute the delta and pan accordingly to compensate
-        # such that the point under the mouse stays under the mouse
-        delta = tuple(relpos[i] - relpos_old[i] for i in range(2))
-        self.pan(*delta)
+        self.zoom(multiplier)
+        zoom_ratio = zoom_old / self.zoom_value  # usually == multiplier
+
+        # Now pan such that what was previously under the mouse is again under the mouse.
+        vecx, vecy = get_screen_vectors_in_world_cords(self.target, canvas_size, camera)
+        delta = tuple(pos[i] - canvas_size[i] / 2 for i in (0, 1))
+        delta1 = vecx.multiply_scalar(delta[0]).add(vecy.multiply_scalar(-delta[1]))
+        delta2 = delta1.clone().multiply_scalar(zoom_ratio)
+        self.pan(delta1.sub(delta2))
         return self
 
     def get_view(self) -> (Vector3, Vector3, float):

--- a/pygfx/controls/_panzoom.py
+++ b/pygfx/controls/_panzoom.py
@@ -1,16 +1,10 @@
 from typing import Tuple
 
-from ..linalg import Vector3, Matrix4, Quaternion, Spherical
+from ..linalg import Vector3, Matrix4, Quaternion
 from ._orbit import get_screen_vectors_in_world_cords
 
 
 class PanZoomControls:
-    _m = Matrix4()
-    _v = Vector3()
-    _origin = Vector3()
-    _orbit_up = Vector3(0, 1, 0)
-    _s = Spherical()
-
     def __init__(
         self,
         eye: Vector3 = None,
@@ -26,20 +20,24 @@ class PanZoomControls:
             target = Vector3()
         if up is None:
             up = Vector3(0.0, 1.0, 0.0)
-        self.look_at(eye, target, up)
         self.zoom_value = zoom
         self.min_zoom = min_zoom
 
         # State info used during a pan or rotate operation
         self._pan_info = None
 
+        # Temp objects (to avoid garbage collection)
+        self._m = Matrix4()
+        self._v = Vector3()
+
+        # Initialize orientation
+        self.look_at(eye, target, up)
+
     def look_at(self, eye: Vector3, target: Vector3, up: Vector3) -> "PanZoomControls":
         self.distance = eye.distance_to(target)
         self.target = target
         self.up = up
         self.rotation.set_from_rotation_matrix(self._m.look_at(eye, target, up))
-        self._up_quat = Quaternion().set_from_unit_vectors(self.up, self._orbit_up)
-        self._up_quat_inv = self._up_quat.clone().inverse()
         return self
 
     def pan(self, vec3: Vector3) -> "PanZoomControls":
@@ -49,33 +47,47 @@ class PanZoomControls:
         return self
 
     def pan_start(
-        self, pos: Tuple[float, float], canvas_size: Tuple[float, float], camera
-    ):
+        self,
+        pos: Tuple[float, float],
+        canvas_size: Tuple[float, float],
+        camera: "Camera",
+    ) -> "PanZoomControls":
         # Using this function may be a bit overkill. We can also simply
         # get the ortho cameras world_size (camera.visible_world_size).
         # However, now the panzoom controls work with a perspecive camera ...
         vecx, vecy = get_screen_vectors_in_world_cords(self.target, canvas_size, camera)
         self._pan_info = {"last": pos, "vecx": vecx, "vecy": vecy}
+        return self
 
-    def pan_stop(self):
+    def pan_stop(self) -> "PanZoomControls":
         self._pan_info = None
+        return self
 
-    def pan_move(self, pos: Tuple[float, float]):
+    def pan_move(self, pos: Tuple[float, float]) -> "PanZoomControls":
         """ Pan the camera, based on a (2D) screen location. Call pan_start first.
         """
         if self._pan_info is None:
             return
         delta = tuple((pos[i] - self._pan_info["last"][i]) for i in range(2))
-        self.pan(self._pan_info["vecx"].clone().multiply_scalar(-delta[0]))
-        self.pan(self._pan_info["vecy"].clone().multiply_scalar(+delta[1]))
+        self.pan(
+            self._pan_info["vecx"]
+            .clone()
+            .multiply_scalar(-delta[0])
+            .add_scaled_vector(self._pan_info["vecy"], +delta[1])
+        )
         self._pan_info["last"] = pos
+        return self
 
     def zoom(self, multiplier: float) -> "PanZoomControls":
         self.zoom_value = max(self.min_zoom, float(multiplier) * self.zoom_value)
         return self
 
     def zoom_to_point(
-        self, multiplier: float, pos, canvas_size, camera,
+        self,
+        multiplier: float,
+        pos: Tuple[float, float],
+        canvas_size: Tuple[float, float],
+        camera: "Camera",
     ) -> "PanZoomControls":
 
         # Apply zoom
@@ -91,7 +103,7 @@ class PanZoomControls:
         self.pan(delta1.sub(delta2))
         return self
 
-    def get_view(self) -> (Vector3, Vector3, float):
+    def get_view(self) -> Tuple[Vector3, Vector3, float]:
         self._v.set(0, 0, self.distance).apply_quaternion(self.rotation).add(
             self.target
         )


### PR DESCRIPTION
* the control classes get more convenience api that is targeted at mouse stuff, but gui independent.
* the panning logic makes sure that the object under the mouse stays under the mouse.
* the gui proxy classes in the examples became a bit smaller.