### PR TITLE
WIP: Text overlay with Qt

### DIFF
--- a/examples/text_with_qt.py
+++ b/examples/text_with_qt.py
@@ -1,0 +1,159 @@
+import numpy as np
+import pygfx as gfx
+
+from PyQt5 import QtWidgets, QtCore, QtGui
+from wgpu.gui.qt import WgpuCanvas
+
+
+class Overlay(QtWidgets.QWidget):
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args, **kwargs,
+        )
+        # We want a tranlucent background, no window frame, and always on top
+        # of the parent widget.
+        self.setAttribute(QtCore.Qt.WA_TranslucentBackground, True)
+        self.setWindowFlags(QtCore.Qt.FramelessWindowHint | QtCore.Qt.Tool)
+        # No background
+        self.setAutoFillBackground(False)
+        # self.setAttribute(QtCore.Qt.WA_PaintOnScreen, True)
+
+    def paintEvent(self, event):
+
+        painter = QtGui.QPainter()
+        if not painter.begin(self):
+            return
+
+        features = None
+        for label in self.parent().text_labels:
+            if features != (label.size, label.color):
+                features = label.size, label.color
+                painter.setFont(QtGui.QFont("Arial", label.size))
+                painter.setPen(QtGui.QColor(label.color))
+            x, y = label.ppos
+            painter.drawText(QtCore.QPointF(x, y), label.text)
+
+        painter.end()
+
+
+class TextCanvas(WgpuCanvas):
+
+    overlay = None
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.text_labels = []
+
+        self.overlay = Overlay(self)
+        self.overlay.setGeometry(self.geometry())
+        self.overlay.show()
+        self.overlay.raise_()
+
+    def resizeEvent(self, event):
+        super().resizeEvent(event)
+        if self.overlay:
+            self.overlay.setGeometry(self.geometry())
+
+    def moveEvent(self, event):
+        super().moveEvent(event)
+        if self.overlay:
+            self.overlay.setGeometry(self.geometry())
+
+
+import wgpu
+from pygfx.renderers import Renderer
+
+
+class TextLabel(gfx.WorldObject):
+    def __init__(self, text, size=12, color="f000000", position=(0, 0, 0)):
+        super().__init__()
+        self.text = str(text)
+        self.size = int(size)
+        self.color = color
+        self.position = gfx.linalg.Vector3(*position)
+
+
+class QtTextRenderer(Renderer):
+    def __init__(self, canvas):
+        self._canvas = canvas
+
+        # todo: allow passing a normal qt canvas?
+        # assert isinstance(canvas, wgpu.gui.qt.QtWgpuCanvas)
+        assert isinstance(canvas, TextCanvas)
+
+    def render(self, scene: gfx.WorldObject, camera: gfx.Camera):
+        """ Main render method, called from the canvas.
+        """
+
+        # Ensure that matrices are up-to-date
+        # Or not: assume that this is done by the wgpu renderer
+        if False:
+            scene.update_matrix_world()
+            camera.set_viewport_size(*logical_size)
+            camera.update_matrix_world()  # camera may not be a member of the scene
+            camera.update_projection_matrix()
+
+        # Get the sorted list of objects to render
+        def visit(wobject):
+            if wobject.visible and isinstance(wobject, TextLabel):
+                q.append(wobject)
+
+        q = []
+        scene.traverse(visit)
+
+        gfx.linalg.Vector4()
+        m = gfx.linalg.Matrix4()
+        mul = m.multiply_matrices
+        # proj = mul(camera.projection_matrix, camera.matrix_world_inverse)
+        logical_size = self._canvas.get_logical_size()
+
+        self._canvas.text_labels = q
+        self._canvas.overlay.update()
+        for wobject in q:
+            # m = gfx.linalg.Matrix4().multiply_matrices(proj, wobject.matrix_world)
+            pos = gfx.linalg.Vector4(
+                wobject.position.x, wobject.position.y, wobject.position.z, 1
+            )
+            pos = pos.apply_matrix4(wobject.matrix_world)
+            pos = pos.apply_matrix4(camera.matrix_world_inverse)
+            pos = pos.apply_matrix4(camera.projection_matrix)
+
+            pos_pix = (
+                (pos.x + 1) * logical_size[0] / 2,
+                (pos.y + 1) * logical_size[1] / 2,
+            )
+            wobject.ppos = pos_pix
+            # print(pos_pix)
+
+
+app = QtWidgets.QApplication([])
+
+canvas = TextCanvas()
+renderer = gfx.WgpuRenderer(canvas)
+text_renderer = QtTextRenderer(canvas)
+
+scene = gfx.Scene()
+
+positions = np.random.normal(0, 0.5, (20, 2)).astype(np.float32)
+geometry = gfx.Geometry(positions=positions)
+
+material = gfx.PointsMaterial(size=10, color=(0, 1, 0.5, 0.7))
+points = gfx.Points(geometry, material)
+scene.add(points)
+for point in positions:
+    scene.add(TextLabel(f"{point}", position=point, color="#ffffff"))
+
+scene.add(gfx.Background(gfx.BackgroundMaterial((0.04, 0.0, 0, 1), (0, 0.0, 0.04, 1))))
+
+camera = gfx.NDCCamera()
+
+
+def aninmate():
+    renderer.render(scene, camera)
+    text_renderer.render(scene, camera)
+
+
+if __name__ == "__main__":
+    canvas.request_draw(aninmate)
+    app.exec_()

--- a/examples/text_with_qt.py
+++ b/examples/text_with_qt.py
@@ -5,45 +5,19 @@ from PyQt5 import QtWidgets, QtCore, QtGui
 from wgpu.gui.qt import WgpuCanvas
 
 
-class Overlay(QtWidgets.QWidget):
-    def __init__(self, *args, **kwargs):
-        super().__init__(
-            *args, **kwargs,
-        )
-        # We want a tranlucent background, no window frame, and always on top
-        # of the parent widget.
-        self.setAttribute(QtCore.Qt.WA_TranslucentBackground, True)
-        self.setWindowFlags(QtCore.Qt.FramelessWindowHint | QtCore.Qt.Tool)
-        # No background
-        self.setAutoFillBackground(False)
-        # self.setAttribute(QtCore.Qt.WA_PaintOnScreen, True)
-
-    def paintEvent(self, event):
-
-        painter = QtGui.QPainter()
-        if not painter.begin(self):
-            return
-
-        features = None
-        for label in self.parent().text_labels:
-            if features != (label.size, label.color):
-                features = label.size, label.color
-                painter.setFont(QtGui.QFont("Arial", label.size))
-                painter.setPen(QtGui.QColor(label.color))
-            x, y = label.ppos
-            painter.drawText(QtCore.QPointF(x, y), label.text)
-
-        painter.end()
+# %% Qt logic
 
 
-class TextCanvas(WgpuCanvas):
+class CanvasWithOverlay(WgpuCanvas):
+    """ A Qt canvas with support for 2D overlay.
+    """
 
     overlay = None
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.text_labels = []
+        self._text_labels = []
 
         self.overlay = Overlay(self)
         self.overlay.setGeometry(self.geometry())
@@ -60,98 +34,153 @@ class TextCanvas(WgpuCanvas):
         if self.overlay:
             self.overlay.setGeometry(self.geometry())
 
+    def set_text_labels(self, wobjects):
+        """ Set text labels to overlay. Must be a list of TextOverlay objects.
+        """
+        self._text_labels = wobjects
 
-import wgpu
+
+class Overlay(QtWidgets.QWidget):
+    """ Overlay that draws 2D featues using the canvas API.
+
+    We cannot draw in the wgpu widget directly, because that widget has
+    no paint engine (we have to remove it to prevent Qt from overwriting
+    the screen that we draw with wgpu). We can also not use a normal
+    widget overlaid over it, because Qt would then do the compositing,
+    but the wgpu widget draws directly to screen, so the overlay widget
+    would get a black background. Therefore, the overlay widget is a
+    toplevel widget (a window) that we keep exactly on top of the actual
+    widget. Not pretty, but it seems to work. I am not sure how well
+    this holds up on other platforms.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(
+            *args, **kwargs,
+        )
+        # We want a tranlucent background, and no window frame.
+        # Setting the Tool flag make it always on top of the parent widget.
+        self.setAttribute(QtCore.Qt.WA_TranslucentBackground, True)
+        self.setWindowFlags(QtCore.Qt.FramelessWindowHint | QtCore.Qt.Tool)
+        # No background, just in case.
+        self.setAutoFillBackground(False)
+
+    def paintEvent(self, event):
+
+        painter = QtGui.QPainter()
+        if not painter.begin(self):
+            return
+
+        # Draw text labels
+        text_labels = self.parent()._text_labels
+        features = None
+        for label in text_labels:
+            if features != (label.size, label.color):
+                features = label.size, label.color
+                painter.setFont(QtGui.QFont("Arial", label.size))
+                painter.setPen(QtGui.QColor(label.color))
+            painter.drawText(QtCore.QPointF(*label.ppos), label.text)
+
+        painter.end()
+
+
+# %% wgpu world object and renderer
+
 from pygfx.renderers import Renderer
 
 
-class TextLabel(gfx.WorldObject):
+class TextOverlay(gfx.WorldObject):
+    """ A text label that can get overlaid on the visualization using e.q. Qt.
+    """
+
     def __init__(self, text, size=12, color="f000000", position=(0, 0, 0)):
         super().__init__()
         self.text = str(text)
         self.size = int(size)
         self.color = color
         self.position = gfx.linalg.Vector3(*position)
+        # Other options: font, bold, background, pixel-offset, alignment
 
 
-class QtTextRenderer(Renderer):
+class QtOverlayRenderer(Renderer):
+    """ A special renderer that can draw certain 2D overlays over a Qt canvas.
+    Currently only text (TextOverlay objects).
+    """
+
     def __init__(self, canvas):
         self._canvas = canvas
 
         # todo: allow passing a normal qt canvas?
         # assert isinstance(canvas, wgpu.gui.qt.QtWgpuCanvas)
-        assert isinstance(canvas, TextCanvas)
+        assert isinstance(canvas, CanvasWithOverlay)
 
     def render(self, scene: gfx.WorldObject, camera: gfx.Camera):
         """ Main render method, called from the canvas.
         """
 
-        # Ensure that matrices are up-to-date
-        # Or not: assume that this is done by the wgpu renderer
-        if False:
-            scene.update_matrix_world()
-            camera.set_viewport_size(*logical_size)
-            camera.update_matrix_world()  # camera may not be a member of the scene
-            camera.update_projection_matrix()
+        logical_size = self._canvas.get_logical_size()
 
-        # Get the sorted list of objects to render
+        # We assume that this call is preceded by a call to the wgpu renderer,
+        # so we don't need to apply any updates.
+        # scene.update_matrix_world()
+        # camera.set_viewport_size(*logical_size)
+        # camera.update_matrix_world()
+        # camera.update_projection_matrix()
+
+        # Get the list of objects to render
         def visit(wobject):
-            if wobject.visible and isinstance(wobject, TextLabel):
+            if wobject.visible and isinstance(wobject, TextOverlay):
                 q.append(wobject)
 
         q = []
         scene.traverse(visit)
 
-        gfx.linalg.Vector4()
-        m = gfx.linalg.Matrix4()
-        mul = m.multiply_matrices
-        # proj = mul(camera.projection_matrix, camera.matrix_world_inverse)
-        logical_size = self._canvas.get_logical_size()
-
-        self._canvas.text_labels = q
-        self._canvas.overlay.update()
+        # Set the pixel position of each text overlay object
         for wobject in q:
-            # m = gfx.linalg.Matrix4().multiply_matrices(proj, wobject.matrix_world)
-            pos = gfx.linalg.Vector4(
-                wobject.position.x, wobject.position.y, wobject.position.z, 1
-            )
-            pos = pos.apply_matrix4(wobject.matrix_world)
-            pos = pos.apply_matrix4(camera.matrix_world_inverse)
-            pos = pos.apply_matrix4(camera.projection_matrix)
-
+            pos = wobject.position.clone()
+            pos = pos.apply_matrix4(wobject.matrix_world).project(camera)
+            # I don't understand this 0.25 value. I would expect it to be 0.5
+            # but for some reason it needs to be 0.25.
             pos_pix = (
-                (pos.x + 1) * logical_size[0] / 2,
-                (pos.y + 1) * logical_size[1] / 2,
+                (+pos.x * 0.25 + 0.5) * logical_size[0],
+                (-pos.y * 0.25 + 0.5) * logical_size[1],
             )
             wobject.ppos = pos_pix
-            # print(pos_pix)
+
+        # Store the labels for the overlay, and schedule a draw.
+        self._canvas.set_text_labels(q)
+        self._canvas.overlay.update()
 
 
 app = QtWidgets.QApplication([])
 
-canvas = TextCanvas()
+canvas = CanvasWithOverlay()
 renderer = gfx.WgpuRenderer(canvas)
-text_renderer = QtTextRenderer(canvas)
+overlay_renderer = QtOverlayRenderer(canvas)
 
 scene = gfx.Scene()
 
-positions = np.random.normal(0, 0.5, (20, 2)).astype(np.float32)
+positions = np.random.normal(0, 1, (20, 2)).astype(np.float32)
 geometry = gfx.Geometry(positions=positions)
 
 material = gfx.PointsMaterial(size=10, color=(0, 1, 0.5, 0.7))
 points = gfx.Points(geometry, material)
 scene.add(points)
 for point in positions:
-    scene.add(TextLabel(f"{point}", position=point, color="#ffffff"))
+    scene.add(
+        TextOverlay(
+            f"{point[0]:0.1f}, {point[1]:0.1f}", position=point, color="#ffffff"
+        )
+    )
 
 scene.add(gfx.Background(gfx.BackgroundMaterial((0.04, 0.0, 0, 1), (0, 0.0, 0.04, 1))))
 
-camera = gfx.NDCCamera()
+camera = gfx.OrthographicCamera(3, 3)
 
 
 def aninmate():
     renderer.render(scene, camera)
-    text_renderer.render(scene, camera)
+    overlay_renderer.render(scene, camera)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adds text overlay using Qt. Some observations during investigating the way to do this in Qt:

* Remember: The `QtWgpuCanvas` is a normal widget, which wraps a subwidget to which wgpu does the actual drawing. That subwidget has flags to disable any Qt drawing, because wgpu will draw directly to screen (in the rectangle occupied by the widget).
* We cannot draw in the subwidget directly, because that widget has no paint engine (we have to remove it to prevent Qt from overwriting the screen that we draw with wgpu).
* We cannot draw the overlay in the main widget, because it is fully occupied by te subwidget. If we even could, it would not work because see next point.
* We can not use a normal widget overlaid over the main widget or subwidget, because Qt would then do the compositing, but since the wgpu widget draws directly to screen, the overlay widget gets a black background, hiding whatever we drew with wgpu. In other words, we cannot do transparency.

What *does* work (at least on Windows, and probably on other platforms too, but we should probably test this) is to draw the overlay in a second toplevel widget. Then we can use the OS level compositing and alpha blending. If we make the window frameless and keep it on top of the original widget, the user won't even notice there is a second window. The `Qt.Tool` window flag also helps here.

Todo:
* [x] Test whether this works well enough on Linux (tested on Ubuntu 20.04).
* [ ] Test whether this works well enough on MacOS.
* [ ] See if and how to integrate this in pygfx.
