### PR TITLE
Refactoring the wgpu renderer internals and how it deals with updates

### DIFF
--- a/examples/collection_line.py
+++ b/examples/collection_line.py
@@ -1,0 +1,88 @@
+"""
+Display multiple lines in a collection for performance.
+"""
+
+import time  # noqa
+import numpy as np
+
+import pygfx as gfx
+
+from PyQt5 import QtWidgets, QtCore
+from wgpu.gui.qt import WgpuCanvas
+
+app = QtWidgets.QApplication([])
+
+
+class WgpuCanvasWithInputEvents(WgpuCanvas):
+    _drag_modes = {QtCore.Qt.RightButton: "pan"}
+    _mode = None
+
+    def wheelEvent(self, event):  # noqa: N802
+        zoom_multiplier = 2 ** (event.angleDelta().y() * 0.0015)
+        controls.zoom_to_point(
+            zoom_multiplier, (event.x(), event.y()), self.get_logical_size(), camera
+        )
+        self.request_draw()
+
+    def mousePressEvent(self, event):  # noqa: N802
+        mode = self._drag_modes.get(event.button(), None)
+        if self._mode or not mode:
+            return
+        self._mode = mode
+        controls.pan_start((event.x(), event.y()), self.get_logical_size(), camera)
+        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
+
+    def mouseReleaseEvent(self, event):  # noqa: N802
+        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
+            self._mode = None
+            controls.pan_stop()
+            app.restoreOverrideCursor()
+
+    def mouseMoveEvent(self, event):  # noqa: N802
+        if self._mode is not None:
+            controls.pan_move((event.x(), event.y()))
+        self.request_draw()
+
+
+canvas = WgpuCanvasWithInputEvents()
+renderer = gfx.WgpuRenderer(canvas)
+
+scene = gfx.Scene()
+
+nvertices = 1000
+rows = 50
+cols = 20
+
+print(nvertices * rows * cols, "vertices in total")
+
+x = np.linspace(0.05, 0.95, nvertices, dtype=np.float32)
+
+for row in range(rows):
+    for col in range(cols):
+        y = np.sin(x * 25) * 0.45 + np.random.normal(0, 0.02, len(x)).astype(np.float32)
+        positions = np.column_stack([x, y, np.zeros_like(x), np.ones_like(x)])
+        geometry = gfx.Geometry(positions=positions)
+        material = gfx.LineMaterial(
+            thickness=0.2 + 2 * row / rows, color=(col / cols, row / rows, 0.5, 1.0)
+        )
+        line = gfx.Line(geometry, material)
+        line.position.x = col
+        line.position.y = row
+        scene.add(line)
+
+camera = gfx.OrthographicCamera(cols, rows)
+camera.maintain_aspect = False
+controls = gfx.PanZoomControls(camera.position.clone())
+controls.pan(gfx.linalg.Vector3(cols / 2, rows / 2, 0))
+
+
+def animate():
+    controls.update_camera(camera)
+    t0 = time.perf_counter()  # noqa
+    renderer.render(scene, camera)
+    # print(time.perf_counter() - t0)
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec_()

--- a/examples/collection_line.py
+++ b/examples/collection_line.py
@@ -1,5 +1,6 @@
 """
-Display multiple lines in a collection for performance.
+Display a lot of line objects. Because of the architecture of wgpu,
+this is still performant.
 """
 
 import time  # noqa

--- a/examples/instancing_mesh.py
+++ b/examples/instancing_mesh.py
@@ -1,0 +1,53 @@
+"""
+Example rendering the same mesh object multiple times, using instancing.
+"""
+
+import numpy as np
+import imageio
+import pygfx as gfx
+
+from PyQt5 import QtWidgets
+from wgpu.gui.qt import WgpuCanvas
+
+
+app = QtWidgets.QApplication([])
+
+canvas = WgpuCanvas()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+im = imageio.imread("imageio:bricks.jpg").astype(np.float32) / 255
+im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
+tex = gfx.Texture(im, dim=2, usage="sampled").get_view(
+    filter="linear", address_mode="repeat"
+)
+
+geometry = gfx.TorusKnotGeometry(1, 0.3, 128, 32)
+geometry.texcoords.data[:, 0] *= 10  # stretch the texture
+material = gfx.MeshPhongMaterial(map=tex, clim=(0.2, 0.8))
+obj = gfx.InstancedMesh(geometry, material, 100)
+scene.add(obj)
+
+
+# Set matrices. Note that these are sub-transforms of the mesh's own matrix.
+for y in range(10):
+    for x in range(10):
+        m = gfx.linalg.Matrix4().set_position_xyz(y * 2, x * 2, 0)
+        obj.set_matrix_at(x + y * 10, m.elements)
+
+
+camera = gfx.PerspectiveCamera(70, 1)
+camera.position.set(9, 9, 15)
+
+
+def animate():
+    rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.00071, 0.001))
+    obj.rotation.multiply(rot)
+
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec_()

--- a/pygfx/cameras/_orthographic.py
+++ b/pygfx/cameras/_orthographic.py
@@ -25,7 +25,7 @@ class OrthographicCamera(Camera):
         self.far = float(far)
         assert self.near < self.far
         self.zoom = 1
-        self._maintain_aspect = True
+        self.maintain_aspect = True
         self.set_viewport_size(1, 1)
         self.update_projection_matrix()
 
@@ -41,7 +41,9 @@ class OrthographicCamera(Camera):
         height = self.height / self.zoom
         # Increase either the width or height, depending on the viewport shape
         aspect = width / height
-        if aspect < self._view_aspect:
+        if not self.maintain_aspect:
+            pass
+        elif aspect < self._view_aspect:
             width *= self._view_aspect / aspect
         else:
             height *= aspect / self._view_aspect

--- a/pygfx/objects/__init__.py
+++ b/pygfx/objects/__init__.py
@@ -5,4 +5,4 @@ from ._group import Group
 from ._scene import Scene, Background
 from ._points import Points
 from ._line import Line
-from ._mesh import Mesh
+from ._mesh import Mesh, InstancedMesh

--- a/pygfx/objects/_mesh.py
+++ b/pygfx/objects/_mesh.py
@@ -1,4 +1,7 @@
+import numpy as np
+
 from ._base import WorldObject
+from ..datawrappers import Buffer
 
 
 class Mesh(WorldObject):
@@ -6,3 +9,18 @@ class Mesh(WorldObject):
         super().__init__()
         self.geometry = geometry
         self.material = material
+
+
+class InstancedMesh(Mesh):
+    def __init__(self, geometry, material, count):
+        super().__init__(geometry, material)
+        count = int(count)
+        # Create count eye matrices
+        matrices = np.zeros((count, 4, 4), np.float32)
+        for i in range(4):
+            matrices[:, i, i] = 1
+        self.matrices = Buffer(matrices, usage="STORAGE", nitems=count)
+
+    def set_matrix_at(self, index: int, matrix):
+        matrix = np.array(matrix).reshape(4, 4)
+        self.matrices.data[index] = matrix

--- a/pygfx/renderers/wgpu/__init__.py
+++ b/pygfx/renderers/wgpu/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 
-from ._wgpurenderer import stdinfo_uniform_type, WgpuRenderer
-from ._wgpurenderer import registry, register_wgpu_render_function
+from ._wgpurenderer import stdinfo_uniform_type, wobject_uniform_type
+from ._wgpurenderer import WgpuRenderer, registry, register_wgpu_render_function
 from . import meshrender
 from . import pointsrender
 from . import linerender

--- a/pygfx/renderers/wgpu/backgroundrender.py
+++ b/pygfx/renderers/wgpu/backgroundrender.py
@@ -3,7 +3,7 @@ import pyshader
 from pyshader import python2shader
 from pyshader import vec3, vec4
 
-from . import register_wgpu_render_function, stdinfo_uniform_type
+from . import register_wgpu_render_function, stdinfo_uniform_type, wobject_uniform_type
 from ...objects import Background
 from ...materials import BackgroundMaterial, BackgroundImageMaterial
 from ...datawrappers import Texture, TextureView
@@ -14,7 +14,6 @@ def vertex_shader_simple(
     index: (pyshader.RES_INPUT, "VertexId", "i32"),
     out_pos: (pyshader.RES_OUTPUT, "Position", vec4),
     v_texcoord: (pyshader.RES_OUTPUT, 0, vec3),
-    u_stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
 ):
     # Define positions at the four corners of the viewport, at the largest depth
     positions = [
@@ -33,7 +32,7 @@ def vertex_shader_simple(
 @python2shader
 def fragment_shader_gradient(
     v_texcoord: (pyshader.RES_INPUT, 0, vec3),
-    u_background: (pyshader.RES_UNIFORM, (0, 1), BackgroundMaterial.uniform_type),
+    u_background: (pyshader.RES_UNIFORM, (0, 2), BackgroundMaterial.uniform_type),
     out_color: (pyshader.RES_OUTPUT, 0, vec4),
 ):
     f = v_texcoord.xy
@@ -52,6 +51,7 @@ def vertex_shader_skybox(
     out_pos: (pyshader.RES_OUTPUT, "Position", vec4),
     v_texcoord: (pyshader.RES_OUTPUT, 0, vec3),
     u_stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
+    u_wobject: (pyshader.RES_UNIFORM, (0, 1), wobject_uniform_type),
 ):
     # Define positions at the four corners of the viewport, at the largest depth
     positions = [
@@ -67,7 +67,7 @@ def vertex_shader_skybox(
     inv_proj = matrix_inverse(
         u_stdinfo.projection_transform
         * u_stdinfo.cam_transform
-        * u_stdinfo.world_transform
+        * u_wobject.world_transform
     )
     wpos1 = inv_proj * ndc_pos1
     wpos2 = inv_proj * ndc_pos2
@@ -81,8 +81,8 @@ def vertex_shader_skybox(
 @python2shader
 def fragment_shader_tex_rgba(
     v_texcoord: (pyshader.RES_INPUT, 0, vec3),
-    s_sam: (pyshader.RES_SAMPLER, (0, 2), ""),
-    t_tex: (pyshader.RES_TEXTURE, (0, 3), "undecided"),
+    s_sam: (pyshader.RES_SAMPLER, (1, 0), ""),
+    t_tex: (pyshader.RES_TEXTURE, (1, 1), "undecided"),
     out_color: (pyshader.RES_OUTPUT, 0, vec4),
 ):
     color = vec4(t_tex.sample(s_sam, v_texcoord.xyz))
@@ -92,8 +92,8 @@ def fragment_shader_tex_rgba(
 @python2shader
 def fragment_shader_tex_gray(
     v_texcoord: (pyshader.RES_INPUT, 0, vec3),
-    s_sam: (pyshader.RES_SAMPLER, (0, 2), ""),
-    t_tex: (pyshader.RES_TEXTURE, (0, 3), "undecided"),
+    s_sam: (pyshader.RES_SAMPLER, (1, 0), ""),
+    t_tex: (pyshader.RES_TEXTURE, (1, 1), "undecided"),
     out_color: (pyshader.RES_OUTPUT, 0, vec4),
 ):
     color = vec4(t_tex.sample(s_sam, v_texcoord.xyz))
@@ -107,17 +107,19 @@ def background_renderer(wobject, render_info):
     vertex_shader = vertex_shader_simple
     fragment_shader = fragment_shader_tex_rgba
     bindings0 = {
-        0: (wgpu.BindingType.uniform_buffer, render_info.stdinfo),
-        1: (wgpu.BindingType.uniform_buffer, material.uniform_buffer),
+        0: (wgpu.BindingType.uniform_buffer, render_info.stdinfo_uniform),
+        1: (wgpu.BindingType.uniform_buffer, render_info.wobject_uniform),
+        2: (wgpu.BindingType.uniform_buffer, material.uniform_buffer),
     }
+    bindings1 = {}
 
     if isinstance(material, BackgroundImageMaterial) and material.map is not None:
         if isinstance(material.map, Texture):
             raise TypeError("material.map is a Texture, but must be a TextureView")
         elif not isinstance(material.map, TextureView):
             raise TypeError("material.map must be a TextureView")
-        bindings0[2] = wgpu.BindingType.sampler, material.map
-        bindings0[3] = wgpu.BindingType.sampled_texture, material.map
+        bindings1[0] = wgpu.BindingType.sampler, material.map
+        bindings1[1] = wgpu.BindingType.sampled_texture, material.map
         # Select shader
         if material.map.view_dim == "cube":
             vertex_shader = vertex_shader_skybox
@@ -156,5 +158,6 @@ def background_renderer(wobject, render_info):
             "primitive_topology": wgpu.PrimitiveTopology.triangle_strip,
             "indices": 4,
             "bindings0": bindings0,
+            "bindings1": bindings1,
         }
     ]

--- a/pygfx/renderers/wgpu/linerender.py
+++ b/pygfx/renderers/wgpu/linerender.py
@@ -2,7 +2,7 @@ import wgpu  # only for flags/enums
 import pyshader
 from pyshader import f32, vec2, vec4, Array
 
-from . import register_wgpu_render_function, stdinfo_uniform_type
+from . import register_wgpu_render_function, stdinfo_uniform_type, wobject_uniform_type
 from ...objects import Line
 from ...materials import (
     LineMaterial,
@@ -46,10 +46,10 @@ def compute_shader(
     index: (pyshader.RES_INPUT, "GlobalInvocationId", "i32"),
     pos1: (pyshader.RES_BUFFER, (0, 0), Array(vec4)),
     pos2: (pyshader.RES_BUFFER, (0, 1), Array(vec4)),
-    material: (pyshader.RES_UNIFORM, (0, 2), LineMaterial.uniform_type),
+    u_material: (pyshader.RES_UNIFORM, (0, 2), LineMaterial.uniform_type),
 ):
     p = pos1[index] * 1.0
-    dz = material.thickness
+    dz = u_material.thickness
     pos2[index * 2 + 0] = vec4(p.x, p.y + dz, p.z, 1.0)
     pos2[index * 2 + 1] = vec4(p.x, p.y - dz, p.z, 1.0)
 
@@ -57,28 +57,30 @@ def compute_shader(
 @pyshader.python2shader
 def vertex_shader_thin(
     in_pos: (pyshader.RES_INPUT, 0, vec4),
-    stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
+    u_stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
+    u_wobject: (pyshader.RES_UNIFORM, (0, 1), wobject_uniform_type),
     out_pos: (pyshader.RES_OUTPUT, "Position", vec4),
 ):
-    wpos = stdinfo.world_transform * vec4(in_pos.xyz, 1.0)
-    npos = stdinfo.projection_transform * stdinfo.cam_transform * wpos
+    wpos = u_wobject.world_transform * vec4(in_pos.xyz, 1.0)
+    npos = u_stdinfo.projection_transform * u_stdinfo.cam_transform * wpos
     out_pos = npos  # noqa
 
 
 @pyshader.python2shader
 def fragment_shader_thin(
-    material: (pyshader.RES_UNIFORM, (0, 1), LineMaterial.uniform_type),
+    u_material: (pyshader.RES_UNIFORM, (0, 2), LineMaterial.uniform_type),
     out_color: (pyshader.RES_OUTPUT, 0, vec4),
 ):
-    out_color = material.color  # noqa - shader assign
+    out_color = u_material.color  # noqa - shader assign
 
 
 @pyshader.python2shader
 def vertex_shader(
     index: (pyshader.RES_INPUT, "VertexId", "i32"),
-    buf_pos: (pyshader.RES_BUFFER, (0, 2), Array(vec4)),
-    stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
-    material: (pyshader.RES_UNIFORM, (0, 1), LineMaterial.uniform_type),
+    u_stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
+    u_wobject: (pyshader.RES_UNIFORM, (0, 1), wobject_uniform_type),
+    u_material: (pyshader.RES_UNIFORM, (0, 2), LineMaterial.uniform_type),
+    buf_pos: (pyshader.RES_BUFFER, (1, 0), Array(vec4)),
     out_pos: (pyshader.RES_OUTPUT, "Position", vec4),
     v_line_width_p: (pyshader.RES_OUTPUT, 0, f32),
     v_vec_from_node_p: (pyshader.RES_OUTPUT, 1, vec2),
@@ -126,9 +128,9 @@ def vertex_shader(
     # - we can prepare the nodes' screen coordinates in a compute shader.
 
     # Prepare some numbers
-    screen_factor = stdinfo.logical_size.xy / 2.0
-    l2p = stdinfo.physical_size.x / stdinfo.logical_size.x
-    half_line_width = material.thickness * 0.5  # in logical pixels
+    screen_factor = u_stdinfo.logical_size.xy / 2.0
+    l2p = u_stdinfo.physical_size.x / u_stdinfo.logical_size.x
+    half_line_width = u_material.thickness * 0.5  # in logical pixels
 
     # What i in the node list (point on the line) is this?
     i = index // 5
@@ -137,12 +139,12 @@ def vertex_shader(
     pos1, pos2, pos3 = buf_pos[i - 1], buf_pos[i], buf_pos[i + 1]
     # pos1, pos2, pos3 = vec4(pos1, 1.0), vec4(buf_pos[i], 1.0), vec4(buf_pos[i + 1], 1.0)
     # pos1, pos2, pos3 = vec4(pos1.x, pos1.y, 0.0, 1.0), vec4(pos2.x, pos2.y, 0.0, 1.0), vec4(pos3.x, pos3.y, 0.0 , 1.0)
-    wpos1 = stdinfo.world_transform * vec4(pos1.xyz, 1.0)
-    wpos2 = stdinfo.world_transform * vec4(pos2.xyz, 1.0)
-    wpos3 = stdinfo.world_transform * vec4(pos3.xyz, 1.0)
-    npos1 = stdinfo.projection_transform * stdinfo.cam_transform * wpos1
-    npos2 = stdinfo.projection_transform * stdinfo.cam_transform * wpos2
-    npos3 = stdinfo.projection_transform * stdinfo.cam_transform * wpos3
+    wpos1 = u_wobject.world_transform * vec4(pos1.xyz, 1.0)
+    wpos2 = u_wobject.world_transform * vec4(pos2.xyz, 1.0)
+    wpos3 = u_wobject.world_transform * vec4(pos3.xyz, 1.0)
+    npos1 = u_stdinfo.projection_transform * u_stdinfo.cam_transform * wpos1
+    npos2 = u_stdinfo.projection_transform * u_stdinfo.cam_transform * wpos2
+    npos3 = u_stdinfo.projection_transform * u_stdinfo.cam_transform * wpos3
     npos2 = npos2 / npos2.w
     npos3 = npos3 / npos3.w
 
@@ -208,8 +210,7 @@ def fragment_shader(
     in_coord: (pyshader.RES_INPUT, "FragCoord", vec4),
     v_line_width_p: (pyshader.RES_INPUT, 0, f32),
     v_vec_from_node_p: (pyshader.RES_INPUT, 1, vec2),
-    stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
-    material: (pyshader.RES_UNIFORM, (0, 1), LineMaterial.uniform_type),
+    u_material: (pyshader.RES_UNIFORM, (0, 2), LineMaterial.uniform_type),
     out_color: (pyshader.RES_OUTPUT, 0, vec4),
     out_depth: (pyshader.RES_OUTPUT, "FragDepth", f32),
 ):
@@ -234,16 +235,17 @@ def fragment_shader(
     out_depth = in_coord.z + 0.0001 * (0.8 - min(0.8, alpha))  # noqa
 
     # Set color
-    color = material.color
+    color = u_material.color
     out_color = vec4(color.rgb, min(1.0, color.a) * alpha)  # noqa - shader assign
 
 
 @pyshader.python2shader
 def vertex_shader_segment(
     index: (pyshader.RES_INPUT, "VertexId", "i32"),
-    buf_pos: (pyshader.RES_BUFFER, (0, 2), Array(vec4)),
-    stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
-    material: (pyshader.RES_UNIFORM, (0, 1), LineMaterial.uniform_type),
+    u_stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
+    u_wobject: (pyshader.RES_UNIFORM, (0, 1), wobject_uniform_type),
+    u_material: (pyshader.RES_UNIFORM, (0, 2), LineMaterial.uniform_type),
+    buf_pos: (pyshader.RES_BUFFER, (1, 0), Array(vec4)),
     out_pos: (pyshader.RES_OUTPUT, "Position", vec4),
     v_line_width_p: (pyshader.RES_OUTPUT, 0, f32),
     v_vec_from_node_p: (pyshader.RES_OUTPUT, 1, vec2),
@@ -254,19 +256,19 @@ def vertex_shader_segment(
     # caps, no joins.
 
     # Prepare some numbers
-    screen_factor = stdinfo.logical_size.xy / 2.0
-    l2p = stdinfo.physical_size.x / stdinfo.logical_size.x
-    half_line_width = material.thickness * 0.5  # in logical pixels
+    screen_factor = u_stdinfo.logical_size.xy / 2.0
+    l2p = u_stdinfo.physical_size.x / u_stdinfo.logical_size.x
+    half_line_width = u_material.thickness * 0.5  # in logical pixels
     # What i in the node list (point on the line) is this?
     i = index // 5
     # Sample the current node and either of its neighbours
     pos2 = buf_pos[i]
     pos3 = buf_pos[i + 1 - (i % 2) * 2]  # (i + 1) if i is even else (i - 1)
     # Convert to ndc
-    wpos2 = stdinfo.world_transform * vec4(pos2.xyz, 1.0)
-    wpos3 = stdinfo.world_transform * vec4(pos3.xyz, 1.0)
-    npos2 = stdinfo.projection_transform * stdinfo.cam_transform * wpos2
-    npos3 = stdinfo.projection_transform * stdinfo.cam_transform * wpos3
+    wpos2 = u_wobject.world_transform * vec4(pos2.xyz, 1.0)
+    wpos3 = u_wobject.world_transform * vec4(pos3.xyz, 1.0)
+    npos2 = u_stdinfo.projection_transform * u_stdinfo.cam_transform * wpos2
+    npos3 = u_stdinfo.projection_transform * u_stdinfo.cam_transform * wpos3
     npos2 = npos2 / npos2.w
     npos3 = npos3 / npos3.w
     # Convert to logical screen coordinates, because that's were the lines work
@@ -303,9 +305,10 @@ def vertex_shader_segment(
 @pyshader.python2shader
 def vertex_shader_arrow(
     index: (pyshader.RES_INPUT, "VertexId", "i32"),
-    buf_pos: (pyshader.RES_BUFFER, (0, 2), Array(vec4)),
-    stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
-    material: (pyshader.RES_UNIFORM, (0, 1), LineMaterial.uniform_type),
+    u_stdinfo: (pyshader.RES_UNIFORM, (0, 0), stdinfo_uniform_type),
+    u_wobject: (pyshader.RES_UNIFORM, (0, 1), wobject_uniform_type),
+    u_material: (pyshader.RES_UNIFORM, (0, 2), LineMaterial.uniform_type),
+    buf_pos: (pyshader.RES_BUFFER, (1, 0), Array(vec4)),
     out_pos: (pyshader.RES_OUTPUT, "Position", vec4),
     v_line_width_p: (pyshader.RES_OUTPUT, 0, f32),
     v_vec_from_node_p: (pyshader.RES_OUTPUT, 1, vec2),
@@ -316,19 +319,19 @@ def vertex_shader_arrow(
     # only draw caps, no joins.
 
     # Prepare some numbers
-    screen_factor = stdinfo.logical_size.xy / 2.0
-    l2p = stdinfo.physical_size.x / stdinfo.logical_size.x
-    half_line_width = material.thickness * 0.5  # in logical pixels
+    screen_factor = u_stdinfo.logical_size.xy / 2.0
+    l2p = u_stdinfo.physical_size.x / u_stdinfo.logical_size.x
+    half_line_width = u_material.thickness * 0.5  # in logical pixels
     # What i in the node list (point on the line) is this?
     i = index // 3
     # Sample the current node and either of its neighbours
     pos2 = buf_pos[i]
     pos3 = buf_pos[i + 1 - (i % 2) * 2]  # (i + 1) if i is even else (i - 1)
     # Convert to ndc
-    wpos2 = stdinfo.world_transform * vec4(pos2.xyz, 1.0)
-    wpos3 = stdinfo.world_transform * vec4(pos3.xyz, 1.0)
-    npos2 = stdinfo.projection_transform * stdinfo.cam_transform * wpos2
-    npos3 = stdinfo.projection_transform * stdinfo.cam_transform * wpos3
+    wpos2 = u_wobject.world_transform * vec4(pos2.xyz, 1.0)
+    wpos3 = u_wobject.world_transform * vec4(pos3.xyz, 1.0)
+    npos2 = u_stdinfo.projection_transform * u_stdinfo.cam_transform * wpos2
+    npos3 = u_stdinfo.projection_transform * u_stdinfo.cam_transform * wpos3
     npos2 = npos2 / npos2.w
     npos3 = npos3 / npos3.w
     # Convert to logical screen coordinates, because that's were the lines work
@@ -384,8 +387,9 @@ def thin_line_renderer(wobject, render_info):
             "indices": (positions1.nitems, 1),
             "vertex_buffers": {0: positions1},
             "bindings0": {
-                0: (wgpu.BindingType.uniform_buffer, render_info.stdinfo),
-                1: (wgpu.BindingType.uniform_buffer, material.uniform_buffer),
+                0: (wgpu.BindingType.uniform_buffer, render_info.stdinfo_uniform),
+                1: (wgpu.BindingType.uniform_buffer, render_info.wobject_uniform),
+                2: (wgpu.BindingType.uniform_buffer, material.uniform_buffer),
             },
             # "bindings1": {},
             "target": None,  # default
@@ -445,10 +449,11 @@ def line_renderer(wobject, render_info):
             "primitive_topology": wgpu.PrimitiveTopology.triangle_strip,
             "indices": (n, 1),
             "bindings0": {
-                0: (wgpu.BindingType.uniform_buffer, render_info.stdinfo),
-                1: (wgpu.BindingType.uniform_buffer, material.uniform_buffer),
-                2: (wgpu.BindingType.storage_buffer, positions1),
+                0: (wgpu.BindingType.uniform_buffer, render_info.stdinfo_uniform),
+                1: (wgpu.BindingType.uniform_buffer, render_info.wobject_uniform),
+                2: (wgpu.BindingType.uniform_buffer, material.uniform_buffer),
             },
+            "bindings1": {0: (wgpu.BindingType.storage_buffer, positions1),},
             # "bindings1": {},
             "target": None,  # default
         },


### PR DESCRIPTION
* [x] Adds an example that draws 1000 small plots. This puts a strain on the amount of work that Python must do each draw.
* [x] Put the `stdinfo` uniform into a singleton uniform that is reused by all objects.
* [x] The `world_transform` that was previously in `stdinfo` is now in a per-wobect uniform. This is what makes the 1000-plot example fast.
* [x] Investigate the need for collections. We don't seem to need them!
* [x] All shaders now uses binding set 0 for uniforms, and 1 for textures and storage buffers (just for consistency).
* [x] The ortho camera can be set to not maintain aspect ratio.
* [x] Add (basic) support for instancing, including an example.
* [ ] Would be nice to let those meshes in the instanced mesh example rotate ...
* [ ] Only update world-uniform when needed.
* [ ] Smarter updating overall.
