### PR TITLE
add WorldObject.matrix_auto_update, set_matrix and apply_matrix

### DIFF
--- a/examples/manual_matrix_update.py
+++ b/examples/manual_matrix_update.py
@@ -1,0 +1,55 @@
+"""
+Example showing transform control flow without matrix auto updating.
+"""
+
+import numpy as np
+import imageio
+import pygfx as gfx
+
+from PyQt5 import QtWidgets
+from wgpu.gui.qt import WgpuCanvas
+
+
+app = QtWidgets.QApplication([])
+
+canvas = WgpuCanvas()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+im = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
+im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
+tex = gfx.Texture(im, dim=2, usage="sampled").get_view(filter="linear")
+
+material = gfx.MeshBasicMaterial(map=tex, clim=(0.2, 0.8))
+geometry = gfx.BoxGeometry(100, 100, 100)
+cubes = [gfx.Mesh(geometry, material) for i in range(8)]
+for i, cube in enumerate(cubes):
+    cube.matrix_auto_update = False
+    cube.set_matrix(gfx.linalg.Matrix4().set_position_xyz(350 - i * 100, 0, 0))
+    scene.add(cube)
+
+background = gfx.Background(gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+scene.add(background)
+
+camera = gfx.PerspectiveCamera(70, 16 / 9)
+camera.matrix_auto_update = False
+camera.set_matrix(gfx.linalg.Matrix4().set_position_xyz(0, 0, 500))
+
+
+def animate():
+    for i, cube in enumerate(cubes):
+        pos = gfx.linalg.Matrix4().set_position_xyz(350 - i * 100, 0, 0)
+        rot = gfx.linalg.Matrix4().extract_rotation(cube.matrix)
+        rot.premultiply(gfx.linalg.Matrix4().make_rotation_from_euler(
+            gfx.linalg.Euler(0.01 * i, 0.02 * i)
+        ))
+        rot.premultiply(pos)
+        cube.set_matrix(rot)
+
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec_()

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -76,6 +76,7 @@ class WorldObject(ResourceContainer):
         self.up = Vector3(0, 1, 0)
 
         self.matrix = Matrix4()
+        self.matrix_auto_update = True
         self.matrix_world = Matrix4()
         self.matrix_world_dirty = True
 
@@ -119,6 +120,18 @@ class WorldObject(ResourceContainer):
             self.matrix.compose(self.position, self.rotation, self.scale)
             self.matrix_world_dirty = True
 
+    def set_matrix(self, matrix):
+        self.matrix.copy(matrix)
+        self.matrix.decompose(self.position, self.rotation, self.scale)
+        self.matrix_world_dirty = True
+
+    def apply_matrix(self, matrix):
+        if self.matrix_auto_update:
+            self.update_matrix()
+        self.matrix.premultiply(matrix)
+        self.matrix.decompose(self.position, self.rotation, self.scale)
+        self.matrix_world_dirty = True
+
     def update_matrix_world(
         self, force=False, update_children=True, update_parents=False
     ):
@@ -126,7 +139,8 @@ class WorldObject(ResourceContainer):
             self.parent.update_matrix_world(
                 force=force, update_children=False, update_parents=True
             )
-        self.update_matrix()
+        if self.matrix_auto_update:
+            self.update_matrix()
         if self.matrix_world_dirty or force:
             if self.parent is None:
                 self.matrix_world.copy(self.matrix)


### PR DESCRIPTION
Closes #60

Adds `WorldObject.matrix_auto_update` property

The example shows one way to use it; the helper functions `set_matrix` and `apply_matrix` will try to keep the pos/rot/scale properties in sync.

Another option that is not demonstrated here is to just directly set the properties yourself, and forgo the pos/rot/scale property synchronization. You would replace `cube.set_matrix(rot)` in the example with:

```python
cube.matrix.copy(rot)
cube.matrix_world_dirty = True
```