### PR TITLE
Support for RGB textures

### DIFF
--- a/examples/geometry_cube.py
+++ b/examples/geometry_cube.py
@@ -17,7 +17,6 @@ renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
 im = imageio.imread("imageio:bricks.jpg").astype(np.float32) / 255
-im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
 tex = gfx.Texture(im, dim=2, usage="sampled").get_view(
     filter="linear", address_mode="repeat"
 )

--- a/examples/geometry_cubes.py
+++ b/examples/geometry_cubes.py
@@ -16,11 +16,10 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
-im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
+im = imageio.imread("imageio:chelsea.png")
 tex = gfx.Texture(im, dim=2, usage="sampled").get_view(filter="linear")
 
-material = gfx.MeshBasicMaterial(map=tex, clim=(0.2, 0.8))
+material = gfx.MeshBasicMaterial(map=tex, clim=(0, 255))
 geometry = gfx.BoxGeometry(100, 100, 100)
 cubes = [gfx.Mesh(geometry, material) for i in range(8)]
 for i, cube in enumerate(cubes):

--- a/examples/geometry_torus_knot.py
+++ b/examples/geometry_torus_knot.py
@@ -16,15 +16,14 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:bricks.jpg").astype(np.float32) / 255
-im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
+im = imageio.imread("imageio:bricks.jpg")
 tex = gfx.Texture(im, dim=2, usage="sampled").get_view(
     filter="linear", address_mode="repeat"
 )
 
 geometry = gfx.TorusKnotGeometry(1, 0.3, 128, 32)
 geometry.texcoords.data[:, 0] *= 10  # stretch the texture
-material = gfx.MeshPhongMaterial(map=tex, clim=(0.2, 0.8))
+material = gfx.MeshPhongMaterial(map=tex, clim=(10, 240))
 obj = gfx.Mesh(geometry, material)
 scene.add(obj)
 

--- a/examples/image_plus_points.py
+++ b/examples/image_plus_points.py
@@ -19,8 +19,6 @@ scene = gfx.Scene()
 # %% add image
 
 im = imageio.imread("imageio:astronaut.png")
-im = np.concatenate([im, 255 * np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)  # yuk!
-
 tex = gfx.Texture(im, dim=2, usage="sampled")
 
 geometry = gfx.PlaneGeometry(512, 512)

--- a/examples/instancing_mesh.py
+++ b/examples/instancing_mesh.py
@@ -17,7 +17,6 @@ renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
 im = imageio.imread("imageio:bricks.jpg").astype(np.float32) / 255
-im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
 tex = gfx.Texture(im, dim=2, usage="sampled").get_view(
     filter="linear", address_mode="repeat"
 )

--- a/examples/manual_matrix_update.py
+++ b/examples/manual_matrix_update.py
@@ -16,11 +16,10 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
-im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
+im = imageio.imread("imageio:chelsea.png")
 tex = gfx.Texture(im, dim=2, usage="sampled").get_view(filter="linear")
 
-material = gfx.MeshBasicMaterial(map=tex, clim=(0.2, 0.8))
+material = gfx.MeshBasicMaterial(map=tex, clim=(0, 250))
 geometry = gfx.BoxGeometry(100, 100, 100)
 cubes = [gfx.Mesh(geometry, material) for i in range(8)]
 for i, cube in enumerate(cubes):

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -53,11 +53,10 @@ scene = gfx.Scene()
 
 scene.add(gfx.AxesHelper(size=250))
 
-im = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
-im = np.concatenate([im, np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
+im = imageio.imread("imageio:chelsea.png")
 tex = gfx.Texture(im, dim=2, usage="sampled").get_view(filter="linear")
 
-material = gfx.MeshBasicMaterial(map=tex, clim=(0.2, 0.8))
+material = gfx.MeshBasicMaterial(map=tex, clim=(0, 255))
 geometry = gfx.BoxGeometry(100, 100, 100)
 cubes = [gfx.Mesh(geometry, material) for i in range(8)]
 for i, cube in enumerate(cubes):

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -54,7 +54,6 @@ background = gfx.Background(gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
 scene.add(background)
 
 im = imageio.imread("imageio:astronaut.png")
-im = np.concatenate([im, 255 * np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)  # yuk!
 tex = gfx.Texture(im, dim=2, usage="sampled")
 geometry = gfx.PlaneGeometry(512, 512)
 material = gfx.MeshBasicMaterial(map=tex.get_view(filter="linear"), clim=(0, 255))

--- a/examples/skybox.py
+++ b/examples/skybox.py
@@ -14,11 +14,10 @@ from wgpu.gui.qt import WgpuCanvas
 # Read the image
 # The order of the images is already correct for GPU cubemap texture sampling
 im = imageio.imread("imageio:meadow_cube.jpg")
-im = np.concatenate([im, 255 * np.ones(im.shape[:2] + (1,), dtype=im.dtype)], 2)
 
 # Turn it into a 3D image (a 4d nd array)
 width = height = im.shape[1]
-im.shape = -1, width, height, 4
+im.shape = -1, width, height, 3
 
 app = QtWidgets.QApplication([])
 canvas = WgpuCanvas()

--- a/pygfx/renderers/wgpu/backgroundrender.py
+++ b/pygfx/renderers/wgpu/backgroundrender.py
@@ -132,7 +132,7 @@ def background_renderer(wobject, render_info):
             raise ValueError(
                 "BackgroundImageMaterial should have map with texture view 2d or cube."
             )
-        if "rgba" in material.map.format:
+        if "rgb" in material.map.format:
             fragment_shader = fragment_shader_tex_rgba
         else:
             fragment_shader = fragment_shader_tex_gray

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -95,7 +95,7 @@ def mesh_renderer(wobject, render_info):
     elif isinstance(material, MeshPhongMaterial):
         fragment_shader = fragment_shader_phong
         if material.map is not None:
-            if "rgba" in material.map.format:
+            if "rgb" in material.map.format:  # rgb maps to rgba
                 fragment_shader = fragment_shader_textured_rgba_phong
             else:
                 raise ValueError(
@@ -104,10 +104,13 @@ def mesh_renderer(wobject, render_info):
     else:
         fragment_shader = fragment_shader_simple
         if material.map is not None:
-            if "rgba" in material.map.format:
-                fragment_shader = fragment_shader_textured_rgba
-            else:
-                fragment_shader = fragment_shader_textured_gray
+            if material.map.view_dim == "2d":
+                if "rgb" in material.map.format:
+                    fragment_shader = fragment_shader_textured_rgba
+                else:
+                    fragment_shader = fragment_shader_textured_gray
+            elif material.map.view_dim == "3d":
+                fragment_shader = fragment_shader_textured_gray_3dtex
 
     # Instanced meshes have their own vertex shader
     n_instances = 1

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -191,7 +191,7 @@ class Texture(Resource):
             else:  # dim == 3:
                 return shape[2], shape[1], shape[0]
 
-    def _get_subdata(self, offset, size):
+    def _get_subdata(self, offset, size, pixel_padding=None):
         """Return subdata as a contiguous array."""
         # If this is a full range, this is easy
         if offset == 0 and size == self.nitems and self.mem.contiguous:
@@ -211,6 +211,9 @@ class Texture(Resource):
         for d in reversed(range(3)):
             slices.append(slice(offset[d], offset[d] + size[d]))
         sub_arr = arr[tuple(slices)]
+        if pixel_padding is not None:
+            padding = np.ones(sub_arr.shape[:3] + (1,), dtype=sub_arr.dtype)
+            sub_arr = np.concatenate([sub_arr, pixel_padding * padding], -1)
         return memoryview(np.ascontiguousarray(sub_arr))
 
 
@@ -227,8 +230,8 @@ def format_from_memoryview(mem, size):
         nchannels = 1
     assert 1 <= nchannels <= 4
     tex_format = [None, "r", "rg", "rgb", "rgba"][nchannels]
-    if tex_format == "rgb":
-        raise ValueError("RGB textures not supported, use RGBA instead")
+    # if tex_format == "rgb":
+    #     raise ValueError("RGB textures not supported, use RGBA instead")
     # Process dtype. We select the tex_format that matches the dtype.
     # This means that uint8 values become 0..255 in the shader.
     # todo: not yet entirely sure about this

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -231,7 +231,7 @@ def format_from_memoryview(mem, size):
     assert 1 <= nchannels <= 4
     tex_format = [None, "r", "rg", "rgb", "rgba"][nchannels]
     # if tex_format == "rgb":
-    #     raise ValueError("RGB textures not supported, use RGBA instead")
+    #     -> no raise: WGPU does not support rgb, but we handle it in the renderer
     # Process dtype. We select the tex_format that matches the dtype.
     # This means that uint8 values become 0..255 in the shader.
     # todo: not yet entirely sure about this


### PR DESCRIPTION
Closes #44 

Adds support for RGB textures by appending an alpha channel when we upload the data. Causes some overhead, but we can document this. I think it's well worth the benefit. By handling this "just in time", we also avoid the issue of whether or not to replace the internal array of the Texture object.