### PR TITLE
Attempt at implementing OIT via fragment buffer

### DIFF
--- a/examples/geometry_cube.py
+++ b/examples/geometry_cube.py
@@ -12,7 +12,8 @@ from wgpu.gui.qt import WgpuCanvas
 app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
-renderer = gfx.renderers.WgpuRenderer(canvas)
+canvas._target_fps = 1000
+renderer = gfx.renderers.WgpuRenderer(canvas, show_fps=True)
 scene = gfx.Scene()
 
 im = imageio.imread("imageio:bricks.jpg")

--- a/examples/transparency1.py
+++ b/examples/transparency1.py
@@ -1,0 +1,49 @@
+"""
+Example showing transparency.
+"""
+import time
+import wgpu
+import pygfx as gfx
+
+from PyQt5 import QtWidgets
+from wgpu.gui.qt import WgpuCanvas
+
+
+app = QtWidgets.QApplication([])
+
+canvas = WgpuCanvas()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+geometry = gfx.PlaneGeometry(50, 50)
+plane1 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(1, 0, 0, 0.4)))
+plane2 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 1, 0, 0.4)))
+plane3 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 0, 1, 0.4)))
+plane4 = gfx.Mesh(
+    gfx.PlaneGeometry(100, 10), gfx.MeshBasicMaterial(color=(0, 1, 0, 0.4))
+)
+
+plane1.position.set(-10, -10, 1)
+plane2.position.set(0, 0, 2)
+plane3.position.set(10, 10, 3)
+
+scene.add(plane2, plane1, plane3, plane4)
+# scene.add(plane1, plane2, plane3, plane4)
+# scene.add(plane3, plane2, plane1)
+
+
+camera = gfx.OrthographicCamera(100, 100)
+
+
+def animate():
+    z = time.time() % 4
+    plane4.position.x = z
+    plane4.position.z = z * 400
+
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec()

--- a/examples/transparency2.py
+++ b/examples/transparency2.py
@@ -1,0 +1,83 @@
+"""
+Example showing transparency using three orthogonal planes.
+"""
+
+import wgpu
+import pygfx as gfx
+
+from PyQt5 import QtWidgets, QtCore
+from wgpu.gui.qt import WgpuCanvas
+
+
+class WgpuCanvasWithInputEvents(WgpuCanvas):
+    _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
+    _mode = None
+
+    def wheelEvent(self, event):  # noqa: N802
+        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
+
+    def mousePressEvent(self, event):  # noqa: N802
+        mode = self._drag_modes.get(event.button(), None)
+        if self._mode or not mode:
+            return
+        self._mode = mode
+        drag_start = (
+            controls.pan_start if self._mode == "pan" else controls.rotate_start
+        )
+        drag_start(
+            (event.x(), event.y()),
+            self.get_logical_size(),
+            camera,
+        )
+        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
+
+    def mouseReleaseEvent(self, event):  # noqa: N802
+        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
+            self._mode = None
+            drag_stop = (
+                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
+            )
+            drag_stop()
+            app.restoreOverrideCursor()
+
+    def mouseMoveEvent(self, event):  # noqa: N802
+        if self._mode is not None:
+            drag_move = (
+                controls.pan_move if self._mode == "pan" else controls.rotate_move
+            )
+            drag_move((event.x(), event.y()))
+
+
+app = QtWidgets.QApplication([])
+
+canvas = WgpuCanvasWithInputEvents()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+sphere = gfx.Mesh(gfx.SphereGeometry(10), gfx.MeshBasicMaterial())
+
+geometry = gfx.PlaneGeometry(50, 50)
+plane1 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(1, 0, 0, 0.4)))
+plane2 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 1, 0, 0.4)))
+plane3 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 0, 1, 0.4)))
+
+plane1.rotation.set_from_axis_angle(gfx.linalg.Vector3(1, 0, 0), 1.571)
+plane2.rotation.set_from_axis_angle(gfx.linalg.Vector3(0, 1, 0), 1.571)
+plane3.rotation.set_from_axis_angle(gfx.linalg.Vector3(0, 0, 1), 1.571)
+
+scene.add(sphere, plane1, plane2, plane3)
+
+camera = gfx.PerspectiveCamera(70, 16/9)
+camera.position.z = 70
+controls = gfx.OrbitControls(camera.position.clone())
+
+
+def animate():
+    controls.update_camera(camera)
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec()

--- a/examples/transparency2.py
+++ b/examples/transparency2.py
@@ -51,10 +51,11 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
 app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvasWithInputEvents()
-renderer = gfx.renderers.WgpuRenderer(canvas)
+canvas._target_fps = 1000
+renderer = gfx.renderers.WgpuRenderer(canvas, show_fps=True)
 scene = gfx.Scene()
 
-sphere = gfx.Mesh(gfx.SphereGeometry(10), gfx.MeshBasicMaterial())
+sphere = gfx.Mesh(gfx.SphereGeometry(10), gfx.MeshPhongMaterial())
 
 geometry = gfx.PlaneGeometry(50, 50)
 plane1 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(1, 0, 0, 0.4)))
@@ -67,7 +68,7 @@ plane3.rotation.set_from_axis_angle(gfx.linalg.Vector3(0, 0, 1), 1.571)
 
 scene.add(sphere, plane1, plane2, plane3)
 
-camera = gfx.PerspectiveCamera(70, 16/9)
+camera = gfx.PerspectiveCamera(70, 16 / 9)
 camera.position.z = 70
 controls = gfx.OrbitControls(camera.position.clone())
 

--- a/pygfx/renderers/wgpu/_renderutils.py
+++ b/pygfx/renderers/wgpu/_renderutils.py
@@ -331,7 +331,14 @@ class FragmentResolverStep:
             let index = ipos.x + ipos.y * w;
 
             let frag = s_fragments.data[index].frag;
-            return frag.rgba;
+
+            // Simple
+            //return unpack_vec4(frag.rgba);
+
+            // Weighted blended
+            let color = unpack_vec4(frag.color);
+            return vec4<f32>(frag.accum.rgb / max(frag.accum.a, 0.00001), 1.0);
+
             //return vec4<f32>(f32(x), f32(y), 0.0, 1.0);
         }
     """

--- a/pygfx/renderers/wgpu/_wgpurenderer.py
+++ b/pygfx/renderers/wgpu/_wgpurenderer.py
@@ -11,7 +11,7 @@ from ...cameras import Camera
 from ...resources import Buffer, Texture, TextureView
 from ...utils import array_from_shadertype
 
-from ._renderutils import RenderTexture, RenderFlusher
+from ._renderutils import RenderTexture, RenderFlusher, FragmentResolverStep
 from ._conv import to_vertex_format, to_texture_format
 
 
@@ -80,8 +80,9 @@ class RenderInfo:
     will probably also include lights etc.
     """
 
-    def __init__(self, *, stdinfo_uniform):
+    def __init__(self, *, stdinfo_uniform, out_buffer):
         self.stdinfo_uniform = stdinfo_uniform
+        self.out_buffer = out_buffer
 
 
 class SharedData:
@@ -204,6 +205,8 @@ class WgpuRenderer(Renderer):
 
         # Prepare object that performs the final render step into a texture
         self._flusher = RenderFlusher(self._shared.device)
+        # Prepare post-processing steps. Users can append/insert more
+        self._fragment_resolver_step = FragmentResolverStep(self._shared.device)
 
         # Prepare other properties
         self._msaa = 1  # todo: cannot set sample_count of render_pass yet
@@ -326,6 +329,28 @@ class WgpuRenderer(Renderer):
         # Determine the physical size of the first and last render pass
         framebuffer_size = tuple(max(1, int(pixel_ratio * x)) for x in logical_size)
 
+        force_reset = False
+
+        # TODO: This needs work, because resizing the fragment buffer means creating
+        # a new storage buffer, which means we need to rebuild all pipelines in which
+        # it is used ...
+
+        # Resize fragment buffer as needed. This buffer can hold multiple fragments
+        # per pixel, so we can achieve order independent transparency.
+        nfragments = 8
+        fragment_buffer_size = (
+            framebuffer_size[0] * framebuffer_size[1] * nfragments * 8
+        )
+        if (
+            not hasattr(self, "_fragment_buffer")
+            or self._fragment_buffer.nbytes != fragment_buffer_size
+        ):
+            self._fragment_buffer = Buffer(
+                nbytes=fragment_buffer_size,
+                nitems=framebuffer_size[0] * framebuffer_size[1],
+            )
+            force_reset = True
+
         # Set the size of the textures (is a no-op if the size does not change)
         self._render_texture.ensure_size(device, framebuffer_size + (1,))
         self._depth_texture.ensure_size(device, framebuffer_size + (1,))
@@ -360,13 +385,26 @@ class WgpuRenderer(Renderer):
 
         # Ensure each wobject has pipeline info
         for wobject in q:
-            self._ensure_up_to_date(wobject)
+            self._ensure_up_to_date(wobject, force_reset)
 
         # Filter out objects that we cannot render
         q = [wobject for wobject in q if wobject._wgpu_pipeline_objects is not None]
 
-        # Render the scene graph (to the first texture)
         command_encoder = device.create_command_encoder()
+
+        # Clear fragment buffer
+        # todo: this seems like something that can be done more efficiently
+        wgpu_frag_buffer = self._fragment_buffer._wgpu_buffer[1]
+        clear_size = fragment_buffer_size // 8
+        tmp_buffer = device.create_buffer(
+            size=clear_size, usage=wgpu.BufferUsage.COPY_SRC
+        )
+        for i in range(fragment_buffer_size // clear_size):
+            command_encoder.copy_buffer_to_buffer(
+                tmp_buffer, 0, wgpu_frag_buffer, i * clear_size, clear_size
+            )
+
+        # Render the scene graph (to the fragment bufer)
         self._render_recording(
             command_encoder, q, physical_viewport, clear_color, clear_depth
         )
@@ -375,6 +413,10 @@ class WgpuRenderer(Renderer):
 
         # Flush to target
         if flush:
+            # Resolve the per-pixel fragments into a color texture (OIT)
+            self._fragment_resolver_step.render(
+                framebuffer_size, self._fragment_buffer, self._render_texture
+            )
             self.flush()
 
     def flush(self):
@@ -592,6 +634,7 @@ class WgpuRenderer(Renderer):
         # Prepare info for the render function
         render_info = RenderInfo(
             stdinfo_uniform=self._shared.stdinfo_buffer,
+            out_buffer=self._fragment_buffer,
         )
 
         # Call render function
@@ -923,7 +966,6 @@ class WgpuRenderer(Renderer):
             for slot, binding in resources.items():
                 resource = binding.resource
                 subtype = binding.type.partition("/")[2]
-
                 if binding.type.startswith("buffer/"):
                     assert isinstance(resource, Buffer)
                     bindings.append(


### PR DESCRIPTION
This is an attempt at Order independent Transparency #73.

* [x] Change architecture to render via a buffer.
* [x] Test atomic ops and spin-lock. (looks like we need a newer Naga for this)
* [ ] Properly deal with canvas resizing.
* [ ] Do some benchmarking to see what the costs are.
* [ ] Implement WB-OIT or MLAB.
* [ ] Write examples to see result.
* [ ] Make all visuals use this approach.

## Spinlocks notes

This spinlock looks like it should work, but it does not. The reason is probably [this](https://stackoverflow.com/a/51708878/2271927): 
    
 > you are relying on one aspect of relative order: that all threads will eventually make forward progress. That is, you assume that any thread spinning on a lock will not starve the thread that has the lock of its execution resources. That threads holding the lock will eventually make forward progress and release it.
 
```wgsl
        fn write_fragment_spinlock1(index: i32, frag: Fragment) {
           let active_lock = &s_fragments.data[index].lock;
            loop {
                let old = atomicExchange(active_lock, 2);
                if (old != 2) { break; }
            }
            write_fragment_naive(index, frag);
            atomicStore(active_lock, 1);
        }
```

The next lock is an interesting alternative. I read in an nvidia presentation (that I can't find back now) that this has advantages over an actual spinlock. Unfortunately, this does not work right now because it's not yet (fully) implemented in Naga. Also see
 https://github.com/gfx-rs/naga/blob/3e1244c5cbff24506b82bed906e283260fc19849/src/valid/function.rs#L336,    https://github.com/gfx-rs/naga/issues/1413,  https://github.com/gpuweb/gpuweb/issues/2021, and  https://github.com/gpuweb/gpuweb/pull/2113
```
        fn write_fragment_retry(index: i32, frag: Fragment) {
            let active_lock = &s_fragments.data[index].lock;
            var old_lock_value = atomicLoad(active_lock);
            var new_lock_value = old_lock_value + 1;
            loop {
                write_fragment_naive(index, frag);
                let res = atomicCompareExchangeWeak(active_lock, old_lock_value, new_lock_value);
                if (res.exchanged) {
                    break;
                }
            }
        }
```

And then there's the one that actually does work, thanks to [this SO comment](https://stackoverflow.com/q/11820066/2271927):
```
        fn write_fragment_spinlock2(index: i32, frag: Fragment) {
            let active_lock = &s_fragments.data[index].lock;  // per pixel
            var done = false;
            loop {
                if (done) { break; }
                let old = atomicExchange(active_lock, 1);
                if (old != 1) {
                    write_fragment_naive(index, frag);
                    atomicStore(active_lock, 0);
                    done = true;
                }
            }
        }
```
