### PR TITLE
Implement culling for mesh material

### DIFF
--- a/examples/validate_culling.py
+++ b/examples/validate_culling.py
@@ -7,7 +7,6 @@ Example test to validate winding and culling.
 
 """
 
-import numpy as np
 import pygfx as gfx
 from PyQt5 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas

--- a/examples/validate_culling.py
+++ b/examples/validate_culling.py
@@ -42,6 +42,7 @@ scene.add(obj1, obj2)
 
 camera = gfx.OrthographicCamera(6, 4)
 
+
 def animate():
     # Render top row
     camera.scale.z = 1
@@ -52,6 +53,7 @@ def animate():
     # take this effect into account in the mesh shader.
     camera.scale.z = -1
     renderer.render(scene, camera, viewport=(0, 300, 600, 300))
+
 
 if __name__ == "__main__":
     print(__doc__)

--- a/examples/validate_culling.py
+++ b/examples/validate_culling.py
@@ -1,0 +1,66 @@
+"""
+Example test to validate winding and culling.
+
+* The red knot should look normal and well lit.
+* The green know should show the backfaces, well lit.
+* The purple and cyan knots are not lit.
+
+"""
+
+import pygfx as gfx
+
+from PyQt5 import QtWidgets
+from wgpu.gui.qt import WgpuCanvas
+
+
+app = QtWidgets.QApplication([])
+
+canvas = WgpuCanvas()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+# geometry = gfx.BoxGeometry(1, 1, 1)
+geometry = gfx.TorusKnotGeometry(1, 0.3, 64, 10)
+
+# Top left
+material1 = gfx.MeshPhongMaterial(color=(1, 0, 0, 1))
+obj1 = gfx.Mesh(geometry, material1)
+obj1.position.set(-2, +2, 0)
+obj1.material.winding = "CCW"
+obj1.material.side = "FRONT"
+
+# Top right
+material2 = gfx.MeshPhongMaterial(color=(0, 1, 0, 1))
+obj2 = gfx.Mesh(geometry, material2)
+obj2.position.set(+2, +2, 0)
+obj2.material.winding = "CCW"
+obj2.material.side = "BACK"
+
+# Bottom left
+material3 = gfx.MeshPhongMaterial(color=(1, 0, 1, 1))
+obj3 = gfx.Mesh(geometry, material3)
+obj3.position.set(-2, -2, 0)
+obj3.material.winding = "CW"
+obj3.material.side = "FRONT"
+
+# Bottom right
+material4 = gfx.MeshPhongMaterial(color=(0, 1, 1, 1))
+obj4 = gfx.Mesh(geometry, material4)
+obj4.position.set(+2, -2, 0)
+obj4.material.winding = "CW"
+obj4.material.side = "BACK"
+
+# Rotate all of them and add to scene
+rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.71, 1))
+for obj in obj1, obj2, obj3, obj4:
+    obj.rotation.multiply(rot)
+    scene.add(obj)
+
+camera = gfx.OrthographicCamera(6, 8)
+
+
+if __name__ == "__main__":
+    print(__doc__)
+    canvas.request_draw(lambda: renderer.render(scene, camera))
+    # canvas.request_draw(animate)
+    app.exec_()

--- a/examples/validate_culling.py
+++ b/examples/validate_culling.py
@@ -57,7 +57,7 @@ for obj in obj1, obj2, obj3, obj4:
     scene.add(obj)
 
 camera = gfx.OrthographicCamera(6, 8)
-
+camera.scale.z *= -1
 
 if __name__ == "__main__":
     print(__doc__)

--- a/pygfx/cameras/_base.py
+++ b/pygfx/cameras/_base.py
@@ -38,6 +38,14 @@ class Camera(WorldObject):
     def update_projection_matrix(self):
         raise NotImplementedError()
 
+    @property
+    def flips_winding(self):
+        """Get whether the camera flips any dimensions causing the
+        winding of faces to be flipped. Note that if an even number of
+        dimensions are flipped, the winding is not affected.
+        """
+        return False
+
 
 class NDCCamera(Camera):
     """A Camera operating in NDC coordinates: its projection matrix

--- a/pygfx/cameras/_orthographic.py
+++ b/pygfx/cameras/_orthographic.py
@@ -34,6 +34,12 @@ class OrthographicCamera(Camera):
             f"OrthographicCamera({self.width}, {self.height}, {self.near}, {self.far})"
         )
 
+    @property
+    def flips_winding(self):
+        # This assumes not flips in the projection part (no negative with or height)
+        flips = int(self.scale.x < 0) + int(self.scale.y < 0) + int(self.scale.z < 0)
+        return bool(flips % 2)
+
     def set_view_size(self, width, height):
         self._view_aspect = width / height
         # The reference view plane is scaled with the zoom factor

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -32,6 +32,11 @@ class PerspectiveCamera(Camera):
     def __repr__(self) -> str:
         return f"PerspectiveCamera({self.fov}, {self.aspect}, {self.near}, {self.far})"
 
+    @property
+    def flips_winding(self):
+        flips = int(self.scale.x < 0) + int(self.scale.y < 0) + int(self.scale.z < 0)
+        return bool(flips % 2)
+
     def set_view_size(self, width, height):
         self._view_aspect = width / height
 

--- a/pygfx/geometries/_toroidal.py
+++ b/pygfx/geometries/_toroidal.py
@@ -170,7 +170,7 @@ class TorusKnotGeometry(Geometry):
         # Create indices
         # Two triangles onto the "top-left" rectangle (six vertices)
         indices = np.array(
-            [0, radial_verts, radial_verts + 1, radial_verts + 1, 1, 0],
+            [radial_verts, 0, radial_verts + 1, radial_verts + 1, 0, 1],
             np.int32,
         )
         # Replicate to all rectangles, add offsets
@@ -183,7 +183,8 @@ class TorusKnotGeometry(Geometry):
         if stitch:
             indices[-1, :, 1:4] -= radial_verts * tubular_verts
             indices[:, -1, 2:5] -= radial_verts
-        indices = indices.reshape(-1)
+        indices = indices.reshape(-1, 3)
+        # indices = np.fliplr(indices)  # Use this to change winding between CW and CCW
 
         # Create buffers for this geometry
         self.positions = Buffer(positions, usage="vertex|storage")

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -19,7 +19,6 @@ class MeshBasicMaterial(Material):
         clim=(0, 1),
         map=None,
         side="BOTH",
-        winding="CCW",
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -28,7 +27,6 @@ class MeshBasicMaterial(Material):
         self.clim = clim
         self.map = map
         self.side = side
-        self.winding = winding
 
     def _wgpu_get_pick_info(self, pick_value):
         inst = pick_value[1]
@@ -70,28 +68,14 @@ class MeshBasicMaterial(Material):
         self.uniform_buffer.update_range(0, 1)
 
     @property
-    def winding(self):
-        """The winding determines what is the front-facing side of a
-        triangle. Possible values are "CW" and "CCW", meaning clock-wise
-        and counter-clock-wise, respectively. By default this is CCW
-        like in e.g. ThreeJS.
-        """
-        return self._winding
-
-    @winding.setter
-    def winding(self, value):
-        winding = str(value).upper()
-        if winding in ("CW", "CCW"):
-            self._winding = winding
-        else:
-            raise ValueError(f"Unexpected winding: '{value}'")
-        self._bump_rev()
-
-    @property
     def side(self):
         """Defines which side of faces will be rendered - front, back
-        or both. By default this is both. Setting to front or back will
+        or both. By default this is "both". Setting to "front" or "back" will
         not render faces from that side, a feature also known as culling.
+
+        Which side of the mesh is the front is determined by the winding of the faces.
+        Counter-clockwise (CCW) winding is assumed. If this is not the case,
+        adjust your geometry (using e.g. ``np.fliplr()`` on ``geometry.indices``).
         """
         return self._side
 

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -13,12 +13,22 @@ class MeshBasicMaterial(Material):
         opacity=("float32",),
     )
 
-    def __init__(self, color=(1, 1, 1, 1), clim=(0, 1), map=None, **kwargs):
+    def __init__(
+        self,
+        color=(1, 1, 1, 1),
+        clim=(0, 1),
+        map=None,
+        side="BOTH",
+        winding="CCW",
+        **kwargs,
+    ):
         super().__init__(**kwargs)
 
         self.color = color
         self.clim = clim
         self.map = map
+        self.side = side
+        self.winding = winding
 
     def _wgpu_get_pick_info(self, pick_value):
         inst = pick_value[1]
@@ -58,6 +68,41 @@ class MeshBasicMaterial(Material):
     def clim(self, clim):
         self.uniform_buffer.data["clim"] = clim
         self.uniform_buffer.update_range(0, 1)
+
+    @property
+    def winding(self):
+        """The winding determines what is the front-facing side of a
+        triangle. Possible values are "CW" and "CCW", meaning clock-wise
+        and counter-clock-wise, respectively. By default this is CCW
+        like in e.g. ThreeJS.
+        """
+        return self._winding
+
+    @winding.setter
+    def winding(self, value):
+        winding = str(value).upper()
+        if winding in ("CW", "CCW"):
+            self._winding = winding
+        else:
+            raise ValueError(f"Unexpected winding: '{value}'")
+        self._bump_rev()
+
+    @property
+    def side(self):
+        """Defines which side of faces will be rendered - front, back
+        or both. By default this is both. Setting to front or back will
+        not render faces from that side, a feature also known as culling.
+        """
+        return self._side
+
+    @side.setter
+    def side(self, value):
+        side = str(value).upper()
+        if side in ("FRONT", "BACK", "BOTH"):
+            self._side = side
+        else:
+            raise ValueError(f"Unexpected side: '{value}'")
+        self._bump_rev()
 
 
 class MeshNormalMaterial(MeshBasicMaterial):

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -118,6 +118,7 @@ class MeshNormalLinesMaterial(MeshBasicMaterial):
 
 # todo: MeshLambertMaterial(MeshBasicMaterial):
 # A material for non-shiny surfaces, without specular highlights.
+# Other than for completeness or something, I don't see a need for this, TBH.
 
 
 class MeshPhongMaterial(MeshBasicMaterial):

--- a/pygfx/renderers/wgpu/_wgpurenderer.py
+++ b/pygfx/renderers/wgpu/_wgpurenderer.py
@@ -25,6 +25,7 @@ stdinfo_uniform_type = dict(
     projection_transform_inv=("float32", (4, 4)),
     physical_size=("float32", 2),
     logical_size=("float32", 2),
+    flip_winding=("int32", 1),
 )
 
 
@@ -508,6 +509,7 @@ class WgpuRenderer(Renderer):
         # stdinfo_data["ndc_to_world"].flat = np.linalg.inv(stdinfo_data["cam_transform"] @ stdinfo_data["projection_transform"])
         stdinfo_data["physical_size"] = physical_size
         stdinfo_data["logical_size"] = logical_size
+        stdinfo_data["flip_winding"] = camera.flips_winding
         # Upload to GPU
         self._shared.stdinfo_buffer.update_range(0, 1)
         self._update_buffer(self._shared.stdinfo_buffer)

--- a/pygfx/renderers/wgpu/_wgpurenderer.py
+++ b/pygfx/renderers/wgpu/_wgpurenderer.py
@@ -816,8 +816,8 @@ class WgpuRenderer(Renderer):
             primitive={
                 "topology": pipeline_info["primitive_topology"],
                 "strip_index_format": strip_index_format,
-                "front_face": wgpu.FrontFace.ccw,
-                "cull_mode": wgpu.CullMode.none,
+                "front_face": pipeline_info.get("front_face", wgpu.FrontFace.ccw),
+                "cull_mode": pipeline_info.get("cull_mode", wgpu.CullMode.none),
             },
             depth_stencil={
                 "format": self._depth_texture.format,

--- a/pygfx/renderers/wgpu/_wgpurenderer.py
+++ b/pygfx/renderers/wgpu/_wgpurenderer.py
@@ -25,7 +25,7 @@ stdinfo_uniform_type = dict(
     projection_transform_inv=("float32", (4, 4)),
     physical_size=("float32", 2),
     logical_size=("float32", 2),
-    flip_winding=("int32", 1),
+    flipped_winding=("int32", 1),  # A bool, really
 )
 
 
@@ -509,7 +509,7 @@ class WgpuRenderer(Renderer):
         # stdinfo_data["ndc_to_world"].flat = np.linalg.inv(stdinfo_data["cam_transform"] @ stdinfo_data["projection_transform"])
         stdinfo_data["physical_size"] = physical_size
         stdinfo_data["logical_size"] = logical_size
-        stdinfo_data["flip_winding"] = camera.flips_winding
+        stdinfo_data["flipped_winding"] = camera.flips_winding
         # Upload to GPU
         self._shared.stdinfo_buffer.update_range(0, 1)
         self._update_buffer(self._shared.stdinfo_buffer)
@@ -818,7 +818,7 @@ class WgpuRenderer(Renderer):
             primitive={
                 "topology": pipeline_info["primitive_topology"],
                 "strip_index_format": strip_index_format,
-                "front_face": pipeline_info.get("front_face", wgpu.FrontFace.ccw),
+                "front_face": wgpu.FrontFace.ccw,
                 "cull_mode": pipeline_info.get("cull_mode", wgpu.CullMode.none),
             },
             depth_stencil={

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -246,7 +246,13 @@ class MeshShader(BaseShader):
             // Select what face we're at
             let index = i32(in.index);
             let face_index = index / 3;
-            let sub_index = index % 3;
+            var sub_index = index % 3;
+
+            // If the camera flips a dimension, it reverses the face winding.
+            // We can correct for this by changing the winding (sub_index) here.
+            sub_index = select(sub_index, -1 * (sub_index - 1) + 1, u_stdinfo.flip_winding > 0);
+
+            // Sample
             let i1 = s_indices.data[face_index * 3 + 0];
             let i2 = s_indices.data[face_index * 3 + 1];
             let i3 = s_indices.data[face_index * 3 + 2];

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -150,7 +150,6 @@ def mesh_renderer(wobject, render_info):
             "vertex_shader": (wgsl, vs_entry_point),
             "fragment_shader": (wgsl, fs_entry_point),
             "primitive_topology": topology,
-            "front_face": getattr(wgpu.FrontFace, material.winding.lower()),
             "cull_mode": cull_mode,
             "indices": (range(n), range(n_instances)),
             "index_buffer": index_buffer,
@@ -248,9 +247,9 @@ class MeshShader(BaseShader):
             let face_index = index / 3;
             var sub_index = index % 3;
 
-            // If the camera flips a dimension, it reverses the face winding.
-            // We can correct for this by changing the winding (sub_index) here.
-            sub_index = select(sub_index, -1 * (sub_index - 1) + 1, u_stdinfo.flip_winding > 0);
+            // If the camera flips a dimension, it flips the face winding.
+            // We can correct for this by adjusting the order (sub_index) here.
+            sub_index = select(sub_index, -1 * (sub_index - 1) + 1, u_stdinfo.flipped_winding > 0);
 
             // Sample
             let i1 = s_indices.data[face_index * 3 + 0];

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -135,6 +135,14 @@ def mesh_renderer(wobject, render_info):
         bindings1[6] = "buffer/read_only_storage", wobject.matrices
         n_instances = wobject.matrices.nitems
 
+    # Determine culling
+    if material.side == "FRONT":
+        cull_mode = wgpu.CullMode.back
+    elif material.side == "BACK":
+        cull_mode = wgpu.CullMode.front
+    else:  # material.side == "BOTH"
+        cull_mode = wgpu.CullMode.none
+
     # Put it together!
     wgsl = shader.generate_wgsl()
     return [
@@ -142,6 +150,8 @@ def mesh_renderer(wobject, render_info):
             "vertex_shader": (wgsl, vs_entry_point),
             "fragment_shader": (wgsl, fs_entry_point),
             "primitive_topology": topology,
+            "front_face": getattr(wgpu.FrontFace, material.winding.lower()),
+            "cull_mode": cull_mode,
             "indices": (range(n), range(n_instances)),
             "index_buffer": index_buffer,
             "vertex_buffers": vertex_buffers,


### PR DESCRIPTION
Implements a part of #50. Closes #105.

* [x] Implements `MeshMaterial.side`.
* [x] Decide on what to do with a winding property vs assuming CCW.
* [x] Fixes lighting to use `fron_facing` builtin.
* [x] Check the winding of all geometries.
* [x] Fixes winding of torus know geometry.
* [x] Correct front_facing (for lighting) when the camera has an axis flipped.
* [x] Correct culling when the camera has an axis flipped?

![culling1](https://user-images.githubusercontent.com/3015475/133324535-178a77d0-f35c-43fb-a3c4-f9135705614c.gif)
