### PR TITLE
Rename index to vertex_index to prevent redefinition

### DIFF
--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -178,7 +178,7 @@ class MeshShader(BaseShader):
         return """
 
         struct VertexInput {
-            [[builtin(vertex_index)]] index : u32;
+            [[builtin(vertex_index)]] vertex_index : u32;
             $$ if instanced
             [[builtin(instance_index)]] instance_index : u32;
             $$ endif
@@ -246,7 +246,7 @@ class MeshShader(BaseShader):
         fn vs_main(in: VertexInput) -> VertexOutput {
 
             // Select what face we're at
-            let index = i32(in.index);
+            let index = i32(in.vertex_index);
             let face_index = index / 3;
             var sub_index = index % 3;
 
@@ -326,7 +326,7 @@ class MeshShader(BaseShader):
 
         [[stage(vertex)]]
         fn vs_normal_lines(in: VertexInput) -> VertexOutput {
-            let index = i32(in.index);
+            let index = i32(in.vertex_index);
             let r = index % 2;
             let i0 = (index - r) / 2;
 
@@ -583,7 +583,7 @@ class MeshSliceShader(BaseShader):
         return """
 
         struct VertexInput {
-            [[builtin(vertex_index)]] index : u32;
+            [[builtin(vertex_index)]] vertex_index : u32;
         };
         struct VertexOutput {
             [[location(0)]] dist2center: vec2<f32>;
@@ -635,7 +635,7 @@ class MeshSliceShader(BaseShader):
             let line_width = u_material.thickness;  // in logical pixels
 
             // Get the face index, and sample the vertex indices
-            let index = i32(in.index);
+            let index = i32(in.vertex_index);
             let segment_index = index % 6;
             let face_index = (index - segment_index) / 6;
             let i1 = s_indices.data[face_index * 3 + 0];


### PR DESCRIPTION
When running some of the examples with Metal backend I got an error about `index` already being defined. Renaming to `vertex_index` prevents this and makes sure that the shader compiles fine.

For completeness: here is the last bit from the stacktrace:

```
thread '<unnamed>' panicked at 'Internal { stage: VERTEX, error: "Metal: Compilation failed: 

program_source:175:9: error: redefinition of 'index' with a different type: 'int' vs 'metal::uint' (aka 'unsigned int')
    int index = static_cast<int>(in.index);
        ^
program_source:161:15: note: previous definition is here
  metal::uint index [[vertex_id]]
              ^
program_source:250:9: error: redefinition of 'index' with a different type: 'int' vs 'metal::uint' (aka 'unsigned int')
    int index = static_cast<int>(in1.index);
        ^
program_source:241:15: note: previous definition is here
  metal::uint index [[vertex_id]]
              ^
" }', src/device.rs:566:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
libc++abi: terminating with uncaught foreign exception
[1]    99943 abort      poetry run python examples/geometry_cube.py
```