### PR TITLE
Show utility

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,6 +8,6 @@ wheel
 twine
 
 # examples
-PyQt5
+PySide6
 imageio
 imageio-ffmpeg

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -103,7 +103,7 @@ If you run this, you should see a rotating yellow cube.
 
     import pygfx as gfx
 
-    from PyQt5 import QtWidgets
+    from PySide6 import QtWidgets
     from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/collection_line.py
+++ b/examples/collection_line.py
@@ -8,7 +8,7 @@ import numpy as np
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets, QtCore
+from PySide6 import QtWidgets, QtCore
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/custom_object.py
+++ b/examples/custom_object.py
@@ -2,7 +2,7 @@
 Example that implements a custom object and renders it.
 """
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 import pygfx as gfx

--- a/examples/cylinder.py
+++ b/examples/cylinder.py
@@ -5,7 +5,7 @@ Example showing different types of geometric cylinders.
 import numpy as np
 import pygfx as gfx
 
-from PyQt5 import QtWidgets, QtCore
+from PySide6 import QtWidgets, QtCore
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/flat_shaded_torus.py
+++ b/examples/flat_shaded_torus.py
@@ -4,7 +4,7 @@ Example showing a Torus knot, using flat shading.
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/geometry_cube.py
+++ b/examples/geometry_cube.py
@@ -6,7 +6,7 @@ import numpy as np
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/geometry_cubes.py
+++ b/examples/geometry_cubes.py
@@ -5,7 +5,7 @@ Example showing multiple rotating cubes. This also tests the depth buffer.
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/geometry_klein_bottle.py
+++ b/examples/geometry_klein_bottle.py
@@ -4,7 +4,7 @@ Example showing a Klein Bottle.
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/geometry_plane.py
+++ b/examples/geometry_plane.py
@@ -5,7 +5,7 @@ Use a plane geometry to show a texture, which is continuously updated to show vi
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/geometry_torus_knot.py
+++ b/examples/geometry_torus_knot.py
@@ -5,7 +5,7 @@ Example showing a Torus knot, with a texture and lighting.
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/image_plus_points.py
+++ b/examples/image_plus_points.py
@@ -5,7 +5,7 @@ Show an image with points overlaid.
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/instancing_mesh.py
+++ b/examples/instancing_mesh.py
@@ -6,7 +6,7 @@ import numpy as np
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/integration_qt.py
+++ b/examples/integration_qt.py
@@ -1,6 +1,6 @@
 import random
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 import pygfx as gfx

--- a/examples/line_basic.py
+++ b/examples/line_basic.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 app = QtWidgets.QApplication([])

--- a/examples/line_performance.py
+++ b/examples/line_performance.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 app = QtWidgets.QApplication([])

--- a/examples/line_segments.py
+++ b/examples/line_segments.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 app = QtWidgets.QApplication([])

--- a/examples/line_thick.py
+++ b/examples/line_thick.py
@@ -6,7 +6,7 @@ import random
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 app = QtWidgets.QApplication([])

--- a/examples/line_thin.py
+++ b/examples/line_thin.py
@@ -6,7 +6,7 @@ import numpy as np
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 app = QtWidgets.QApplication([])

--- a/examples/manual_matrix_update.py
+++ b/examples/manual_matrix_update.py
@@ -5,7 +5,7 @@ Example showing transform control flow without matrix auto updating.
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/mesh_slice.py
+++ b/examples/mesh_slice.py
@@ -4,7 +4,7 @@ Example showing off the mesh slice material.
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/multi_slice1.py
+++ b/examples/multi_slice1.py
@@ -10,7 +10,7 @@ import imageio
 import numpy as np
 import pygfx as gfx
 
-from PyQt5 import QtWidgets, QtCore
+from PySide6 import QtWidgets, QtCore
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/multi_slice2.py
+++ b/examples/multi_slice2.py
@@ -12,7 +12,7 @@ import numpy as np
 import pygfx as gfx
 from skimage.measure import marching_cubes
 
-from PyQt5 import QtWidgets, QtCore
+from PySide6 import QtWidgets, QtCore
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -5,7 +5,7 @@ Example showing orbit camera controls.
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets, QtCore
+from PySide6 import QtWidgets, QtCore
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -5,7 +5,7 @@ Example showing orbit camera controls.
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets, QtCore
+from PySide6 import QtWidgets, QtCore
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/picking_color_and_depth.py
+++ b/examples/picking_color_and_depth.py
@@ -9,7 +9,7 @@ import numpy as np
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/picking_mesh.py
+++ b/examples/picking_mesh.py
@@ -9,7 +9,7 @@ import numpy as np
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/picking_points.py
+++ b/examples/picking_points.py
@@ -6,7 +6,7 @@ is changed. With a small change, a line is shown instead.
 import numpy as np
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/points_basic.py
+++ b/examples/points_basic.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 app = QtWidgets.QApplication([])

--- a/examples/post_processing1.py
+++ b/examples/post_processing1.py
@@ -16,7 +16,7 @@ import numpy as np
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/post_processing2.py
+++ b/examples/post_processing2.py
@@ -13,7 +13,7 @@ import numpy as np
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/scene_in_a_scene.py
+++ b/examples/scene_in_a_scene.py
@@ -13,7 +13,7 @@ import numpy as np
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/scene_merge.py
+++ b/examples/scene_merge.py
@@ -15,7 +15,7 @@ complicated with the depth buffer values being between 0 and 1.
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/scene_overlay.py
+++ b/examples/scene_overlay.py
@@ -8,7 +8,7 @@ the overlay, so that it's always on top.
 import numpy as np
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/scene_side_by_side.py
+++ b/examples/scene_side_by_side.py
@@ -7,7 +7,7 @@ This is a feature necessary to implement e.g. subplots.
 import numpy as np
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/show_scene.py
+++ b/examples/show_scene.py
@@ -1,0 +1,33 @@
+"""
+Demonstrates show utility
+"""
+
+import imageio
+import pygfx as gfx
+
+scene = gfx.Scene()
+
+im = imageio.imread("imageio:chelsea.png")
+tex = gfx.Texture(im, dim=2).get_view(filter="linear")
+
+material = gfx.MeshBasicMaterial(map=tex, clim=(0, 255))
+geometry = gfx.BoxGeometry(100, 100, 100)
+cubes = [gfx.Mesh(geometry, material) for i in range(8)]
+for i, cube in enumerate(cubes):
+    cube.position.set(350 - i * 100, 0, 0)
+    scene.add(cube)
+
+background = gfx.Background(gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+scene.add(background)
+
+
+def animate():
+    for i, cube in enumerate(cubes):
+        rot = gfx.linalg.Quaternion().set_from_euler(
+            gfx.linalg.Euler(0.01 * i, 0.02 * i)
+        )
+        cube.rotation.multiply(rot)
+
+
+if __name__ == "__main__":
+    gfx.show(scene, animate)

--- a/examples/skybox.py
+++ b/examples/skybox.py
@@ -7,7 +7,7 @@ Inspired by https://github.com/gfx-rs/wgpu-rs/blob/master/examples/skybox/main.r
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 # Read the image

--- a/examples/text_with_qt.py
+++ b/examples/text_with_qt.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pygfx as gfx
 
-from PyQt5 import QtWidgets, QtCore, QtGui
+from PySide6 import QtWidgets, QtCore, QtGui
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/two_canvases.py
+++ b/examples/two_canvases.py
@@ -5,7 +5,7 @@ Example demonstrating rendering the same scene into two different canvases.
 import numpy as np
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/validate_culling.py
+++ b/examples/validate_culling.py
@@ -8,7 +8,7 @@ Example test to validate winding and culling.
 """
 
 import pygfx as gfx
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/validate_depth_clipping.py
+++ b/examples/validate_depth_clipping.py
@@ -8,7 +8,7 @@ rectangles near the near and far clipping planes.
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/validate_helpers1.py
+++ b/examples/validate_helpers1.py
@@ -9,7 +9,7 @@ Example showing the axes helper.
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/validate_helpers2.py
+++ b/examples/validate_helpers2.py
@@ -7,7 +7,7 @@ Example showing the axes and grid helpers with a perspective camera.
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/validate_image.py
+++ b/examples/validate_image.py
@@ -12,7 +12,7 @@ left.
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/validate_ndc.py
+++ b/examples/validate_ndc.py
@@ -7,7 +7,7 @@ Example (and test) for the NDC coordinates. Draws a square that falls partly out
 
 """
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 import pygfx as gfx

--- a/examples/volume_slice1.py
+++ b/examples/volume_slice1.py
@@ -6,7 +6,7 @@ Simple and ... slow.
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/volume_slice2.py
+++ b/examples/volume_slice2.py
@@ -6,7 +6,7 @@ Simple and relatively fast, but no subslices.
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/volume_slice3.py
+++ b/examples/volume_slice3.py
@@ -7,7 +7,7 @@ import imageio
 import numpy as np
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/volume_slice4.py
+++ b/examples/volume_slice4.py
@@ -6,7 +6,7 @@ it with a VolumeSliceMaterial. Easy because we can just define the view plane.
 import imageio
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/wireframe1.py
+++ b/examples/wireframe1.py
@@ -8,7 +8,7 @@ producing a look of a metalic frame around a soft tube.
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/examples/wireframe2.py
+++ b/examples/wireframe2.py
@@ -6,7 +6,7 @@ gray.
 
 import pygfx as gfx
 
-from PyQt5 import QtWidgets
+from PySide6 import QtWidgets
 from wgpu.gui.qt import WgpuCanvas
 
 

--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -9,8 +9,9 @@ from .materials import *
 from .cameras import *
 from .helpers import *
 from .controls import *
-
 from .renderers import *
+
+from .show import *
 
 
 __version__ = "0.1.2"

--- a/pygfx/show/__init__.py
+++ b/pygfx/show/__init__.py
@@ -1,0 +1,13 @@
+"""
+Quickly visualize scenes without any boilerplate.
+"""
+from .backends import get_backend
+from .loop import run
+
+
+__all__ = ("show",)
+
+
+def show(scene, animate=None, backend=None, interactive=True):
+    backend, canvas_cls, extras = get_backend(name=backend)
+    run(backend, canvas_cls, extras, scene, animate=animate, interactive=interactive)

--- a/pygfx/show/backends.py
+++ b/pygfx/show/backends.py
@@ -1,0 +1,27 @@
+import importlib
+
+
+BACKENDS_QT = ("PySide6", "PyQt6", "PySide2", "PyQt5", "PySide", "PyQt4")
+BACKENDS = ("qt", "wx", "glfw", "jupyter")
+
+
+def get_backend(name=None):
+    """Automatically detect which GUI layer and canvas can be used"""
+    backends = (name,) if name else BACKENDS
+    extras = None
+    for backend in backends:
+        try:
+            if backend == "qt":
+                for backend_qt in BACKENDS_QT:
+                    try:
+                        importlib.import_module(f"{backend_qt}.QtCore")
+                    except ImportError:
+                        pass
+            mod = importlib.import_module(f"wgpu.gui.{backend}")
+            canvas_cls = getattr(mod, "WgpuCanvas")
+            if backend == "qt":
+                extras = getattr(mod, "QtWidgets"), getattr(mod, "QtCore")
+            return backend, canvas_cls, extras
+        except (ImportError, AttributeError):
+            pass
+    raise ImportError("No compatible backend found")

--- a/pygfx/show/canvases.py
+++ b/pygfx/show/canvases.py
@@ -1,0 +1,48 @@
+"""This can probably be written much more cleanly..."""
+
+
+def get_interactive_canvas_cls(backend, app, controls, camera, canvas_cls, extras):
+    if backend == "qt":
+        _, QtCore = extras  # noqa: N806
+
+        class WgpuCanvasWithInputEvents(canvas_cls):
+            _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
+            _mode = None
+
+            def wheelEvent(self, event):  # noqa: N802
+                controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
+
+            def mousePressEvent(self, event):  # noqa: N802
+                mode = self._drag_modes.get(event.button(), None)
+                if self._mode or not mode:
+                    return
+                self._mode = mode
+                drag_start = (
+                    controls.pan_start if self._mode == "pan" else controls.rotate_start
+                )
+                drag_start((event.x(), event.y()), self.get_logical_size(), camera)
+                app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
+
+            def mouseReleaseEvent(self, event):  # noqa: N802
+                if self._mode and self._mode == self._drag_modes.get(
+                    event.button(), None
+                ):
+                    self._mode = None
+                    drag_stop = (
+                        controls.pan_stop
+                        if self._mode == "pan"
+                        else controls.rotate_stop
+                    )
+                    drag_stop()
+                    app.restoreOverrideCursor()
+
+            def mouseMoveEvent(self, event):  # noqa: N802
+                if self._mode is not None:
+                    drag_move = (
+                        controls.pan_move
+                        if self._mode == "pan"
+                        else controls.rotate_move
+                    )
+                    drag_move((event.x(), event.y()))
+
+    return WgpuCanvasWithInputEvents

--- a/pygfx/show/loop.py
+++ b/pygfx/show/loop.py
@@ -1,0 +1,47 @@
+"""
+Short utilities to quickly visualize scenes without any boilerplate.
+"""
+from ..renderers import WgpuRenderer
+from ..cameras import PerspectiveCamera
+from ..controls import OrbitControls
+
+from .canvases import get_interactive_canvas_cls
+
+
+def run(backend, canvas_cls, extras, scene, animate=None, interactive=True):
+    """
+    Render a given scene and optional animate callback in the given backend GUI layer
+    """
+    if backend == "qt":
+        QtWidgets, _ = extras  # noqa: N806
+        app = QtWidgets.QApplication([])
+
+    camera = PerspectiveCamera(70, 16 / 9)
+    camera.position.z = 500
+    controls = None
+
+    if interactive:
+        controls = OrbitControls(camera.position.clone())
+        canvas_cls = get_interactive_canvas_cls(
+            backend,
+            app,
+            controls,
+            camera,
+            canvas_cls,
+            extras,
+        )
+
+    canvas = canvas_cls()
+    renderer = WgpuRenderer(canvas)
+
+    def _animate():
+        animate()
+        if controls:
+            controls.update_camera(camera)
+        renderer.render(scene, camera)
+        canvas.request_draw()
+
+    canvas.request_draw(_animate)
+
+    if backend == "qt":
+        app.exec_()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,4 @@
 [flake8]
 max_line_length = 88
 extend-ignore = E203, E501, F821, E231, F722, F541, D
-exclude = build,dist,*.egg-info
+exclude = build,dist,*.egg-info,.venv


### PR DESCRIPTION
This adds `gfx.show(scene, animate=None, backend=None, interactive=True)` which will attempt to show the scene using any available GUI layer, creating its own camera, controls, and event loop.

See the added `examples\show_scene.py` for a demonstration, and the `pygfx\show` subpackage for the code.

Note: it's not particularly clean and only supports Qt for now, but it works. It would be great if this also works in jupyter.

The main purpose is to just provide a very quick way to "get something on screen". This idea can be taken further, for example:

* provide a filename instead of a scene and the scene is also created automatically (simple model viewer)
* add picking and display properties on screen about clicked elements
* etc

I also switched all examples over to PySide6 since PyQt5 is superseded.