### PR TITLE
Fix compilation error follow up

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,3 +11,4 @@ twine
 PyQt5
 imageio
 imageio-ffmpeg
+scikit-image

--- a/pygfx/renderers/wgpu/pointsrender.py
+++ b/pygfx/renderers/wgpu/pointsrender.py
@@ -70,7 +70,7 @@ class PointsShader(BaseShader):
         return """
 
         struct VertexInput {
-            [[builtin(vertex_index)]] index : u32;
+            [[builtin(vertex_index)]] vertex_index : u32;
         };
         struct VertexOutput {
             [[location(0)]] pointcoord: vec2<f32>;
@@ -100,7 +100,7 @@ class PointsShader(BaseShader):
         fn vs_main(in: VertexInput) -> VertexOutput {
             var out: VertexOutput;
 
-            let index = i32(in.index);
+            let index = i32(in.vertex_index);
             let i0 = index / 6;
             let sub_index = index % 6;
 

--- a/pygfx/renderers/wgpu/volumerender.py
+++ b/pygfx/renderers/wgpu/volumerender.py
@@ -97,7 +97,7 @@ class VolumeSliceShader(BaseShader):
         return """
 
         struct VertexInput {
-            [[builtin(vertex_index)]] index : u32;
+            [[builtin(vertex_index)]] vertex_index : u32;
         };
         struct VertexOutput {
             [[location(0)]] texcoord: vec3<f32>;
@@ -197,10 +197,10 @@ class VolumeSliceShader(BaseShader):
                     s_positions.data[edge[1] * 3 + 1],
                     s_positions.data[edge[1] * 3 + 2],
                 );
-                let p1_ = u_wobject.world_transform * vec4<f32>(p1_raw, 1.0);
-                let p2_ = u_wobject.world_transform * vec4<f32>(p2_raw, 1.0);
-                let p1 = p1_.xyz / p1_.w;
-                let p2 = p2_.xyz / p2_.w;
+                let p1_p = u_wobject.world_transform * vec4<f32>(p1_raw, 1.0);
+                let p2_p = u_wobject.world_transform * vec4<f32>(p2_raw, 1.0);
+                let p1 = p1_p.xyz / p1_p.w;
+                let p2 = p2_p.xyz / p2_p.w;
                 let tc1 = vec3<f32>(
                     s_texcoords.data[edge[0] * 3],
                     s_texcoords.data[edge[0] * 3 + 1],
@@ -285,7 +285,7 @@ class VolumeSliceShader(BaseShader):
 
             // Now select the current vertex. We mimic a triangle fan with a triangle list.
             // This works whether the number of vertices/intersections is 3, 4, 5, and 6.
-            let index = i32(in.index);
+            let index = i32(in.vertex_index);
             var indexmap = array<i32,12>(0, 1, 2, 0, 2, 3, 0, 3, 4, 0, 4, 5);
             let world_pos = vertices[ indexmap[index] ];
             let ndc_pos = u_stdinfo.projection_transform * u_stdinfo.cam_transform * vec4<f32>(world_pos, 1.0);


### PR DESCRIPTION
This is a follow up on #139 to make sure (most) examples now also work on Metal, by renaming some variables. We should probably follow up on Almar's suggestion that this could be a bug in Naga's shader generation.

Bonus: added scikit-image to list of example dependencies