### PR TITLE
Shader annotate uniform

### DIFF
--- a/pygfx/renderers/wgpu/_shadercomposer.py
+++ b/pygfx/renderers/wgpu/_shadercomposer.py
@@ -132,7 +132,7 @@ class BaseShader:
         }};
 
         [[group({bindgroup}), binding({index})]]
-        var {name}: {structname};
+        var<uniform> {name}: {structname};
         """
         self._uniform_codes[name] = code
 

--- a/tests/renderers/test_shader_composer.py
+++ b/tests/renderers/test_shader_composer.py
@@ -65,7 +65,7 @@ def test_uniform_definitions():
         };
 
         [[group(0), binding(0)]]
-        var zz: Struct_zz;
+        var<uniform> zz: Struct_zz;
     """.strip()
     )
 
@@ -82,7 +82,7 @@ def test_uniform_definitions():
         };
 
         [[group(0), binding(0)]]
-        var zz: Struct_zz;
+        var<uniform> zz: Struct_zz;
     """.strip()
     )
 
@@ -99,7 +99,7 @@ def test_uniform_definitions():
         };
 
         [[group(0), binding(0)]]
-        var zz: Struct_zz;
+        var<uniform> zz: Struct_zz;
     """.strip()
     )
 


### PR DESCRIPTION
This change is required with the new (upcoming) Naga (and already works with what we currently use).