### PR TITLE
Clipping planes intersect option

### DIFF
--- a/examples/clipping_planes.py
+++ b/examples/clipping_planes.py
@@ -52,7 +52,7 @@ renderer = gfx.renderers.WgpuRenderer(canvas)
 # Compose two of the same scenes
 
 
-def create_scene(clipping_planes, intersect):
+def create_scene(clipping_planes, clipping_mode):
 
     maxsize = 221
     scene = gfx.Scene()
@@ -60,7 +60,7 @@ def create_scene(clipping_planes, intersect):
         material = gfx.MeshPhongMaterial(
             color=(n / maxsize, 1, 0, 1),
             clipping_planes=clipping_planes,
-            clip_intersection=intersect,
+            clipping_mode=clipping_mode,
         )
         geometry = gfx.BoxGeometry(n, n, n)
         cube = gfx.Mesh(geometry, material)
@@ -70,8 +70,8 @@ def create_scene(clipping_planes, intersect):
 
 
 clipping_planes = [(-1, 0, 0, 0), (0, 0, -1, 0)]
-scene1 = create_scene(clipping_planes, False)
-scene2 = create_scene(clipping_planes, True)
+scene1 = create_scene(clipping_planes, "any")
+scene2 = create_scene(clipping_planes, "all")
 
 camera = gfx.PerspectiveCamera(70, 16 / 9)
 camera.position.z = 250

--- a/examples/clipping_planes.py
+++ b/examples/clipping_planes.py
@@ -1,0 +1,96 @@
+"""
+Example demonstrating clipping planes on a mesh.
+"""
+
+import pygfx as gfx
+
+from PyQt5 import QtWidgets, QtCore
+from wgpu.gui.qt import WgpuCanvas
+
+
+class WgpuCanvasWithInputEvents(WgpuCanvas):
+    _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
+    _mode = None
+
+    def wheelEvent(self, event):  # noqa: N802
+        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
+
+    def mousePressEvent(self, event):  # noqa: N802
+        mode = self._drag_modes.get(event.button(), None)
+        if self._mode or not mode:
+            return
+        self._mode = mode
+        drag_start = (
+            controls.pan_start if self._mode == "pan" else controls.rotate_start
+        )
+        drag_start((event.x(), event.y()), self.get_logical_size(), camera)
+        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
+
+    def mouseReleaseEvent(self, event):  # noqa: N802
+        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
+            self._mode = None
+            drag_stop = (
+                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
+            )
+            drag_stop()
+            app.restoreOverrideCursor()
+
+    def mouseMoveEvent(self, event):  # noqa: N802
+        if self._mode is not None:
+            drag_move = (
+                controls.pan_move if self._mode == "pan" else controls.rotate_move
+            )
+            drag_move((event.x(), event.y()))
+
+
+# Create a canvas and a renderer
+
+app = QtWidgets.QApplication([])
+canvas = WgpuCanvasWithInputEvents(size=(800, 400))
+renderer = gfx.renderers.WgpuRenderer(canvas)
+
+# Compose two of the same scenes
+
+
+def create_scene(clipping_planes, intersect):
+
+    maxsize = 221
+    scene = gfx.Scene()
+    for n in range(20, maxsize, 50):
+        material = gfx.MeshPhongMaterial(
+            color=(n / maxsize, 1, 0, 1),
+            clipping_planes=clipping_planes,
+            clip_intersection=intersect,
+        )
+        geometry = gfx.BoxGeometry(n, n, n)
+        cube = gfx.Mesh(geometry, material)
+        scene.add(cube)
+
+    return scene
+
+
+clipping_planes = [(-1, 0, 0, 0), (0, 0, -1, 0)]
+scene1 = create_scene(clipping_planes, False)
+scene2 = create_scene(clipping_planes, True)
+
+camera = gfx.PerspectiveCamera(70, 16 / 9)
+camera.position.z = 250
+
+controls = gfx.OrbitControls(camera.position.clone())
+
+
+def animate():
+
+    controls.update_camera(camera)
+
+    w, h = canvas.get_logical_size()
+    renderer.render(scene1, camera, flush=False, viewport=(0, 0, w / 2, h))
+    renderer.render(scene2, camera, flush=False, viewport=(w / 2, 0, w / 2, h))
+    renderer.flush()
+
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec_()

--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -13,7 +13,7 @@ class Material(ResourceContainer):
         clipping_planes=("float32", (0, 1, 4)),  # array<vec4<f32>,3>
     )
 
-    def __init__(self, *, opacity=1):
+    def __init__(self, *, opacity=1, clipping_planes=None, clip_intersection=False):
         super().__init__()
 
         self.uniform_buffer = Buffer(
@@ -21,6 +21,8 @@ class Material(ResourceContainer):
         )
 
         self.opacity = opacity
+        self.clipping_planes = clipping_planes or []
+        self.clip_intersection = clip_intersection
 
     def _set_size_of_uniform_array(self, key, new_length):
         """Resize the given array field in the uniform struct if the
@@ -116,4 +118,17 @@ class Material(ResourceContainer):
             self.uniform_buffer.data["clipping_planes"][i] = planes2[i]
         self.uniform_buffer.update_range(0, 1)
 
-    # todo: clip_intersection
+    @property
+    def clip_intersection(self):
+        """Changes the behavior of clipping planes so that only their
+        intersection is clipped, rather than their union. Default is false.
+        In other words: by default a fragment is visible if it satisfies all
+        clipping planes. With this set to True, it is visible if it satisfies any
+        of the clipping planes.
+        """
+        return self._clip_intersection
+
+    @clip_intersection.setter
+    def clip_intersection(self, value):
+        self._clip_intersection = bool(value)
+        self._bump_rev()

--- a/pygfx/renderers/wgpu/_shadercomposer.py
+++ b/pygfx/renderers/wgpu/_shadercomposer.py
@@ -144,7 +144,7 @@ class WorldObjectShader(BaseShader):
         super().__init__(**kwargs)
 
         self.kwargs["n_clipping_planes"] = len(wobject.material.clipping_planes)
-        self.kwargs["clip_intersection"] = wobject.material.clip_intersection
+        self.kwargs["clipping_mode"] = wobject.material.clipping_mode
 
     def common_functions(self):
 
@@ -155,11 +155,11 @@ class WorldObjectShader(BaseShader):
         else:
             clipping_plane_code = """
             fn apply_clipping_planes(world_pos: vec3<f32>) {
-                var clipped: bool = {{ 'true' if clip_intersection else 'false' }};
+                var clipped: bool = {{ 'false' if clipping_mode == 'ANY' else 'true' }};
                 for (var i=0; i<{{ n_clipping_planes }}; i=i+1) {
                     let plane = u_material.clipping_planes[i];
                     let plane_clipped = dot( world_pos, plane.xyz ) < plane.w;
-                    clipped = clipped {{ '&&' if clip_intersection else '||' }} plane_clipped;
+                    clipped = clipped {{ '||' if clipping_mode == 'ANY' else '&&' }} plane_clipped;
                 }
                 if (clipped) { discard; }
             }

--- a/pygfx/renderers/wgpu/backgroundrender.py
+++ b/pygfx/renderers/wgpu/backgroundrender.py
@@ -1,7 +1,7 @@
 import wgpu  # only for flags/enums
 
 from . import register_wgpu_render_function
-from ._shadercomposer import BaseShader
+from ._shadercomposer import WorldObjectShader
 from ...objects import Background
 from ...materials import BackgroundMaterial, BackgroundImageMaterial
 from ...resources import Texture, TextureView
@@ -11,7 +11,7 @@ from ...resources import Texture, TextureView
 def background_renderer(wobject, render_info):
 
     material = wobject.material
-    shader = BackgroundShader(texture_dim="")
+    shader = BackgroundShader(wobject, texture_dim="")
 
     bindings0 = {
         0: ("buffer/uniform", render_info.stdinfo_uniform),
@@ -62,7 +62,7 @@ def background_renderer(wobject, render_info):
     ]
 
 
-class BackgroundShader(BaseShader):
+class BackgroundShader(WorldObjectShader):
     def get_code(self):
         return (
             self.get_definitions()

--- a/pygfx/renderers/wgpu/linerender.py
+++ b/pygfx/renderers/wgpu/linerender.py
@@ -1,7 +1,7 @@
 import wgpu  # only for flags/enums
 
 from . import register_wgpu_render_function
-from ._shadercomposer import BaseShader
+from ._shadercomposer import WorldObjectShader
 from ...utils import array_from_shadertype
 from ...resources import Buffer
 from ...objects import Line
@@ -47,7 +47,7 @@ def line_renderer(wobject, render_info):
 
     material = wobject.material
     geometry = wobject.geometry
-    shader = LineShader()
+    shader = LineShader(wobject)
 
     assert isinstance(material, LineMaterial)
 
@@ -127,7 +127,7 @@ def line_renderer(wobject, render_info):
     ]
 
 
-class LineShader(BaseShader):
+class LineShader(WorldObjectShader):
     def get_code(self):
         return (
             self.get_definitions()
@@ -527,7 +527,7 @@ def thin_line_renderer(wobject, render_info):
 
     material = wobject.material
     geometry = wobject.geometry
-    shader = ThinLineShader()
+    shader = ThinLineShader(wobject)
 
     positions1 = geometry.positions
 
@@ -570,7 +570,7 @@ def thin_line_renderer(wobject, render_info):
     ]
 
 
-class ThinLineShader(BaseShader):
+class ThinLineShader(WorldObjectShader):
     def get_code(self):
         return (
             self.get_definitions()

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -1,7 +1,7 @@
 import wgpu  # only for flags/enums
 
 from . import register_wgpu_render_function
-from ._shadercomposer import BaseShader
+from ._shadercomposer import WorldObjectShader
 from ...objects import Mesh, InstancedMesh
 from ...materials import (
     MeshBasicMaterial,
@@ -24,6 +24,8 @@ def mesh_renderer(wobject, render_info):
     # Initialize
     topology = wgpu.PrimitiveTopology.triangle_list
     shader = MeshShader(
+        wobject,
+        clip_intersection=material.clip_intersection,
         lighting="",
         need_normals=False,
         texture_dim="",
@@ -169,7 +171,7 @@ def mesh_renderer(wobject, render_info):
     ]
 
 
-class MeshShader(BaseShader):
+class MeshShader(WorldObjectShader):
     def get_code(self):
         return (
             self.get_definitions()
@@ -572,7 +574,7 @@ def meshslice_renderer(wobject, render_info):
 
     # Initialize
     topology = wgpu.PrimitiveTopology.triangle_list
-    shader = MeshSliceShader()
+    shader = MeshSliceShader(wobject)
     vs_entry_point = "vs_main"
     fs_entry_point = "fs_main"
 
@@ -613,7 +615,7 @@ def meshslice_renderer(wobject, render_info):
     ]
 
 
-class MeshSliceShader(BaseShader):
+class MeshSliceShader(WorldObjectShader):
     def get_code(self):
         return (
             self.get_definitions()

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -25,7 +25,6 @@ def mesh_renderer(wobject, render_info):
     topology = wgpu.PrimitiveTopology.triangle_list
     shader = MeshShader(
         wobject,
-        clip_intersection=material.clip_intersection,
         lighting="",
         need_normals=False,
         texture_dim="",

--- a/pygfx/renderers/wgpu/pointsrender.py
+++ b/pygfx/renderers/wgpu/pointsrender.py
@@ -1,7 +1,7 @@
 import wgpu  # only for flags/enums
 
 from . import register_wgpu_render_function
-from ._shadercomposer import BaseShader
+from ._shadercomposer import WorldObjectShader
 from ...objects import Points
 from ...materials import PointsMaterial, GaussianPointsMaterial
 
@@ -12,7 +12,7 @@ def points_renderer(wobject, render_info):
 
     geometry = wobject.geometry
     material = wobject.material
-    shader = PointsShader(type="circle")
+    shader = PointsShader(wobject, type="circle")
     n = geometry.positions.nitems * 6
 
     shader.define_uniform(0, 0, "u_stdinfo", render_info.stdinfo_uniform.data.dtype)
@@ -48,7 +48,7 @@ def points_renderer(wobject, render_info):
     ]
 
 
-class PointsShader(BaseShader):
+class PointsShader(WorldObjectShader):
 
     # Notes:
     # In WGPU, the pointsize attribute can no longer be larger than 1 because

--- a/pygfx/renderers/wgpu/volumerender.py
+++ b/pygfx/renderers/wgpu/volumerender.py
@@ -1,7 +1,7 @@
 import wgpu  # only for flags/enums
 
 from . import register_wgpu_render_function
-from ._shadercomposer import BaseShader
+from ._shadercomposer import WorldObjectShader
 from ...objects import Volume
 from ...materials import VolumeSliceMaterial
 from ...resources import Texture, TextureView
@@ -13,7 +13,7 @@ def volume_slice_renderer(wobject, render_info):
 
     geometry = wobject.geometry
     material = wobject.material  # noqa
-    shader = VolumeSliceShader(climcorrection=False)
+    shader = VolumeSliceShader(wobject, climcorrection=False)
 
     shader.define_uniform(0, 0, "u_stdinfo", render_info.stdinfo_uniform.data.dtype)
     shader.define_uniform(0, 1, "u_wobject", wobject.uniform_buffer.data.dtype)
@@ -83,7 +83,7 @@ def volume_slice_renderer(wobject, render_info):
     ]
 
 
-class VolumeSliceShader(BaseShader):
+class VolumeSliceShader(WorldObjectShader):
     def get_code(self):
         return (
             self.get_definitions()


### PR DESCRIPTION
Adds `Material.clip_intersection`. Builds further on #124. Closes #131. I also looked into doing the clip logic in the vertex shader, but found out that we can't (see https://github.com/vispy/vispy/issues/2225).

Also adds a clipping planes example:

![image](https://user-images.githubusercontent.com/3015475/135465534-e1d202e5-22b2-4a83-b8eb-280fb138f192.png)
