### PR TITLE
Colormappable meshes

### DIFF
--- a/examples/colormap_channels.py
+++ b/examples/colormap_channels.py
@@ -1,0 +1,67 @@
+"""
+Example demonstrating colormaps in 4 modes: grayscale, gray+alpha, RGB, RGBA.
+"""
+
+import pygfx as gfx
+import numpy as np
+
+from PyQt5 import QtWidgets
+from wgpu.gui.qt import WgpuCanvas
+
+
+app = QtWidgets.QApplication([])
+
+canvas = WgpuCanvas(size=(900, 400))
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+geometry = gfx.TorusKnotGeometry(1, 0.3, 128, 32)
+geometry.texcoords = gfx.Buffer(geometry.texcoords.data[:, 0], usage="vertex|storage")
+
+camera = gfx.OrthographicCamera(16, 3)
+
+
+def create_object(tex, xpos):
+    material = gfx.MeshPhongMaterial(map=tex, clim=(-0.05, 1))
+    obj = gfx.Mesh(geometry, material)
+    obj.position.x = xpos
+    scene.add(obj)
+
+
+# === 1-channel colormap: grayscale
+
+cmap1 = np.array([(1,), (0,), (0,), (1,)], np.float32)
+tex1 = gfx.Texture(cmap1, dim=1).get_view(filter="linear")
+create_object(tex1, -6)
+
+# ==== 2-channel colormap: grayscale + alpha
+
+cmap2 = np.array([(1, 1), (0, 1), (0, 0), (1, 0)], np.float32)
+tex1 = gfx.Texture(cmap2, dim=1).get_view(filter="linear")
+create_object(tex1, -2)
+
+# === 3-channel colormap: RGB
+
+cmap3 = np.array([(1, 1, 0), (0, 1, 0), (0, 1, 0), (1, 1, 0)], np.float32)
+tex1 = gfx.Texture(cmap3, dim=1).get_view(filter="linear")
+create_object(tex1, +2)
+
+# === 4-channel colormap: RGBA
+
+cmap4 = np.array([(1, 1, 0, 1), (0, 1, 0, 1), (0, 1, 0, 0), (1, 1, 0, 0)], np.float32)
+tex1 = gfx.Texture(cmap4, dim=1).get_view(filter="linear")
+create_object(tex1, +6)
+
+
+def animate():
+    rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.0071, 0.01))
+    for obj in scene.children:
+        obj.rotation.multiply(rot)
+
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec_()

--- a/examples/colormap_mesh.py
+++ b/examples/colormap_mesh.py
@@ -1,0 +1,114 @@
+"""
+Example demonstrating different colormap dimensions on a mesh.
+"""
+
+import pygfx as gfx
+import numpy as np
+import imageio
+
+from PyQt5 import QtWidgets
+from wgpu.gui.qt import WgpuCanvas
+
+
+app = QtWidgets.QApplication([])
+
+canvas = WgpuCanvas(size=(900, 400))
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+geometry = gfx.TorusKnotGeometry(1, 0.3, 128, 32)
+
+camera = gfx.OrthographicCamera(16, 3)
+
+
+def create_object(texcoords, tex, xpos):
+    geometry = gfx.TorusKnotGeometry(1, 0.3, 128, 32)
+    geometry.texcoords = gfx.Buffer(texcoords, usage="vertex|storage")
+    material = gfx.MeshPhongMaterial(map=tex, clim=(-0.05, 1))
+    obj = gfx.Mesh(geometry, material)
+    obj.position.x = xpos
+    scene.add(obj)
+
+
+# === 1D colormap
+#
+# For the 1D texcoords we use the first dimension of the default
+# texcoords, which runs along the tube. The 1D colormap runs from yellow
+# to green to red and back to yellow.
+
+texcoords1 = geometry.texcoords.data[:, 0].copy()
+
+cmap1 = np.array([(1, 1, 0, 1), (0, 1, 0, 1), (1, 0, 0, 1), (1, 1, 0, 1)], np.float32)
+tex1 = gfx.Texture(cmap1, dim=1).get_view(filter="linear")
+
+create_object(texcoords1, tex1, -6)
+
+# === 2D colormap
+#
+# For the 2D texcoords we use the default texcoords, but multiply the
+# first dimension so that the texture that we apply is repeated. For
+# the 2D colormap we use an image texture.
+
+texcoords2 = geometry.texcoords.data.copy()
+texcoords2[:, 0] *= 10
+
+cmap2 = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
+tex2 = gfx.Texture(cmap2, dim=2).get_view(address_mode="repeat")
+
+create_object(texcoords2, tex2, -2)
+
+
+# === 3D colormap
+#
+# For the 3D texcoords we use (a scaled version of) the positions. For
+# the colormap we use a volume (a 3D image). In effect, the edge of the
+# mesh gets a color that corresponds to the value of the volume at that
+# position. This can be seen as a specific (maybe somewhat odd) type
+# of volume rendering.
+
+texcoords3 = geometry.positions.data * 0.5 + 0.5
+
+cmap3 = imageio.volread("imageio:stent.npz")
+tex3 = gfx.Texture(cmap3, dim=3).get_view()
+
+create_object(texcoords3, tex3, +2)
+
+
+# === Per vertex coloring
+#
+# To specify a color for each vertex, we also use 3D texture coordinates.
+# In this case we use the normals (a normal in the x direction would be red).
+# To make this work, we use a 3D colormap that represents an RGB color cube.
+
+texcoords4 = geometry.normals.data * 0.4 + 0.5
+
+cmap4 = np.array(
+    [
+        [
+            [(0, 0, 0, 1), (1, 0, 0, 1)],
+            [(0, 1, 0, 1), (1, 1, 0, 1)],
+        ],
+        [
+            [(0, 0, 1, 1), (1, 0, 1, 1)],
+            [(0, 1, 1, 1), (1, 1, 1, 1)],
+        ],
+    ],
+    np.float32,
+)
+tex4 = gfx.Texture(cmap4, dim=3).get_view()
+
+create_object(texcoords4, tex4, +6)
+
+
+def animate():
+    rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.0071, 0.01))
+    for obj in scene.children:
+        obj.rotation.multiply(rot)
+
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec_()

--- a/examples/colormap_mesh.py
+++ b/examples/colormap_mesh.py
@@ -16,13 +16,13 @@ canvas = WgpuCanvas(size=(900, 400))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-geometry = gfx.TorusKnotGeometry(1, 0.3, 128, 32)
 
-camera = gfx.OrthographicCamera(16, 3)
+def get_geometry():
+    return gfx.CylinderGeometry(height=2, radial_segments=32, open_ended=True)
 
 
 def create_object(texcoords, tex, xpos):
-    geometry = gfx.TorusKnotGeometry(1, 0.3, 128, 32)
+    geometry = get_geometry()
     geometry.texcoords = gfx.Buffer(texcoords, usage="vertex|storage")
     material = gfx.MeshPhongMaterial(map=tex, clim=(-0.05, 1))
     obj = gfx.Mesh(geometry, material)
@@ -30,27 +30,30 @@ def create_object(texcoords, tex, xpos):
     scene.add(obj)
 
 
+geometry = get_geometry()
+
+camera = gfx.OrthographicCamera(16, 3)
+
+
 # === 1D colormap
 #
-# For the 1D texcoords we use the first dimension of the default
-# texcoords, which runs along the tube. The 1D colormap runs from yellow
-# to green to red and back to yellow.
+# For the 1D texcoords we use the second dimension of the default
+# texcoords, which runs from the top to the bottom of the cylinder. The
+# 1D colormap runs from yellow to cyan.
 
-texcoords1 = geometry.texcoords.data[:, 0].copy()
+texcoords1 = geometry.texcoords.data[:, 1].copy()
 
-cmap1 = np.array([(1, 1, 0, 1), (0, 1, 0, 1), (1, 0, 0, 1), (1, 1, 0, 1)], np.float32)
+cmap1 = np.array([(1, 1, 0), (0, 1, 1)], np.float32)
 tex1 = gfx.Texture(cmap1, dim=1).get_view(filter="linear")
 
 create_object(texcoords1, tex1, -6)
 
 # === 2D colormap
 #
-# For the 2D texcoords we use the default texcoords, but multiply the
-# first dimension so that the texture that we apply is repeated. For
-# the 2D colormap we use an image texture.
+# For the 2D texcoords we use the default texcoords. For the 2D colormap
+# we use an image texture.
 
 texcoords2 = geometry.texcoords.data.copy()
-texcoords2[:, 0] *= 10
 
 cmap2 = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
 tex2 = gfx.Texture(cmap2, dim=2).get_view(address_mode="repeat")
@@ -66,9 +69,9 @@ create_object(texcoords2, tex2, -2)
 # position. This can be seen as a specific (maybe somewhat odd) type
 # of volume rendering.
 
-texcoords3 = geometry.positions.data * 0.5 + 0.5
+texcoords3 = geometry.positions.data * 0.4 + 0.5
 
-cmap3 = imageio.volread("imageio:stent.npz")
+cmap3 = imageio.volread("imageio:stent.npz").astype(np.float32) / 2000
 tex3 = gfx.Texture(cmap3, dim=3).get_view()
 
 create_object(texcoords3, tex3, +2)
@@ -85,12 +88,12 @@ texcoords4 = geometry.normals.data * 0.4 + 0.5
 cmap4 = np.array(
     [
         [
-            [(0, 0, 0, 1), (1, 0, 0, 1)],
-            [(0, 1, 0, 1), (1, 1, 0, 1)],
+            [(0, 0, 0), (1, 0, 0)],
+            [(0, 1, 0), (1, 1, 0)],
         ],
         [
-            [(0, 0, 1, 1), (1, 0, 1, 1)],
-            [(0, 1, 1, 1), (1, 1, 1, 1)],
+            [(0, 0, 1), (1, 0, 1)],
+            [(0, 1, 1), (1, 1, 1)],
         ],
     ],
     np.float32,

--- a/pygfx/geometries/_toroidal.py
+++ b/pygfx/geometries/_toroidal.py
@@ -161,6 +161,7 @@ class TorusKnotGeometry(Geometry):
         normals = positions - pos
         positions.shape = -1, 3
         normals.shape = -1, 3
+        normals *= 1 / np.linalg.norm(normals, axis=1).reshape(-1, 1)
 
         # Create texcords
         # ty, tx = np.meshgrid(u / u[-1], v / v[-1])

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -114,12 +114,7 @@ def mesh_renderer(wobject, render_info):
         else:
             shader["texture_format"] = "i32"
         # Channels
-        if material.map.format.startswith("rgb"):  # rgb maps to rgba
-            shader["texture_color"] = True
-        elif material.map.format.startswith("r"):
-            shader["texture_color"] = False
-        else:
-            raise ValueError("Unexpected texture format")
+        shader["texture_nchannels"] = material.map.texture.nchannels
 
     # Collect texture and sampler
     if isinstance(material, MeshNormalMaterial):
@@ -438,8 +433,10 @@ class MeshShader(WorldObjectShader):
                 $$ if climcorrection
                     color_value = vec4<f32>(color_value.rgb {{ climcorrection }}, color_value.a);
                 $$ endif
-                $$ if not texture_color
-                    color_value = color_value.rrra;
+                $$ if texture_nchannels == 1
+                    color_value = vec4<f32>(color_value.rrr, 1.0);
+                $$ elif texture_nchannels == 2
+                    color_value = vec4<f32>(color_value.rrr, color_value.g);
                 $$ endif
                 let albeido = (color_value.rgb - u_material.clim[0]) / (u_material.clim[1] - u_material.clim[0]);
             $$ else

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -86,14 +86,22 @@ def mesh_renderer(wobject, render_info):
         bindings1[4] = "sampler/filtering", material.map
         bindings1[5] = "texture/auto", material.map
         # Dimensionality
-        if material.map.view_dim == "1d":
+        view_dim = material.map.view_dim
+        if view_dim == "1d":
             shader["texture_dim"] = "1d"
-        elif material.map.view_dim == "2d":
+        elif view_dim == "2d":
             shader["texture_dim"] = "2d"
-        elif material.map.view_dim == "3d":
+        elif view_dim == "3d":
             shader["texture_dim"] = "3d"
         else:
             raise ValueError("Unexpected texture dimension")
+        # Texture dim matches texcoords
+        if view_dim == "1d" and "x" not in geometry.texcoords.format:
+            pass
+        elif not geometry.texcoords.format.endswith("x" + view_dim[0]):
+            raise ValueError(
+                f"geometry.texcoords {geometry.texcoords.format} does not match material.map {view_dim}"
+            )
         # Sampling type
         if "norm" in material.map.format or "float" in material.map.format:
             shader["texture_format"] = "f32"

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -133,6 +133,12 @@ class Texture(Resource):
         else:
             raise ValueError("Texture has no data nor format.")
 
+    @property
+    def nchannels(self):
+        """The number of (color) channels (1, 2, 3 or 4)."""
+        format = self.format
+        return len(format) - len(format.lstrip("rgba"))
+
     def update_range(self, offset, size):
         """Mark a certain range of the data for upload to the GPU.
         The offset and (sub) size should be (width, height, depth)


### PR DESCRIPTION
Implements #104 for meshes. The mesh material already had support of ND colormaps, so this is just a few tweaks and adding an example. Will add support for lines etc. in subsequent PR's.

* [x] Support for 1D, 2D, and 3D colormapping on Mesh. Was already implemented.
* [x] Add a check for matching map and texcoords. 
* [x] Fixed that 2-channel colors are interpreted as gray+alpha. 
* [x] Added two examples.

----
Example output: 

![image](https://user-images.githubusercontent.com/3015475/135749225-089a2f4c-300a-4614-ab8a-7534dea7a307.png)

