### PR TITLE
Adding a color util

### DIFF
--- a/examples/cube.py
+++ b/examples/cube.py
@@ -12,7 +12,7 @@ scene = gfx.Scene()
 
 cube = gfx.Mesh(
     gfx.box_geometry(200, 200, 200),
-    gfx.MeshPhongMaterial(color=(0.2, 0.4, 0.6, 1.0)),
+    gfx.MeshPhongMaterial(color="#336699"),
 )
 scene.add(cube)
 

--- a/examples/line_basic.py
+++ b/examples/line_basic.py
@@ -28,7 +28,7 @@ for i in range(len(positions)):
 
 line = gfx.Line(
     gfx.Geometry(positions=positions),
-    gfx.LineMaterial(thickness=12.0, color=(0.8, 0.7, 0.0, 1.0)),
+    gfx.LineMaterial(thickness=12.0, color=(0.8, 0.7, 0.0)),
 )
 scene.add(line)
 

--- a/pygfx/helpers/_axes.py
+++ b/pygfx/helpers/_axes.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from .. import Geometry, Line, LineThinSegmentMaterial
+from ..utils import Color
 
 
 class AxesHelper(Line):
@@ -38,6 +39,7 @@ class AxesHelper(Line):
         super().__init__(geometry, material)
 
     def set_colors(self, x, y, z):
+        x, y, z = Color(x), Color(y), Color(z)
         self._geometry.colors.data[0] = x
         self._geometry.colors.data[1] = x
         self._geometry.colors.data[2] = y

--- a/pygfx/helpers/_box.py
+++ b/pygfx/helpers/_box.py
@@ -47,7 +47,7 @@ class BoxHelper(Line):
         positions *= self._size
 
         geometry = Geometry(positions=positions)
-        material = LineThinSegmentMaterial(color=(1, 0, 0, 1))
+        material = LineThinSegmentMaterial(color=(1, 0, 0))
 
         super().__init__(geometry, material)
 

--- a/pygfx/helpers/_grid.py
+++ b/pygfx/helpers/_grid.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from .. import Geometry, Line, LineThinSegmentMaterial
-
+from ..utils import Color
 
 DTYPE = "f4"
 
@@ -33,8 +33,8 @@ class GridHelper(Line):
 
         # color1 for the center lines, color2 for the rest
         colors = np.empty((2, n_lines, 2, 4), dtype=DTYPE)
-        colors[..., :] = color2
-        colors[:, n_lines // 2, :, :] = color1
+        colors[..., :] = Color(color2)
+        colors[:, n_lines // 2, :, :] = Color(color1)
 
         geometry = Geometry(
             positions=positions.reshape((-1, 3)), colors=colors.reshape((-1, 4))

--- a/pygfx/materials/_background.py
+++ b/pygfx/materials/_background.py
@@ -1,4 +1,5 @@
 from ._base import Material
+from ..utils import Color
 
 # todo: in ThreeJS you can simply set a CubeTexture as the scene.background
 # we could do that, and the scene could use these objects automatically.
@@ -27,6 +28,7 @@ class BackgroundMaterial(Material):
         the botton and top. If four colors are given, it will be used for the
         four corners.
         """
+        colors = [Color(c) for c in colors]
         if len(colors) == 0:
             self.color_bottom_left = (0, 0, 0, 1)
             self.color_bottom_right = (0, 0, 0, 1)
@@ -53,41 +55,41 @@ class BackgroundMaterial(Material):
     @property
     def color_bottom_left(self):
         """The color in the bottom left corner."""
-        return self.uniform_buffer.data["color_bottom_left"]
+        return Color(self.uniform_buffer.data["color_bottom_left"])
 
     @color_bottom_left.setter
     def color_bottom_left(self, color):
-        self.uniform_buffer.data["color_bottom_left"] = color
+        self.uniform_buffer.data["color_bottom_left"] = Color(color)
         self.uniform_buffer.update_range(0, 1)
 
     @property
     def color_bottom_right(self):
         """The color in the bottom right corner."""
-        return self.uniform_buffer.data["color_bottom_right"]
+        return Color(self.uniform_buffer.data["color_bottom_right"])
 
     @color_bottom_right.setter
     def color_bottom_right(self, color):
-        self.uniform_buffer.data["color_bottom_right"] = color
+        self.uniform_buffer.data["color_bottom_right"] = Color(color)
         self.uniform_buffer.update_range(0, 1)
 
     @property
     def color_top_left(self):
         """The color in the top left corner."""
-        return self.uniform_buffer.data["color_top_left"]
+        return Color(self.uniform_buffer.data["color_top_left"])
 
     @color_top_left.setter
     def color_top_left(self, color):
-        self.uniform_buffer.data["color_top_left"] = color
+        self.uniform_buffer.data["color_top_left"] = Color(color)
         self.uniform_buffer.update_range(0, 1)
 
     @property
     def color_top_right(self):
         """The color in the top right corner."""
-        return self.uniform_buffer.data["color_top_right"]
+        return Color(self.uniform_buffer.data["color_top_right"])
 
     @color_top_right.setter
     def color_top_right(self, color):
-        self.uniform_buffer.data["color_top_right"] = color
+        self.uniform_buffer.data["color_top_right"] = Color(color)
         self.uniform_buffer.update_range(0, 1)
 
 

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -1,5 +1,5 @@
 from ._base import Material
-from ..utils import unpack_bitfield
+from ..utils import unpack_bitfield, Color
 
 
 class LineMaterial(Material):
@@ -29,11 +29,11 @@ class LineMaterial(Material):
 
     @property
     def color(self):
-        return self.uniform_buffer.data["color"]
+        return Color(self.uniform_buffer.data["color"])
 
     @color.setter
     def color(self, color):
-        color = tuple(color)
+        color = Color(color)
         if (color[3] >= 1) != (self.uniform_buffer.data["color"][3] >= 1):
             self._bump_rev()  # rebuild pipeline if this becomes opaque/transparent
         self.uniform_buffer.data["color"] = color

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -1,7 +1,7 @@
 from ._base import Material
 from ..resources import TextureView
 from ..utils import unpack_bitfield
-from ..utils.colors import Color
+from ..utils.color import Color
 
 
 def clim_from_format(texture):
@@ -91,14 +91,10 @@ class MeshBasicMaterial(Material):
 
     @color.setter
     def color(self, color):
-<<<<<<< HEAD
-        color = tuple(color)
+        color = Color(color)
         if (color[3] >= 1) != (self.uniform_buffer.data["color"][3] >= 1):
             self._bump_rev()  # rebuild pipeline if this becomes opaque/transparent
         self.uniform_buffer.data["color"] = color
-=======
-        self.uniform_buffer.data["color"] = Color(color)
->>>>>>> e1f736c (proposing a color object)
         self.uniform_buffer.update_range(0, 1)
 
     @property

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -1,6 +1,7 @@
 from ._base import Material
 from ..resources import TextureView
 from ..utils import unpack_bitfield
+from ..utils.colors import Color
 
 
 def clim_from_format(texture):
@@ -86,14 +87,18 @@ class MeshBasicMaterial(Material):
         """The uniform color of the mesh, as an rgba tuple.
         This value is ignored if a texture map is used.
         """
-        return self.uniform_buffer.data["color"]
+        return Color(self.uniform_buffer.data["color"])
 
     @color.setter
     def color(self, color):
+<<<<<<< HEAD
         color = tuple(color)
         if (color[3] >= 1) != (self.uniform_buffer.data["color"][3] >= 1):
             self._bump_rev()  # rebuild pipeline if this becomes opaque/transparent
         self.uniform_buffer.data["color"] = color
+=======
+        self.uniform_buffer.data["color"] = Color(color)
+>>>>>>> e1f736c (proposing a color object)
         self.uniform_buffer.update_range(0, 1)
 
     @property

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -1,5 +1,5 @@
 from ._base import Material
-from ..utils import unpack_bitfield
+from ..utils import unpack_bitfield, Color
 
 
 class PointsMaterial(Material):
@@ -39,11 +39,11 @@ class PointsMaterial(Material):
     @property
     def color(self):
         """The color of the points (if map is not set)."""
-        return self.uniform_buffer.data["color"]
+        return Color(self.uniform_buffer.data["color"])
 
     @color.setter
     def color(self, color):
-        color = tuple(color)
+        color = Color(color)
         if (color[3] >= 1) != (self.uniform_buffer.data["color"][3] >= 1):
             self._bump_rev()  # rebuild pipeline if this becomes opaque/transparent
         self.uniform_buffer.data["color"] = color

--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -2,6 +2,8 @@ import logging
 
 import numpy as np
 
+from .color import Color  # noqa: F401
+
 
 logger = logging.getLogger("pygfx")
 logger.setLevel(logging.WARNING)

--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -1,3 +1,4 @@
+"""Provides utilities to deal with color."""
 import ctypes
 
 

--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -90,7 +90,10 @@ class Color:
             self._set_from_tuple(args)
 
     def __repr__(self):
-        return "<Color {:0.2f} {:0.2f} {:0.2f} {:0.2f}>".format(*self.rgba)
+        # A precision of 4 decimals, i.e. 10000 possible values for each color.
+        # We truncate zeros, but make sure the value does not end with a dot.
+        f = lambda v: f"{v:0.4f}".rstrip("0").ljust(3, "0")  # noqa: stfu
+        return f"Color({f(self.r)}, {f(self.g)}, {f(self.b)}, {f(self.a)})"
 
     def __len__(self):
         return 4

--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -61,13 +61,13 @@ class Color:
 
     * `Color("#ff0000")` the commmon hex format.
     * `Color("#ff0000ff")` the hex format that includes alpha.
-    * `Color("#ff0)` the short form hex format.
-    * `Color("#ff0f)` the short form hex format that includes alpha.
+    * `Color("#ff0")` the short form hex format.
+    * `Color("#ff0f")` the short form hex format that includes alpha.
 
     CSS color functions:
 
-    * `Color("rgb(255, 0, 0")`.
-    * `Color("rgba(255, 0, 0, 1.0")`.
+    * `Color("rgb(255, 0, 0)")`.
+    * `Color("rgba(255, 0, 0, 1.0)")`.
 
     """
 

--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -90,7 +90,7 @@ class Color:
             self._set_from_tuple(args)
 
     def __repr__(self):
-        # A precision of 4 decimals, i.e. 10000 possible values for each color.
+        # A precision of 4 decimals, i.e. 10001 possible values for each color.
         # We truncate zeros, but make sure the value does not end with a dot.
         f = lambda v: f"{v:0.4f}".rstrip("0").ljust(3, "0")  # noqa: stfu
         return f"Color({f(self.r)}, {f(self.g)}, {f(self.b)}, {f(self.a)})"

--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -1,4 +1,5 @@
 """Provides utilities to deal with color."""
+
 import ctypes
 
 
@@ -6,26 +7,58 @@ F4 = ctypes.c_float * 4
 
 
 class Color:
-    """An object to hold a color value."""
+    """An object representing a color.
 
+    Internally the color is stored using 4 32-bit floats (rgba).
+    It can be instantiated in a variety of ways. E.g. by providing
+    the color components as values between 0 and 1:
+
+    * `Color(r, g, b, a)` providing rgba values.
+    * `Color(r, g, b)` providing rgb, alpha is 1.
+    * `Color(v, a)` value (gray) and alpha.
+
+    The above variations can also be supplied as a single tuple/list:
+
+    * `Color((r, g, b))`.
+
+    Named colors:
+
+    * `Color("red")` base color names.
+    * `Color("cornflowerblue")` CSS color names.
+    * `Color("m")` Matlab color chars.
+
+    Hex colors:
+
+    * `Color("#ff0000")` the commmon hex format.
+    * `Color("#ff0000ff")` the hex format that includes alpha.
+    * `Color("#ff0)` the short form hex format.
+    * `Color("#ff0f)` the short form hex format that includes alpha.
+    * `Color(0xff0000)` the int form hex color (rgb only).
+
+    CSS color functions:
+
+    * `Color("rgb(255, 0, 0")`.
+    * `Color("rgba(255, 0, 0, 1.0")`.
+
+    """
+
+    # Internally, the color is a ctypes float array
     __slots__ = ["_val"]
 
     def __init__(self, *args):
 
-        if len(args) == 0:
-            self._save_from_rgba(0, 0, 0, 0)
-        elif len(args) == 1:
+        if len(args) == 1:
             color = args[0]
             if isinstance(color, Color):
                 self._val = color._val
-            elif isinstance(color, float):
-                self._save_from_tuple((color,))
             elif isinstance(color, int):
                 self._save_from_int(color)
             elif isinstance(color, str):
                 self._save_from_str(color)
             elif isinstance(color, (tuple, list)):
                 self._save_from_tuple(color)
+            else:
+                raise ValueError("Cannot make color from a {type(color).__name__}")
         else:
             self._save_from_tuple(args)
 
@@ -43,52 +76,103 @@ class Color:
 
     @property
     def __array_interface__(self):
+        # Numpy can wrap our memory in an array without copying
         readonly = True
         ptr = ctypes.addressof(self._val)
         x = dict(version=3, shape=(4,), typestr="<f4", data=(ptr, readonly))
         return x
 
     def _save_from_rgba(self, r, g, b, a):
-        r = max(0.0, min(1.0, float(r)))
-        g = max(0.0, min(1.0, float(g)))
-        b = max(0.0, min(1.0, float(b)))
-        a = max(0.0, min(1.0, float(a)))
-        self._val = F4(r, g, b, a)
+        self._val = F4(
+            max(0.0, min(1.0, float(r))),
+            max(0.0, min(1.0, float(g))),
+            max(0.0, min(1.0, float(b))),
+            max(0.0, min(1.0, float(a))),
+        )
 
     def _save_from_int(self, color):
         v = color
-        a = v % 256
-        v = v >> 8
         b = v % 256
         v = v >> 8
         g = v % 256
         v = v >> 8
         r = v % 256
-        self._save_from_rgba(r, g, b, a)
+        self._save_from_rgba(r, g, b, 1)
 
     def _save_from_tuple(self, color):
         color = tuple(float(c) for c in color)
-        if len(color) == 1:
-            self._save_from_rgba(color[0], color[0], color[0], 1)
+        if len(color) == 4:
+            self._save_from_rgba(*color)
+        elif len(color) == 3:
+            self._save_from_rgba(*color, 1)
         elif len(color) == 2:
             self._save_from_rgba(color[0], color[0], color[0], color[1])
-        elif len(color) == 3:
-            self._save_from_rgba(color[0], color[1], color[2], 1)
-        elif len(color) == 4:
-            self._save_from_rgba(*color)
+        elif len(color) == 1:
+            self._save_from_rgba(color[0], color[0], color[0], 1)
         else:
-            raise ValueError(f"Color tuple must have 1-4 value, got: {color}")
+            raise ValueError(f"Cannot parse color tuple with {len(color)} values")
 
     def _save_from_str(self, color):
         color = color.lower()
-        if color.startswith("#"):
-            # todo: Hex RGB or RGBA
-            raise NotImplementedError()
+        if color.startswith("0x"):
+            # In case someone accidentally puts quotes around the int
+            self._save_from_int(int(color, 0))
+        elif color.startswith("#"):
+            # A hex number
+            if len(color) == 7:  # #rrggbb
+                self._save_from_rgba(
+                    int(color[1:3], 16) / 255,
+                    int(color[3:5], 16) / 255,
+                    int(color[5:7], 16) / 255,
+                    1,
+                )
+            elif len(color) == 4:  # #rgb
+                self._save_from_rgba(
+                    int(color[1], 16) / 15,
+                    int(color[2], 16) / 15,
+                    int(color[3], 16) / 15,
+                    1,
+                )
+            elif len(color) == 9:  # #rrggbbaa
+                self._save_from_rgba(
+                    int(color[1:3], 16) / 255,
+                    int(color[3:5], 16) / 255,
+                    int(color[5:7], 16) / 255,
+                    int(color[7:9], 16) / 255,
+                )
+            elif len(color) == 5:  # #rgba
+                self._save_from_rgba(
+                    int(color[1], 16) / 15,
+                    int(color[2], 16) / 15,
+                    int(color[3], 16) / 15,
+                    int(color[4], 16) / 15,
+                )
+            else:
+                raise ValueError(
+                    f"Expecting 4, 5, 7, or 9 chars in a hex number, got {len(color)}."
+                )
+        elif color.startswith(("rgb(", "rgba(")):
+            # A CSS color 'function'
+            parts = color.split("(")[1].split(")")[0].split(",")
+            parts = [float(p) for p in parts]
+            if len(parts) == 3:
+                self._save_from_rgba(parts[0] / 255, parts[1] / 255, parts[2] / 255, 1)
+            elif len(parts) == 4:
+                self._save_from_rgba(
+                    parts[0] / 255, parts[1] / 255, parts[2] / 255, parts[3]
+                )
+            else:
+                raise ValueError(
+                    f"CSS color {color.split('(')[0]}(..) must have 3 or 4 elements, not {len(parts)} "
+                )
         else:
+            # Maybe a CSS named color
             try:
-                self._save_from_int(CSS_NAMES[color])
+                color_int = NAMED_COLORS[color.lower()]
             except KeyError:
-                raise ValueError(f"Unknown color: '{color}'")
+                raise ValueError(f"Unknown color: '{color}'") from None
+            else:
+                self._save_from_int(color_int)
 
     @property
     def rgba(self):
@@ -121,38 +205,208 @@ class Color:
         return self._val[3]
 
     @property
-    def i(self):
-        """Return as int in which the rgba values are packed."""
-        r, g, b, a = self.rgba
+    def ihex(self):
+        """Return as int in which the rgb values are packed."""
+        r, g, b = self.rgb
         return (
-            (int(r * 255) << 24)
-            + (int(g * 255) << 16)
-            + (int(b * 255) << 8)
-            + int(a * 255)
+            (int(r * 255 + 0.5) << 16)
+            + (int(g * 255 + 0.5) << 8)
+            + (int(b * 255 + 0.5) << 0)
         )
 
     @property
     def hex(self):
         """The CSS hex string, e.g. "#00ff00". The alpha channel is ignored."""
-        return "#" + hex(self.i)[2:]
+        r = int(self.r * 255 + 0.5)
+        b = int(self.b * 255 + 0.5)
+        g = int(self.g * 255 + 0.5)
+        i = (r << 16) + (g << 8) + b
+        return "#" + hex(i)[2:].rjust(6, "0")
+
+    @property
+    def hexa(self):
+        """The hex string including alpha, e.g. "#00ff00ff"."""
+        r = int(self.r * 255 + 0.5)
+        b = int(self.b * 255 + 0.5)
+        g = int(self.g * 255 + 0.5)
+        a = int(self.a * 255 + 0.5)
+        i = (r << 24) + (g << 16) + (b << 8) + a
+        return "#" + hex(i)[2:].rjust(8, "0")
 
     @property
     def css(self):
-        """The CSS color string. If the alpha is 1, returns as hex, otherwise
-        returns e.g. "rgba(0,255,0,0.5)".
-        """
-        if self.a == 1:
-            return self.hex
+        """The CSS color string, e.g. "rgba(0,255,0,0.5)"."""
+        r, g, b, a = self.rgba
+        if a == 1:
+            return f"rgb({int(255*r+0.5)},{int(255*g+0.5)},{int(255*b+0.5)})"
         else:
-            r, g, b, a = self.rgba
-            return "rgba({int(255*r)},int(255*g),int(255*b),{a:03f})"
+            return f"rgba({int(255*r+0.5)},{int(255*g+0.5)},{int(255*b+0.5)},{a:0.3f})"
 
     # todo: __add__, lighter(), darker(), etc.
 
 
-CSS_NAMES = {
-    "red": 0xFF0000FF,
-    "green": 0x00FF00FF,
-    "blue": 0x0000FFFF,
-    # todo: etc.
+NAMED_COLORS = {
+    # CSS Level 1
+    "black": 0x000000,
+    "silver": 0xC0C0C0,
+    "gray": 0x808080,
+    "white": 0xFFFFFF,
+    "maroon": 0x800000,
+    "red": 0xFF0000,
+    "purple": 0x800080,
+    "fuchsia": 0xFF00FF,
+    "green": 0x008000,
+    "lime": 0x00FF00,
+    "olive": 0x808000,
+    "yellow": 0xFFFF00,
+    "navy": 0x000080,
+    "blue": 0x0000FF,
+    "teal": 0x008080,
+    "aqua": 0x00FFFF,
+    # CSS Level 2
+    "orange": 0xFFA500,
+    # CSS Color Module Level 3
+    "aliceblue": 0xF0F8FF,
+    "antiquewhite": 0xFAEBD7,
+    "aquamarine": 0x7FFFD4,
+    "azure": 0xF0FFFF,
+    "beige": 0xF5F5DC,
+    "bisque": 0xFFE4C4,
+    "blanchedalmond": 0xFFEBCD,
+    "blueviolet": 0x8A2BE2,
+    "brown": 0xA52A2A,
+    "burlywood": 0xDEB887,
+    "cadetblue": 0x5F9EA0,
+    "chartreuse": 0x7FFF00,
+    "chocolate": 0xD2691E,
+    "coral": 0xFF7F50,
+    "cornflowerblue": 0x6495ED,
+    "cornsilk": 0xFFF8DC,
+    "crimson": 0xDC143C,
+    "cyan": 0x00FFFF,
+    "aqua": 0x00FFFF,
+    "darkblue": 0x00008B,
+    "darkcyan": 0x008B8B,
+    "darkgoldenrod": 0xB8860B,
+    "darkgray": 0xA9A9A9,
+    "darkgreen": 0x006400,
+    "darkgrey": 0xA9A9A9,
+    "darkkhaki": 0xBDB76B,
+    "darkmagenta": 0x8B008B,
+    "darkolivegreen": 0x556B2F,
+    "darkorange": 0xFF8C00,
+    "darkorchid": 0x9932CC,
+    "darkred": 0x8B0000,
+    "darksalmon": 0xE9967A,
+    "darkseagreen": 0x8FBC8F,
+    "darkslateblue": 0x483D8B,
+    "darkslategray": 0x2F4F4F,
+    "darkslategrey": 0x2F4F4F,
+    "darkturquoise": 0x00CED1,
+    "darkviolet": 0x9400D3,
+    "deeppink": 0xFF1493,
+    "deepskyblue": 0x00BFFF,
+    "dimgray": 0x696969,
+    "dimgrey": 0x696969,
+    "dodgerblue": 0x1E90FF,
+    "firebrick": 0xB22222,
+    "floralwhite": 0xFFFAF0,
+    "forestgreen": 0x228B22,
+    "gainsboro": 0xDCDCDC,
+    "ghostwhite": 0xF8F8FF,
+    "gold": 0xFFD700,
+    "goldenrod": 0xDAA520,
+    "greenyellow": 0xADFF2F,
+    "grey": 0x808080,
+    "honeydew": 0xF0FFF0,
+    "hotpink": 0xFF69B4,
+    "indianred": 0xCD5C5C,
+    "indigo": 0x4B0082,
+    "ivory": 0xFFFFF0,
+    "khaki": 0xF0E68C,
+    "lavender": 0xE6E6FA,
+    "lavenderblush": 0xFFF0F5,
+    "lawngreen": 0x7CFC00,
+    "lemonchiffon": 0xFFFACD,
+    "lightblue": 0xADD8E6,
+    "lightcoral": 0xF08080,
+    "lightcyan": 0xE0FFFF,
+    "lightgoldenrodyellow": 0xFAFAD2,
+    "lightgray": 0xD3D3D3,
+    "lightgreen": 0x90EE90,
+    "lightgrey": 0xD3D3D3,
+    "lightpink": 0xFFB6C1,
+    "lightsalmon": 0xFFA07A,
+    "lightseagreen": 0x20B2AA,
+    "lightskyblue": 0x87CEFA,
+    "lightslategray": 0x778899,
+    "lightslategrey": 0x778899,
+    "lightsteelblue": 0xB0C4DE,
+    "lightyellow": 0xFFFFE0,
+    "limegreen": 0x32CD32,
+    "linen": 0xFAF0E6,
+    "magenta": 0xFF00FF,
+    "fuchsia": 0xFF00FF,
+    "mediumaquamarine": 0x66CDAA,
+    "mediumblue": 0x0000CD,
+    "mediumorchid": 0xBA55D3,
+    "mediumpurple": 0x9370DB,
+    "mediumseagreen": 0x3CB371,
+    "mediumslateblue": 0x7B68EE,
+    "mediumspringgreen": 0x00FA9A,
+    "mediumturquoise": 0x48D1CC,
+    "mediumvioletred": 0xC71585,
+    "midnightblue": 0x191970,
+    "mintcream": 0xF5FFFA,
+    "mistyrose": 0xFFE4E1,
+    "moccasin": 0xFFE4B5,
+    "navajowhite": 0xFFDEAD,
+    "oldlace": 0xFDF5E6,
+    "olivedrab": 0x6B8E23,
+    "orangered": 0xFF4500,
+    "orchid": 0xDA70D6,
+    "palegoldenrod": 0xEEE8AA,
+    "palegreen": 0x98FB98,
+    "paleturquoise": 0xAFEEEE,
+    "palevioletred": 0xDB7093,
+    "papayawhip": 0xFFEFD5,
+    "peachpuff": 0xFFDAB9,
+    "peru": 0xCD853F,
+    "pink": 0xFFC0CB,
+    "plum": 0xDDA0DD,
+    "powderblue": 0xB0E0E6,
+    "rosybrown": 0xBC8F8F,
+    "royalblue": 0x4169E1,
+    "saddlebrown": 0x8B4513,
+    "salmon": 0xFA8072,
+    "sandybrown": 0xF4A460,
+    "seagreen": 0x2E8B57,
+    "seashell": 0xFFF5EE,
+    "sienna": 0xA0522D,
+    "skyblue": 0x87CEEB,
+    "slateblue": 0x6A5ACD,
+    "slategray": 0x708090,
+    "slategrey": 0x708090,
+    "snow": 0xFFFAFA,
+    "springgreen": 0x00FF7F,
+    "steelblue": 0x4682B4,
+    "tan": 0xD2B48C,
+    "thistle": 0xD8BFD8,
+    "tomato": 0xFF6347,
+    "turquoise": 0x40E0D0,
+    "violet": 0xEE82EE,
+    "wheat": 0xF5DEB3,
+    "whitesmoke": 0xF5F5F5,
+    "yellowgreen": 0x9ACD32,
+    # CSS Color Module Level 4
+    "rebeccapurple": 0x663399,
+    # Matlab / Matplotlib
+    "b": 0x0000FF,
+    "g": 0x00FF00,
+    "r": 0xFF0000,
+    "c": 0x00FFFF,
+    "m": 0xFF00FF,
+    "y": 0xFFFF00,
+    "k": 0x000000,
+    "w": 0xFFFFFF,
 }

--- a/pygfx/utils/colors.py
+++ b/pygfx/utils/colors.py
@@ -1,0 +1,157 @@
+import ctypes
+
+
+F4 = ctypes.c_float * 4
+
+
+class Color:
+    """An object to hold a color value."""
+
+    __slots__ = ["_val"]
+
+    def __init__(self, *args):
+
+        if len(args) == 0:
+            self._save_from_rgba(0, 0, 0, 0)
+        elif len(args) == 1:
+            color = args[0]
+            if isinstance(color, Color):
+                self._val = color._val
+            elif isinstance(color, float):
+                self._save_from_tuple((color,))
+            elif isinstance(color, int):
+                self._save_from_int(color)
+            elif isinstance(color, str):
+                self._save_from_str(color)
+            elif isinstance(color, (tuple, list)):
+                self._save_from_tuple(color)
+        else:
+            self._save_from_tuple(args)
+
+    def __repr__(self):
+        return "<Color {:0.2f} {:0.2f} {:0.2f} {:0.2f}>".format(*self.rgba)
+
+    def __len__(self):
+        return 4
+
+    def __getitem__(self, index):
+        return self._val[index]
+
+    def __iter__(self):
+        return self.rgba.__iter__()
+
+    @property
+    def __array_interface__(self):
+        readonly = True
+        ptr = ctypes.addressof(self._val)
+        x = dict(version=3, shape=(4,), typestr="<f4", data=(ptr, readonly))
+        return x
+
+    def _save_from_rgba(self, r, g, b, a):
+        r = max(0.0, min(1.0, float(r)))
+        g = max(0.0, min(1.0, float(g)))
+        b = max(0.0, min(1.0, float(b)))
+        a = max(0.0, min(1.0, float(a)))
+        self._val = F4(r, g, b, a)
+
+    def _save_from_int(self, color):
+        v = color
+        a = v % 256
+        v = v >> 8
+        b = v % 256
+        v = v >> 8
+        g = v % 256
+        v = v >> 8
+        r = v % 256
+        self._save_from_rgba(r, g, b, a)
+
+    def _save_from_tuple(self, color):
+        color = tuple(float(c) for c in color)
+        if len(color) == 1:
+            self._save_from_rgba(color[0], color[0], color[0], 1)
+        elif len(color) == 2:
+            self._save_from_rgba(color[0], color[0], color[0], color[1])
+        elif len(color) == 3:
+            self._save_from_rgba(color[0], color[1], color[2], 1)
+        elif len(color) == 4:
+            self._save_from_rgba(*color)
+        else:
+            raise ValueError(f"Color tuple must have 1-4 value, got: {color}")
+
+    def _save_from_str(self, color):
+        color = color.lower()
+        if color.startswith("#"):
+            # todo: Hex RGB or RGBA
+            raise NotImplementedError()
+        else:
+            try:
+                self._save_from_int(CSS_NAMES[color])
+            except KeyError:
+                raise ValueError(f"Unknown color: '{color}'")
+
+    @property
+    def rgba(self):
+        """The RGBA tuple (values between 0 and 1)."""
+        return self._val[0], self._val[1], self._val[2], self._val[3]
+
+    @property
+    def rgb(self):
+        """The RGB tuple (values between 0 and 1)."""
+        return self._val[0], self._val[1], self._val[2]
+
+    @property
+    def r(self):
+        """The red value."""
+        return self._val[0]
+
+    @property
+    def g(self):
+        """The green value."""
+        return self._val[1]
+
+    @property
+    def b(self):
+        """The blue value."""
+        return self._val[2]
+
+    @property
+    def a(self):
+        """The alpha (transparency) value."""
+        return self._val[3]
+
+    @property
+    def i(self):
+        """Return as int in which the rgba values are packed."""
+        r, g, b, a = self.rgba
+        return (
+            (int(r * 255) << 24)
+            + (int(g * 255) << 16)
+            + (int(b * 255) << 8)
+            + int(a * 255)
+        )
+
+    @property
+    def hex(self):
+        """The CSS hex string, e.g. "#00ff00". The alpha channel is ignored."""
+        return "#" + hex(self.i)[2:]
+
+    @property
+    def css(self):
+        """The CSS color string. If the alpha is 1, returns as hex, otherwise
+        returns e.g. "rgba(0,255,0,0.5)".
+        """
+        if self.a == 1:
+            return self.hex
+        else:
+            r, g, b, a = self.rgba
+            return "rgba({int(255*r)},int(255*g),int(255*b),{a:03f})"
+
+    # todo: __add__, lighter(), darker(), etc.
+
+
+CSS_NAMES = {
+    "red": 0xFF0000FF,
+    "green": 0x00FF00FF,
+    "blue": 0x0000FFFF,
+    # todo: etc.
+}

--- a/tests/utils/test_color.py
+++ b/tests/utils/test_color.py
@@ -14,8 +14,9 @@ class TColor(Color):
 def test_color_basics():
 
     c = Color(0.1, 0.2, 0.3)
-    assert repr(c).startswith("<Color ")
-    assert "0.10 0.20 0.30" in repr(c)
+    assert repr(c) == "Color(0.1, 0.2, 0.3, 1.0)"
+    c = Color(0.123456, 0.2, 0.3, 0.8)
+    assert repr(c) == "Color(0.123, 0.2, 0.3, 0.8)"
 
     d = Color(c)
     assert list(c) == list(d)
@@ -203,6 +204,7 @@ def test_color_named():
 
 
 if __name__ == "__main__":
+    test_color_basics()
     test_color_tuples()
     test_color_iterable()
     test_color_attr()

--- a/tests/utils/test_color.py
+++ b/tests/utils/test_color.py
@@ -15,8 +15,8 @@ def test_color_basics():
 
     c = Color(0.1, 0.2, 0.3)
     assert repr(c) == "Color(0.1, 0.2, 0.3, 1.0)"
-    c = Color(0.123456, 0.2, 0.3, 0.8)
-    assert repr(c) == "Color(0.123, 0.2, 0.3, 0.8)"
+    c = Color(0.012345, 0.2, 0.3, 0.8)
+    assert repr(c) == "Color(0.0123, 0.2, 0.3, 0.8)"
 
     d = Color(c)
     assert list(c) == list(d)

--- a/tests/utils/test_color.py
+++ b/tests/utils/test_color.py
@@ -1,0 +1,171 @@
+from pytest import raises
+import numpy as np
+
+from pygfx.utils.color import Color
+
+
+class TColor(Color):
+    def matches(self, r, g, b, a):
+        eps = 0.501 / 255
+        rgba = r, g, b, a
+        return all(abs(v1 - v2) < eps for v1, v2 in zip(self.rgba, rgba))
+
+
+def test_color_basics():
+
+    c = Color(0.1, 0.2, 0.3)
+    assert repr(c).startswith("<Color ")
+    assert "0.10 0.20 0.30" in repr(c)
+
+    d = Color(c)
+    assert list(c) == list(d)
+
+
+def test_color_tuples():
+
+    # Test setting with values
+    assert TColor(0, 0).matches(0, 0, 0, 0)
+    assert TColor(1, 1).matches(1, 1, 1, 1)
+    assert TColor(0.5, 0.8).matches(0.5, 0.5, 0.5, 0.8)
+    assert TColor(0.1, 0.2, 0.3).matches(0.1, 0.2, 0.3, 1)
+    assert TColor(0.1, 0.2, 0.3, 0.8).matches(0.1, 0.2, 0.3, 0.8)
+
+    # Need at least two args to provide a color tuple
+    with raises(ValueError):
+        Color()
+    with raises(ValueError):
+        Color(0.0)
+
+    # Now with real tuples
+    assert TColor((0, 0)).matches(0, 0, 0, 0)
+    assert TColor((1, 1)).matches(1, 1, 1, 1)
+    assert TColor((0.5, 0.8)).matches(0.5, 0.5, 0.5, 0.8)
+    assert TColor((0.1, 0.2, 0.3)).matches(0.1, 0.2, 0.3, 1)
+    assert TColor((0.1, 0.2, 0.3, 0.8)).matches(0.1, 0.2, 0.3, 0.8)
+
+    # Can also do a 1-element tuple then
+    assert TColor((0.6,)).matches(0.6, 0.6, 0.6, 1)
+
+
+def test_color_attr():
+
+    c = Color(0.1, 0.2, 0.3, 0.8)
+
+    assert c.rgb == c.rgba[:3]
+
+    assert c.r == c.rgba[0]
+    assert c.g == c.rgba[1]
+    assert c.b == c.rgba[2]
+    assert c.a == c.rgba[3]
+
+
+def test_color_indexing():
+
+    c = Color(0.1, 0.2, 0.3, 0.8)
+
+    # Indexing
+    assert c.r == c[0]
+    assert c.g == c[1]
+    assert c.b == c[2]
+    assert c.a == c[3]
+
+    # Iteration
+    assert len(c) == 4  # This is *always* the case
+    assert c.rgba == tuple(c)
+
+
+def test_color_numpy():
+
+    # Map an array to the color data
+    c = Color(0.1, 0.2, 0.3, 0.8)
+    a = np.array(c, copy=False)
+    assert a.dtype == np.float32
+    assert (a == c).all()
+
+    # We cannot change the array
+    assert not a.flags.writeable
+
+    # But we can change the color, with a hack
+    c._val[0] = 9
+    assert a[0] == 9
+
+
+def test_color_hex():
+
+    # Hex -> tuple
+    assert TColor("#000000").matches(0, 0, 0, 1)
+    assert TColor("#ffffff").matches(1, 1, 1, 1)
+    assert TColor("#7f7f7f").matches(0.5, 0.5, 0.5, 1)
+    assert TColor("#7f7f7f10").matches(0.5, 0.5, 0.5, 16 / 255)
+
+    # Tuple -> hex
+    assert TColor(0, 1).hex == "#000000"
+    assert TColor(0, 0.5, 1).hex == "#0080ff"
+    assert TColor(1, 0.5, 0).hex == "#ff8000"
+    assert TColor(0.1, 0.2, 0.3).hex == "#1a334d"
+
+    # Tuple -> hexa
+    assert TColor(0, 1).hexa == "#000000ff"
+    assert TColor(0, 0.5, 1).hexa == "#0080ffff"
+    assert TColor(1, 0.5, 0).hexa == "#ff8000ff"
+    assert TColor(0.1, 0.2, 0.3).hexa == "#1a334dff"
+    assert TColor(0.1, 0.2, 0.3, 0.5).hexa == "#1a334d80"
+
+    # Roundtrip between hex and tuple to make sure the
+    # values are stable and won't "jump"
+    for v in [0.0, 0.1, 0.23, 1 / 7, 0.99, 1.0]:
+        c = Color(v, v, v, 1)
+        for i in range(10):
+            c = TColor(c.hex)
+            assert c.matches(v, v, v, 1)
+
+    # Variations
+    assert Color("#123").hexa == "#112233ff"
+    assert Color("#1234").hexa == "#11223344"
+    assert Color("#112233").hexa == "#112233ff"
+    assert Color("#11223344").hexa == "#11223344"
+
+    for x in ["#1", "#12", "#12345", "#1234567", "#123456789"]:
+        with raises(ValueError):
+            Color(x)
+
+
+def test_color_css():
+
+    assert Color("rgb(10, 20, 30)").hexa == "#0a141eff"
+    assert Color("rgba(10, 20, 30, 0.5)").hexa == "#0a141e80"
+
+    assert Color("#0a141eff").css == "rgb(10,20,30)"
+    assert Color("#0a141e80").css == "rgba(10,20,30,0.502)"
+
+    with raises(ValueError):
+        Color("rgb(10, 20, 30, 40, 50)")
+    with raises(ValueError):
+        Color("rgb(10, 20)")
+
+
+def test_color_min_max():
+
+    assert Color(1.1, 1.2, 1.3).rgb == (1, 1, 1)
+    assert Color(-0.1, -0.2, -0.3).rgb == (0, 0, 0)
+
+    assert Color("rgb(260, 270, 280)").css == "rgb(255,255,255)"
+
+
+def test_color_named():
+
+    assert Color("red").hexa == "#ff0000ff"
+    assert Color("y").hexa == "#ffff00ff"
+
+    with raises(ValueError):
+        Color("notacolorname")
+
+
+if __name__ == "__main__":
+    test_color_tuples()
+    test_color_attr()
+    test_color_indexing()
+    test_color_numpy()
+    test_color_hex()
+    test_color_css()
+    test_color_min_max()


### PR DESCRIPTION
Checks one off in #33.

This is a POC / proposal to add a `Color` class to pygfx.

This makes it possible for users to provide colors in various ways. And when getting a color prop, it can be formatted and processed in various ways too. The user never needs to instantiate it directly (although she could).

We support every way to provide a color in CSS, except the "hsl(..)" format. I left that for another day. We also support color tuples as we've used them so far. ThreeJS promotes the use of using an integer to define a color, e.g. 0xff0000. I started out with supporting this, but eventually removed it, because that integer does not look like a color when shown in decimal notation, so it easily leads to confusion.

In the top of the module I left some ideas for further work, based on ThreeJS and Qt.

Todo:
* [x] Do we want this?
* [x] Implementation.
* [x] Tests.
* [x] ~Tweak and test the hex-int format.~ drop int format
* [x] Tweak the repr.
* [x] Check how CSS, ThreeJS, and Qt handle color.
* [x] Implement where we use colors.
