### PR TITLE
Clean up some WGPU abstraction leaks

### DIFF
--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -1,3 +1,4 @@
+import enum
 import numpy as np
 
 import wgpu
@@ -30,6 +31,15 @@ class Buffer(Resource):
             derived from the data. Set when data is not given or when
             you want to overload the derived value.
     """
+
+    class usage(enum.IntFlag):
+        COPY_DST = wgpu.BufferUsage.COPY_DST
+        COPY_SRC = wgpu.BufferUsage.COPY_SRC
+        INDEX = wgpu.BufferUsage.INDEX
+        INDIRECT = wgpu.BufferUsage.INDIRECT
+        STORAGE = wgpu.BufferUsage.STORAGE
+        UNIFORM = wgpu.BufferUsage.UNIFORM
+        VERTEX = wgpu.BufferUsage.VERTEX
 
     def __init__(
         self,
@@ -198,10 +208,10 @@ def format_from_memoryview(mem, usage):
         format = str(mem.format)
         format = STRUCT_FORMAT_ALIASES.get(format, format)
         mapping = {
-            "h": wgpu.IndexFormat.uint16,
-            "H": wgpu.IndexFormat.uint16,
-            "i": wgpu.IndexFormat.uint32,
-            "I": wgpu.IndexFormat.uint32,
+            "h": "uint16",
+            "H": "uint16",
+            "i": "uint32",
+            "I": "uint32",
         }
         try:
             return mapping[format]
@@ -219,6 +229,8 @@ def format_from_memoryview(mem, usage):
         format = str(mem.format)
         format = STRUCT_FORMAT_ALIASES.get(format, format)
         key = format, shape[-1]
+        # The fact we're using wgpy enums here is a bit of an abstracion leak,
+        # but we have to use *something* and this makes sense ...
         mapping = {
             ("f", 1): wgpu.VertexFormat.float32,
             ("f", 2): wgpu.VertexFormat.float32x2,

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -2,8 +2,6 @@ import numpy as np
 
 from ._buffer import Resource, STRUCT_FORMAT_ALIASES
 
-# todo: what to do about these enums from wgpu. Copy them over?
-
 
 class Texture(Resource):
     """A base texture wrapper that can be implemented for numpy, ctypes arrays,
@@ -16,8 +14,10 @@ class Texture(Resource):
             copied if it's float64 or not contiguous.
         dim (int): The dimensionality of the array (1, 2 or 3).
         usage: The way(s) that the texture will be used. Default "TEXTURE_BINDING",
-            set/add "STORAGE_BINDING" if you're using it as a storage texture
-            (see wgpu.TextureUsage).
+            set/add "STORAGE_BINDING" if you're using it as a storage texture,
+            "TEXTURE_BINDING" if you simply sample from it, and "RENDER_ATTACHMENT"
+            if you render to it. (see wgpu.TextureUsage). Multiple values van be
+            separatedby commas.
         size (3-tuple): The extent ``(width, height, depth)`` of the array.
             If not given or None, it is derived from dim and the shape of
             the data. By creating a 2D array with ``depth > 1``, a view can
@@ -241,9 +241,9 @@ def format_from_memoryview(mem, size):
     # if tex_format == "rgb":
     #     -> no raise: WGPU does not support rgb, but we handle it in the renderer
     # Process dtype. We select the tex_format that matches the dtype.
-    # This means that uint8 values become 0..255 in the shader.
-    # todo: not yet entirely sure about this
-    # todo: there is no reference to wgpu here, but these are wgpu enums. Is that ok?
+    # We use WGPU enum names. This can be seen as an abstraction leak.
+    # On the other hand we need to pick *something*, and then this makes the most sense.
+    # See how we use normalized formats where possible, because these can be interpolated!
     texformatmap = {
         "b": "8snorm",
         "B": "8unorm",


### PR DESCRIPTION
Very much WIP.

There are some points where WGPUs-specifics are present in the main API. In a perfect world, only `renderers/wgpu` should know about wgpu. 

Places where wgpu-specifics are used:

* The `material._wgpu_get_pick_info` methods. I don't worry much about this, since it's not public API and clearly prefixed.
* The format prop in the `Buffer` and `Texture` classes. So we can come up with our own way to describe a format, but why not simply use the wgpu enums? In most cases the format is auto-determined anyway.
* The usage flags in the `Buffer` and `Texture` classes. This part is real ugly now. Options:
  * Use strings from their WGPU names, that can be combined using commas. yuk.
  * Let user use actual WGPU flags. Feels wrong.
  * Define our own flag (that's really just a copy of the wgpu flags). Shown in this PR.
  * Turn each flag-value in a boolean property. 
 