### PR TITLE
Tweak our format spec s -> i for signed integer

### DIFF
--- a/examples/post_processing2.py
+++ b/examples/post_processing2.py
@@ -41,7 +41,7 @@ class MyRenderFlusher(gfx.renderers.wgpu._renderutils.RenderFlusher):
     uniform_type = dict(
         size="2xf4",
         sigma="f4",
-        support="s4",
+        support="i4",
         amplitude="f4",
     )
 

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -68,7 +68,7 @@ class WorldObject(ResourceContainer):
 
     uniform_type = dict(
         world_transform="4x4xf4",
-        id="s4",
+        id="i4",
     )
 
     _v = Vector3()

--- a/pygfx/renderers/wgpu/_renderutils.py
+++ b/pygfx/renderers/wgpu/_renderutils.py
@@ -13,11 +13,11 @@ def to_vertex_format(format):
 
     # Get primitive type
     primitives = {
-        "s1": "sint8",
+        "i1": "sint8",
         "u1": "uint8",
-        "s2": "sint16",
+        "i2": "sint16",
         "u2": "uint16",
-        "s4": "sint32",
+        "i4": "sint32",
         "u4": "uint32",
         "f2": "float16",
         "f4": "float32",
@@ -44,11 +44,11 @@ def to_texture_format(format):
     # Note how we use normalized types (float in the shader) where we can,
     # because these types can work with an interpolating sampler.
     primitives = {
-        "s1": "8snorm",
+        "i1": "8snorm",
         "u1": "8unorm",
-        "s2": "16sint",
+        "i2": "16sint",
         "u2": "16uint",
-        "s4": "32sint",
+        "i4": "32sint",
         "u4": "32uint",
         "f2": "16float",
         "f4": "32float",
@@ -176,7 +176,7 @@ class RenderFlusher:
     uniform_type = dict(
         size="2xf4",
         sigma="f4",
-        support="s4",
+        support="i4",
     )
 
     def __init__(self, device):

--- a/pygfx/renderers/wgpu/_wgpurenderer.py
+++ b/pygfx/renderers/wgpu/_wgpurenderer.py
@@ -30,7 +30,7 @@ stdinfo_uniform_type = dict(
     projection_transform_inv="4x4xf4",
     physical_size="2xf4",
     logical_size="2xf4",
-    flipped_winding="s4",  # A bool, really
+    flipped_winding="i4",  # A bool, really
 )
 
 

--- a/pygfx/renderers/wgpu/linerender.py
+++ b/pygfx/renderers/wgpu/linerender.py
@@ -38,7 +38,7 @@ from ...materials import (
 # todo: we can learn about dashing, unfolding and more at http://jcgt.org/published/0002/02/08/paper.pdf
 
 
-renderer_uniform_type = dict(last_i="s4")
+renderer_uniform_type = dict(last_i="i4")
 
 
 @register_wgpu_render_function(Line, LineMaterial)

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -112,7 +112,7 @@ class Buffer(Resource):
     @property
     def format(self):
         """The vertex format. Usually a pygfx format specifier (e.g. u2
-        for scalar uint32, or 3xf4 for 3xfloat32), but can also be a
+        for scalar uint16, or 3xf4 for 3xfloat32), but can also be a
         overriden to a backend-specific format.
         """
         if self._format is not None:
@@ -182,11 +182,11 @@ class Buffer(Resource):
 def format_from_memoryview(mem):
 
     formatmap = {
-        "b": "s1",
+        "b": "i1",
         "B": "u1",
-        "h": "s2",
+        "h": "i2",
         "H": "u2",
-        "i": "s4",
+        "i": "i4",
         "U": "u4",
         "e": "f2",
         "f": "f4",

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -103,7 +103,7 @@ class Texture(Resource):
     @property
     def format(self):
         """The texture format as a string. Usually a pygfx format specifier
-        (e.g. u2 for scalar uint32, or 3xf4 for RGB float32),
+        (e.g. u2 for scalar uint16, or 3xf4 for RGB float32),
         but can also be a overriden to a backend-specific format.
         """
         if self._format is not None:
@@ -203,11 +203,11 @@ class Texture(Resource):
 def format_from_memoryview(mem, size):
 
     formatmap = {
-        "b": "s1",
+        "b": "i1",
         "B": "u1",
-        "h": "s2",
+        "h": "i2",
         "H": "u2",
-        "i": "s4",
+        "i": "i4",
         "U": "u4",
         "e": "f2",
         "f": "f4",

--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -12,11 +12,11 @@ def array_from_shadertype(shadertype):
     assert isinstance(shadertype, dict)
 
     primitives = {
-        "s1": "int8",
+        "i1": "int8",
         "u1": "uint8",
-        "s2": "int16",
+        "i2": "int16",
         "u2": "uint16",
-        "s4": "int32",
+        "i4": "int32",
         "u4": "uint32",
         "f2": "float16",
         "f4": "float32",

--- a/tests/renderers/test_shader_composer.py
+++ b/tests/renderers/test_shader_composer.py
@@ -53,7 +53,7 @@ def test_uniform_definitions():
         shader.define_uniform(0, 0, "zz", np.array([1]).dtype)
 
     # Test simple scalars
-    struct = dict(foo="f4", bar="s2")
+    struct = dict(foo="f4", bar="i2")
     shader.define_uniform(0, 0, "zz", struct)
     assert (
         shader.get_definitions().strip()
@@ -70,7 +70,7 @@ def test_uniform_definitions():
     )
 
     # Test vec
-    struct = dict(foo="4xf4", bar="2xs4")
+    struct = dict(foo="4xf4", bar="2xi4")
     shader.define_uniform(0, 0, "zz", struct)
     assert (
         shader.get_definitions().strip()
@@ -87,7 +87,7 @@ def test_uniform_definitions():
     )
 
     # Test mat
-    struct = dict(foo="4x4xf4", bar="2x3xs4")
+    struct = dict(foo="4x4xf4", bar="2x3xi4")
     shader.define_uniform(0, 0, "zz", struct)
     assert (
         shader.get_definitions().strip()
@@ -104,10 +104,10 @@ def test_uniform_definitions():
     )
 
     # Test alignment
-    struct = dict(foo="3xf4", bar="4xs4")
+    struct = dict(foo="3xf4", bar="4xi4")
     with raises(TypeError):
         shader.define_uniform(0, 0, "zz", struct)
-    struct = dict(foo="3xf4", _padding="f4", bar="4xs4")
+    struct = dict(foo="3xf4", _padding="f4", bar="4xi4")
     shader.define_uniform(0, 0, "zz", struct)
 
 


### PR DESCRIPTION
Addendum to #156 

In Numpy, WGSL and Rust, the single-char type for a signed integer is `i`, not `s`. I have no idea how I came to using "s".