### PR TITLE
Release pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
           pytest -v tests
 
   release-build:
-    name: Build wheels on ubuntu-latest
+    name: Build release on ubuntu-latest
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -106,9 +106,22 @@ jobs:
       - name: Install dev dependencies
         run: |
             python -m pip install --upgrade pip wheel setuptools twine
+      - name: Create source distribution
+        run: |
+          python setup.py sdist
       - name: Build wheels
         run: |
             pip wheel --no-deps -w dist .
+      - name: Test sdist
+        shell: bash
+        run: |
+            rm -rf ./pygfx
+            pushd $HOME
+            pip install $GITHUB_WORKSPACE/dist/*.tar.gz
+            popd
+            # don't run tests, we just want to know if the sdist can be installed
+            pip uninstall -y pygfx
+            git reset --hard HEAD
       - name: Twine check
         run: |
             twine check dist/*
@@ -118,47 +131,10 @@ jobs:
           path: dist
           name: dist
 
-  sdist-build:
-    name: Build sdist on ubuntu-latest
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.9'
-    - name: Install dev dependencies
-      run: |
-          python -m pip install --upgrade pip
-          pip install -U -r dev-requirements.txt
-    - name: Create source distribution
-      run: |
-          python setup.py sdist
-    - name: Test sdist
-      shell: bash
-      run: |
-          rm -rf ./pygfx
-          pushd $HOME
-          pip install $GITHUB_WORKSPACE/dist/*.tar.gz
-          popd
-          # don't run tests, we just want to know if the sdist can be installed
-          pip uninstall -y pygfx
-          git reset --hard HEAD
-    - name: Twine check
-      run: |
-          twine check dist/*
-    - name: Upload distributions
-      uses: actions/upload-artifact@v2
-      with:
-        path: dist
-        name: dist
-
   publish:
     name: Publish release to Github and Pypi
     runs-on: ubuntu-latest
-    needs: [test-builds, release-build, sdist-build]
+    needs: [test-builds, release-build]
     if: success() && startsWith(github.ref, 'refs/tags/v')
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR sets up a release pipeline.

I copied most of it from wgpu, but adjusted the following things:

* Only build 1 wheel on one platform (no matrix)
* Replace AButler/upload-release-assets@v2.0 and actions/create-release@v1 with softprops/action-gh-release@v1, as the other actions seem to be unmaintained.

See [here](https://github.com/marketplace/actions/gh-release) for configuration options of this task.