### PR TITLE
WIP OIT via weighted blended / McGuire

### DIFF
--- a/examples/transparency1.py
+++ b/examples/transparency1.py
@@ -1,0 +1,49 @@
+"""
+Example showing transparency.
+"""
+import time
+import wgpu
+import pygfx as gfx
+
+from PyQt5 import QtWidgets
+from wgpu.gui.qt import WgpuCanvas
+
+
+app = QtWidgets.QApplication([])
+
+canvas = WgpuCanvas()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+geometry = gfx.PlaneGeometry(50, 50)
+plane1 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(1, 0, 0, 0.4)))
+plane2 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 1, 0, 0.4)))
+plane3 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 0, 1, 0.4)))
+plane4 = gfx.Mesh(
+    gfx.PlaneGeometry(100, 10), gfx.MeshBasicMaterial(color=(0, 1, 0, 0.4))
+)
+
+plane1.position.set(-10, -10, 1)
+plane2.position.set(0, 0, 2)
+plane3.position.set(10, 10, 3)
+
+scene.add(plane2, plane1, plane3, plane4)
+# scene.add(plane1, plane2, plane3, plane4)
+# scene.add(plane3, plane2, plane1)
+
+
+camera = gfx.OrthographicCamera(100, 100)
+
+
+def animate():
+    z = time.time() % 4
+    plane4.position.x = z
+    plane4.position.z = z * 400
+
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    app.exec()


### PR DESCRIPTION
We use the existing color target as the accumulation buffer and a new (additional) render target for the revealage.

In the current state it implicitly assumes that there are no opaque fragments. One thing that should be done is to add a render step that renders the opaque fragments (and sets the depth buffer). These opaque fragments should then be blended where we also resolve the transparent objects.

Thoughts:
* It's nice that this does not require any advanced GPU trickery.
* I don't like that we'd need to draw everything twice to separate the opaque from the transparent objects. 
* One feature of this approach is that it has "smooth transitions". This is nice if you have particle systems, e.g. simulate fog with 20 or so blobs, but it can also result in unexpected results. In particular, this method performs really bad with near-opaque objects that are too close to each-other for the weighing function to make a significant difference.

![image](https://user-images.githubusercontent.com/3015475/137030176-d3235a58-b94e-4a58-a5d5-2045ce3a5441.png)
