### PR TITLE
Rename VertexOutput.ndc_pos to position 

### DIFF
--- a/pygfx/renderers/wgpu/_renderutils.py
+++ b/pygfx/renderers/wgpu/_renderutils.py
@@ -43,7 +43,7 @@ class FinalShader(BaseShader):
 
         struct VertexOutput {
             [[location(0)]] texcoord: vec2<f32>;
-            [[builtin(position)]] pos: vec4<f32>;
+            [[builtin(position)]] position: vec4<f32>;
         };
 
         [[group(0), binding(1)]]
@@ -57,7 +57,7 @@ class FinalShader(BaseShader):
             let pos = positions[index];
             var out: VertexOutput;
             out.texcoord = vec2<f32>(pos.x, 1.0 - pos.y);
-            out.pos = vec4<f32>(pos * 2.0 - 1.0, 0.0, 1.0);
+            out.position = vec4<f32>(pos * 2.0 - 1.0, 0.0, 1.0);
             return out;
         }
 

--- a/pygfx/renderers/wgpu/backgroundrender.py
+++ b/pygfx/renderers/wgpu/backgroundrender.py
@@ -78,7 +78,7 @@ class BackgroundShader(WorldObjectShader):
         struct VertexOutput {
             [[location(0)]] texcoord: vec3<f32>;
             [[location(1)]] world_pos: vec3<f32>;
-            [[builtin(position)]] ndc_pos: vec4<f32>;
+            [[builtin(position)]] position: vec4<f32>;
         };
 
         struct FragmentOutput {
@@ -107,13 +107,13 @@ class BackgroundShader(WorldObjectShader):
                 let wpos1 = ndc_to_world_pos(ndc_pos1);
                 let wpos2 = ndc_to_world_pos(ndc_pos2);
                 // Store positions and the view direction in the world
-                out.ndc_pos = ndc_pos1;
+                out.position = ndc_pos1;
                 out.world_pos = wpos1;
                 out.texcoord = wpos2.xyz - wpos1.xyz;
             $$ else
                 // Store positions and the view direction in the world
-                out.ndc_pos = vec4<f32>(pos, 0.9999999, 1.0);
-                out.world_pos = ndc_to_world_pos(out.ndc_pos);
+                out.position = vec4<f32>(pos, 0.9999999, 1.0);
+                out.world_pos = ndc_to_world_pos(out.position);
                 out.texcoord = vec3<f32>(pos * 0.5 + 0.5, 0.0);
             $$ endif
             return out;

--- a/pygfx/renderers/wgpu/linerender.py
+++ b/pygfx/renderers/wgpu/linerender.py
@@ -146,7 +146,7 @@ class LineShader(WorldObjectShader):
             [[location(2)]] color: vec4<f32>;
             [[location(3)]] vertex_idx: vec2<f32>;
             [[location(4)]] world_pos: vec3<f32>;
-            [[builtin(position)]] ndc_pos: vec4<f32>;
+            [[builtin(position)]] position: vec4<f32>;
         };
 
         struct VertexFuncOutput {
@@ -200,7 +200,7 @@ class LineShader(WorldObjectShader):
 
             var out: VertexOutput;
             out.world_pos = ndc_to_world_pos(result.pos);
-            out.ndc_pos = result.pos;
+            out.position = result.pos;
             out.thickness_p = result.thickness_p;
             out.vec_from_node_p = result.vec_from_node_p;
             out.vertex_idx = vec2<f32>(f32(result.i / 10000), f32(result.i % 10000));
@@ -474,7 +474,7 @@ class LineShader(WorldObjectShader):
             alpha = pow(min(1.0, alpha), 2.0);
 
             // The outer edges with lower alpha for aa are pushed a bit back to avoid artifacts.
-            out.depth = in.ndc_pos.z + 0.0001 * (0.8 - min(0.8, alpha));
+            out.depth = in.position.z + 0.0001 * (0.8 - min(0.8, alpha));
 
             // Set color
             let color = in.color;
@@ -565,7 +565,7 @@ class ThinLineShader(WorldObjectShader):
             $$ if per_vertex_color
             [[location(0)]] color: vec4<f32>;
             $$ endif
-            [[builtin(position)]] pos: vec4<f32>;
+            [[builtin(position)]] position: vec4<f32>;
         };
 
         struct FragmentOutput {
@@ -579,11 +579,11 @@ class ThinLineShader(WorldObjectShader):
         [[stage(vertex)]]
         fn vs_main(in: VertexInput) -> VertexOutput {
 
-            let wpos = u_wobject.world_transform * vec4<f32>(in.pos.xyz, 1.0);
+            let wpos = u_wobject.world_transform * vec4<f32>(in.position.xyz, 1.0);
             let npos = u_stdinfo.projection_transform * u_stdinfo.cam_transform * wpos;
 
             var out: VertexOutput;
-            out.pos = npos;
+            out.position = npos;
             $$ if per_vertex_color
             out.color = in.color;
             $$ endif

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -219,7 +219,7 @@ class MeshShader(WorldObjectShader):
             $$ if wireframe
             [[location(7)]] wireframe_coords: vec3<f32>;
             $$ endif
-            [[builtin(position)]] ndc_pos: vec4<f32>;
+            [[builtin(position)]] position: vec4<f32>;
         };
 
         struct FragmentOutput {
@@ -288,7 +288,7 @@ class MeshShader(WorldObjectShader):
 
             // Set position
             out.world_pos =world_pos.xyz / world_pos.w;
-            out.ndc_pos = vec4<f32>(ndc_pos.xyz, ndc_pos.w);
+            out.position = vec4<f32>(ndc_pos.xyz, ndc_pos.w);
 
             // Set texture coords
             $$ if texture_dim == '1d'
@@ -375,7 +375,7 @@ class MeshShader(WorldObjectShader):
 
             var out: VertexOutput;
             out.world_pos = vec3<f32>(world_pos.xyz / world_pos.w);
-            out.ndc_pos = ndc_pos;
+            out.position = ndc_pos;
             return out;
         }
         """
@@ -628,7 +628,7 @@ class MeshSliceShader(WorldObjectShader):
             [[location(3)]] face_idx: vec4<f32>;
             [[location(4)]] face_coords: vec3<f32>;
             [[location(5)]] world_pos: vec3<f32>;
-            [[builtin(position)]] ndc_pos: vec4<f32>;
+            [[builtin(position)]] position: vec4<f32>;
         };
 
         struct FragmentOutput {
@@ -788,7 +788,7 @@ class MeshSliceShader(WorldObjectShader):
 
             // Shader output
             out.world_pos = ndc_to_world_pos(the_pos);
-            out.ndc_pos = the_pos;
+            out.position = the_pos;
             out.dist2center = the_coord * l2p;
             out.segment_length = segment_length * l2p;
             out.segment_width = thickness * l2p;

--- a/pygfx/renderers/wgpu/pointsrender.py
+++ b/pygfx/renderers/wgpu/pointsrender.py
@@ -94,7 +94,7 @@ class PointsShader(WorldObjectShader):
             $$ if per_vertex_colors
             [[location(4)]] color: vec4<f32>;
             $$ endif
-            [[builtin(position)]] ndc_pos: vec4<f32>;
+            [[builtin(position)]] position: vec4<f32>;
         };
 
         struct FragmentOutput {
@@ -138,7 +138,7 @@ class PointsShader(WorldObjectShader):
             let delta_logical = deltas[sub_index] * (size + aa_margin);
             let delta_ndc = delta_logical * (1.0 / u_stdinfo.logical_size);
             out.world_pos = world_pos.xyz / world_pos.w;
-            out.ndc_pos = vec4<f32>(ndc_pos.xy + delta_ndc, ndc_pos.zw);
+            out.position = vec4<f32>(ndc_pos.xy + delta_ndc, ndc_pos.zw);
             out.pointcoord = delta_logical;
 
             $$ if per_vertex_colors

--- a/pygfx/renderers/wgpu/volumerender.py
+++ b/pygfx/renderers/wgpu/volumerender.py
@@ -165,7 +165,7 @@ class VolumeSliceShader(BaseVolumeShader):
         struct VertexOutput {
             [[location(0)]] texcoord: vec3<f32>;
             [[location(1)]] world_pos: vec3<f32>;
-            [[builtin(position)]] ndc_pos: vec4<f32>;
+            [[builtin(position)]] position: vec4<f32>;
         };
 
         struct FragmentOutput {
@@ -319,7 +319,7 @@ class VolumeSliceShader(BaseVolumeShader):
             let world_pos = vertices[ indexmap[index] ];
             let ndc_pos = u_stdinfo.projection_transform * u_stdinfo.cam_transform * vec4<f32>(world_pos, 1.0);
             out.world_pos = world_pos;
-            out.ndc_pos = ndc_pos;
+            out.position = ndc_pos;
             out.texcoord = texcoords[ indexmap[index] ];
 
             return out;


### PR DESCRIPTION
Based on #177 - will rebase when that's merged.

In all shaders we have a struct for the vertex output, which is also the fragment input:
```
        struct VertexOutput {
            [[location(0)]] varying1: f32;
            ...
            [[builtin(position)]] ndc_pos: vec4<f32>;
        };
```

That `ndc_pos` field is indeed the NDC (normalized device coordinate) when its the output of the vertex shader, but when its the input to the fragment shader, its not - then xy are in pixel coordinates and z is -1..1 (same as in NDC). To avoid confusion, this PR makes that field use a more generic name.

Also see the [WGSL docs](https://www.w3.org/TR/WGSL/):
![image](https://user-images.githubusercontent.com/3015475/138849551-f3530ac3-ff34-40e3-827a-c27511aa9f40.png)


