### PR TITLE
OIT step 3: proper rendering of frontmost layer

### DIFF
--- a/examples/transparency1.py
+++ b/examples/transparency1.py
@@ -19,7 +19,15 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
             scene.add(scene.children[0])
             canvas.request_draw()
         elif event.text() in "0123456789":
-            m = [None, "opaque", "simple1", "simple2", "blended", "weighted"]
+            m = [
+                None,
+                "opaque",
+                "simple1",
+                "simple2",
+                "weighted",
+                "weighted_depth",
+                "weighted_plus",
+            ]
             mode = m[int(event.text())]
             renderer.blend_mode = mode
             print("Selecting blend_mode", mode)

--- a/examples/transparency2.py
+++ b/examples/transparency2.py
@@ -39,7 +39,15 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
             print("Rotating scene element order")
             scene.add(scene.children[0])
         elif event.text() in "0123456789":
-            m = [None, "opaque", "simple1", "simple2", "blended", "weighted"]
+            m = [
+                None,
+                "opaque",
+                "simple1",
+                "simple2",
+                "weighted",
+                "weighted_depth",
+                "weighted_plus",
+            ]
             mode = m[int(event.text())]
             renderer.blend_mode = mode
             print("Selecting blend_mode", mode)
@@ -71,9 +79,9 @@ scene = gfx.Scene()
 sphere = gfx.Mesh(gfx.sphere_geometry(10), gfx.MeshPhongMaterial())
 
 geometry = gfx.plane_geometry(50, 50)
-plane1 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(1, 0, 0, 0.5)))
+plane1 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(1, 0, 0, 0.3)))
 plane2 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 1, 0, 0.5)))
-plane3 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 0, 1, 0.5)))
+plane3 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 0, 1, 0.7)))
 
 plane1.rotation.set_from_axis_angle(gfx.linalg.Vector3(1, 0, 0), 1.571)
 plane2.rotation.set_from_axis_angle(gfx.linalg.Vector3(0, 1, 0), 1.571)

--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -63,13 +63,13 @@ class OpaquePass(BasePass):
     depth_write_enabled = True
 
     def get_pipeline_targets(self, blender):
-        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
+        bf, bo = wgpu.BlendFactor, wgpu.BlendOperation
         return [
             {
                 "format": blender.color_format,
                 "blend": {
-                    "alpha": (BF.one, BF.zero, BO.add),
-                    "color": (BF.one, BF.zero, BO.add),
+                    "alpha": (bf.one, bf.zero, bo.add),
+                    "color": (bf.one, bf.zero, bo.add),
                 },
                 "write_mask": wgpu.ColorWrite.ALL,
             },
@@ -162,13 +162,13 @@ class SimpleSinglePass(OpaquePass):
     depth_write_enabled = True
 
     def get_pipeline_targets(self, blender):
-        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
+        bf, bo = wgpu.BlendFactor, wgpu.BlendOperation
         return [
             {
                 "format": blender.color_format,
                 "blend": {
-                    "alpha": (BF.one, BF.one_minus_src_alpha, BO.add),
-                    "color": (BF.one, BF.one_minus_src_alpha, BO.add),
+                    "alpha": (bf.one, bf.one_minus_src_alpha, bo.add),
+                    "color": (bf.one, bf.one_minus_src_alpha, bo.add),
                 },
                 "write_mask": wgpu.ColorWrite.ALL,
             },
@@ -213,13 +213,13 @@ class SimpleTransparencyPass(BasePass):
     depth_write_enabled = False
 
     def get_pipeline_targets(self, blender):
-        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
+        bf, bo = wgpu.BlendFactor, wgpu.BlendOperation
         return [
             {
                 "format": blender.color_format,
                 "blend": {
-                    "alpha": (BF.one, BF.one_minus_src_alpha, BO.add),
-                    "color": (BF.one, BF.one_minus_src_alpha, BO.add),
+                    "alpha": (bf.one, bf.one_minus_src_alpha, bo.add),
+                    "color": (bf.one, bf.one_minus_src_alpha, bo.add),
                 },
                 "write_mask": wgpu.ColorWrite.ALL,
             },
@@ -286,21 +286,21 @@ class WeightedTransparencyPass(BasePass):
         self._weight_code = weight_code.strip()
 
     def get_pipeline_targets(self, blender):
-        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
+        bf, bo = wgpu.BlendFactor, wgpu.BlendOperation
         return [
             {
                 "format": blender.accum_format,
                 "blend": {
-                    "alpha": (BF.one, BF.one, BO.add),
-                    "color": (BF.one, BF.one, BO.add),
+                    "alpha": (bf.one, bf.one, bo.add),
+                    "color": (bf.one, bf.one, bo.add),
                 },
                 "write_mask": wgpu.ColorWrite.ALL,
             },
             {
                 "format": blender.reveal_format,
                 "blend": {
-                    "alpha": (BF.zero, BF.one_minus_src_alpha, BO.add),
-                    "color": (BF.zero, BF.one_minus_src, BO.add),
+                    "alpha": (bf.zero, bf.one_minus_src_alpha, bo.add),
+                    "color": (bf.zero, bf.one_minus_src, bo.add),
                 },
                 "write_mask": wgpu.ColorWrite.ALL,
             },
@@ -365,13 +365,13 @@ class FrontmostTransparencyPass(BasePass):
     depth_write_enabled = True
 
     def get_pipeline_targets(self, blender):
-        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
+        bf, bo = wgpu.BlendFactor, wgpu.BlendOperation
         return [
             {
                 "format": blender.frontcolor_format,
                 "blend": {
-                    "alpha": (BF.one, BF.zero, BO.add),
-                    "color": (BF.one, BF.zero, BO.add),
+                    "alpha": (bf.one, bf.zero, bo.add),
+                    "color": (bf.one, bf.zero, bo.add),
                 },
                 "write_mask": wgpu.ColorWrite.ALL,
             },
@@ -617,13 +617,13 @@ class WeightedFragmentBlender(BaseFragmentBlender):
             {"binding": 1, "resource": self.reveal_view},
         ]
 
-        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
+        bf, bo = wgpu.BlendFactor, wgpu.BlendOperation
         targets = [
             {
                 "format": self.color_format,
                 "blend": {
-                    "alpha": (BF.one, BF.one_minus_src_alpha, BO.add),
-                    "color": (BF.one, BF.one_minus_src_alpha, BO.add),
+                    "alpha": (bf.one, bf.one_minus_src_alpha, bo.add),
+                    "color": (bf.one, bf.one_minus_src_alpha, bo.add),
                 },
             },
         ]
@@ -731,13 +731,13 @@ class WeightedPlusFragmentBlender(WeightedFragmentBlender):
             {"binding": 2, "resource": self.frontcolor_view},
         ]
 
-        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
+        bf, bo = wgpu.BlendFactor, wgpu.BlendOperation
         targets = [
             {
                 "format": self.color_format,
                 "blend": {
-                    "alpha": (BF.one, BF.one_minus_src_alpha, BO.add),
-                    "color": (BF.one, BF.one_minus_src_alpha, BO.add),
+                    "alpha": (bf.one, bf.one_minus_src_alpha, bo.add),
+                    "color": (bf.one, bf.one_minus_src_alpha, bo.add),
                 },
             },
         ]

--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -447,6 +447,7 @@ class BaseFragmentBlender:
 
         # The below targets are always present, and the renderer expects their
         # format, texture, and view to be present.
+        # These contribute to 4+4+16 = 24 bytes per pixel
 
         usg = wgpu.TextureUsage
 
@@ -591,6 +592,10 @@ class WeightedFragmentBlender(BaseFragmentBlender):
 
         usg = wgpu.TextureUsage
 
+        # Create two additional render targets.
+        # These contribute 8+2 = 10 bytes per pixel
+        # So the total = 24 + 10 = 34 bytes per pixel
+
         # The accumulation buffer collects weighted fragments
         self._texture_info["accum"] = (
             wgpu.TextureFormat.rgba16float,
@@ -700,7 +705,11 @@ class WeightedPlusFragmentBlender(WeightedFragmentBlender):
 
         usg = wgpu.TextureUsage
 
-        # One extra color buffer for the front-most semitransparent layer
+        # Create one additional render target.
+        # This contributes 4 bytes per pixel
+        # So the total = 24 + 10 + 4 = 38 bytes per pixel
+
+        # Color buffer for the front-most semitransparent layer
         self._texture_info["frontcolor"] = (
             wgpu.TextureFormat.rgba8unorm,
             usg.RENDER_ATTACHMENT | usg.TEXTURE_BINDING,

--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -11,7 +11,7 @@ from ._flusher import FULL_QUAD_SHADER, _create_pipeline
 
 
 standard_texture_des = {
-    "sample_type": wgpu.TextureSampleType.float,
+    "sample_type": wgpu.TextureSampleType.unfilterable_float,
     "view_dimension": wgpu.TextureViewDimension.d2,
     "multisampled": False,
 }

--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -313,7 +313,7 @@ class WeightedTransparencyPass(BasePass):
                 let weight = alpha;
             """
         elif weight_func == "depth":
-            # The "generic purpose" depth function proposed by McGuire in
+            # The "generic purpose" weight function proposed by McGuire in
             # http://casual-effects.blogspot.com/2015/03/implemented-weighted-blended-order.html
             weight_code = """
                 let a = min(1.0, alpha) * 8.0 + 0.01;
@@ -745,7 +745,7 @@ class WeightedDepthFragmentBlender(WeightedFragmentBlender):
 
 class WeightedPlusFragmentBlender(WeightedFragmentBlender):
     """Three-pass weighted blended order independent transparency (McGuire 2013),
-    using a depth function based on alpha, and in which the top-most
+    using a weight function based on alpha, and in which the top-most
     transparent layer is actually in front.
 
     This uses the same approach as WeightedFragmentBlender, but in a

--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -3,11 +3,27 @@ import wgpu  # only for flags/enums
 from ._flusher import FULL_QUAD_SHADER, _create_pipeline
 
 
+# Notes:
+# - The user code provides color as-is in rgba.
+# - In the add_fragment logic defined in the shaders here, the color
+#   is pre-multiplied with the alpha.
+# - All fixed-pipeling blending option assume premultiplied alpha.
+
+
+standard_texture_des = {
+    "sample_type": wgpu.TextureSampleType.float,
+    "view_dimension": wgpu.TextureViewDimension.d2,
+    "multisampled": False,
+}
+
+
 # %%%%%%%%%%  Define passes
 
 
 class BasePass:
     """The base pass class, defining and documenting the API that a pass must provide."""
+
+    depth_write_enabled = True
 
     def get_pipeline_targets(self, blender):
         """Get the list of fragment targets for device.create_render_pipeline()."""
@@ -38,31 +54,22 @@ class BasePass:
         return ""
 
 
-class NullPass(BasePass):
-    """An empty (unused) pass."""
-
-
 class OpaquePass(BasePass):
     """A pass that renders opaque fragments with depth testing, while
     discarting transparent fragments. This functions as the first pass
-    in all mult-pass blenders.
+    in all multi-pass blenders.
     """
 
+    depth_write_enabled = True
+
     def get_pipeline_targets(self, blender):
+        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
         return [
             {
                 "format": blender.color_format,
                 "blend": {
-                    "alpha": (
-                        wgpu.BlendFactor.one,
-                        wgpu.BlendFactor.zero,
-                        wgpu.BlendOperation.add,
-                    ),
-                    "color": (
-                        wgpu.BlendFactor.one,
-                        wgpu.BlendFactor.zero,
-                        wgpu.BlendOperation.add,
-                    ),
+                    "alpha": (BF.one, BF.zero, BO.add),
+                    "color": (BF.one, BF.zero, BO.add),
                 },
                 "write_mask": wgpu.ColorWrite.ALL,
             },
@@ -107,14 +114,14 @@ class OpaquePass(BasePass):
         };
         fn add_fragment(depth: f32, color: vec4<f32>) {
             if (color.a >= 1.0 && depth < p_fragment_depth) {
-                p_fragment_color = color;
+                p_fragment_color = vec4<f32>(color.rgb, 1.0);
                 p_fragment_depth = depth;
             }
         }
         fn finalize_fragment() -> FragmentOutput {
             if (p_fragment_depth > 1.0) { discard; }
             var out : FragmentOutput;
-            out.color = vec4<f32>(p_fragment_color.rgb, 1.0);
+            out.color = p_fragment_color;
             return out;
         }
         """
@@ -122,6 +129,8 @@ class OpaquePass(BasePass):
 
 class FullOpaquePass(OpaquePass):
     """A pass that considers all fragments opaque."""
+
+    depth_write_enabled = True
 
     def get_shader_code(self, blender):
         return """
@@ -134,14 +143,14 @@ class FullOpaquePass(OpaquePass):
         };
         fn add_fragment(depth: f32, color: vec4<f32>) {
             if (depth < p_fragment_depth) {
-                p_fragment_color = color;
+                p_fragment_color = vec4<f32>(color.rgb, 1.0);  // always opaque
                 p_fragment_depth = depth;
             }
         }
         fn finalize_fragment() -> FragmentOutput {
             if (p_fragment_depth > 1.0) { discard; }
             var out : FragmentOutput;
-            out.color = vec4<f32>(p_fragment_color.rgb, 1.0);  // opaque
+            out.color = p_fragment_color;
             return out;
         }
         """
@@ -150,21 +159,16 @@ class FullOpaquePass(OpaquePass):
 class SimpleSinglePass(OpaquePass):
     """A pass that blends opaque and transparent fragments in a single pass."""
 
+    depth_write_enabled = True
+
     def get_pipeline_targets(self, blender):
+        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
         return [
             {
                 "format": blender.color_format,
                 "blend": {
-                    "alpha": (
-                        wgpu.BlendFactor.one,
-                        wgpu.BlendFactor.one_minus_src_alpha,
-                        wgpu.BlendOperation.add,
-                    ),
-                    "color": (
-                        wgpu.BlendFactor.src_alpha,
-                        wgpu.BlendFactor.one_minus_src_alpha,
-                        wgpu.BlendOperation.add,
-                    ),
+                    "alpha": (BF.one, BF.one_minus_src_alpha, BO.add),
+                    "color": (BF.one, BF.one_minus_src_alpha, BO.add),
                 },
                 "write_mask": wgpu.ColorWrite.ALL,
             },
@@ -187,7 +191,7 @@ class SimpleSinglePass(OpaquePass):
         };
         fn add_fragment(depth: f32, color: vec4<f32>) {
             if (depth < p_fragment_depth) {
-                p_fragment_color = color;
+                p_fragment_color = vec4<f32>(color.rgb * color.a, color.a);
                 p_fragment_depth = depth;
             }
         }
@@ -200,26 +204,22 @@ class SimpleSinglePass(OpaquePass):
         """
 
 
-class SimpleSecondPass(BasePass):
+class SimpleTransparencyPass(BasePass):
     """A pass that only renders transparent fragments, blending them
-    with the classic OVER operator.
+    with the classic recursive alpha blending equation (a.k.a. the OVER
+    operator).
     """
 
+    depth_write_enabled = False
+
     def get_pipeline_targets(self, blender):
+        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
         return [
             {
                 "format": blender.color_format,
                 "blend": {
-                    "alpha": (
-                        wgpu.BlendFactor.one,
-                        wgpu.BlendFactor.one_minus_src_alpha,
-                        wgpu.BlendOperation.add,
-                    ),
-                    "color": (
-                        wgpu.BlendFactor.one,
-                        wgpu.BlendFactor.one_minus_src_alpha,
-                        wgpu.BlendOperation.add,
-                    ),
+                    "alpha": (BF.one, BF.one_minus_src_alpha, BO.add),
+                    "color": (BF.one, BF.one_minus_src_alpha, BO.add),
                 },
                 "write_mask": wgpu.ColorWrite.ALL,
             },
@@ -256,18 +256,17 @@ class SimpleSecondPass(BasePass):
         """
 
 
-class McGuirePass(BasePass):
+class WeightedTransparencyPass(BasePass):
     """A pass that implements weighted blended order-independed
-    blending for transparent fragments.
+    blending for transparent fragments, as proposed by McGuire in 2013.
+    Multiple weight functions are supported.
     """
+
+    depth_write_enabled = False
 
     def __init__(self, weight_func):
 
-        if weight_func == "none":
-            weight_code = """
-                let weight = 1.0;
-            """
-        elif weight_func == "alpha":
+        if weight_func == "alpha":
             weight_code = """
                 let weight = alpha;
             """
@@ -280,41 +279,28 @@ class McGuirePass(BasePass):
                 let weight = clamp(a * a * a * 1e8 * b * b * b, 1e-2, 3e2);
             """
         else:
-            raise ValueError(f"Unknown McGuirePass weight_func: {weight_func!r}")
+            raise ValueError(
+                f"Unknown WeightedTransparencyPass weight_func: {weight_func!r}"
+            )
 
         self._weight_code = weight_code.strip()
 
     def get_pipeline_targets(self, blender):
+        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
         return [
             {
                 "format": blender.accum_format,
                 "blend": {
-                    "alpha": (
-                        wgpu.BlendFactor.one,
-                        wgpu.BlendFactor.one,
-                        wgpu.BlendOperation.add,
-                    ),
-                    "color": (
-                        wgpu.BlendFactor.one,
-                        wgpu.BlendFactor.one,
-                        wgpu.BlendOperation.add,
-                    ),
+                    "alpha": (BF.one, BF.one, BO.add),
+                    "color": (BF.one, BF.one, BO.add),
                 },
                 "write_mask": wgpu.ColorWrite.ALL,
             },
             {
                 "format": blender.reveal_format,
                 "blend": {
-                    "alpha": (
-                        wgpu.BlendFactor.one,
-                        wgpu.BlendFactor.one_minus_src,
-                        wgpu.BlendOperation.add,
-                    ),
-                    "color": (
-                        wgpu.BlendFactor.zero,
-                        wgpu.BlendFactor.one_minus_src,
-                        wgpu.BlendOperation.add,
-                    ),
+                    "alpha": (BF.zero, BF.one_minus_src_alpha, BO.add),
+                    "color": (BF.zero, BF.one_minus_src, BO.add),
                 },
                 "write_mask": wgpu.ColorWrite.ALL,
             },
@@ -354,7 +340,7 @@ class McGuirePass(BasePass):
         };
         fn add_fragment(depth: f32, color: vec4<f32>) {
             let premultiplied = color.rgb * color.a;
-            let alpha = color.a;  // could take transmittance into account here
+            let alpha = color.a;  // could take user-specified transmittance into account
             WEIGHT_CODE
             p_fragment_accum = vec4<f32>(premultiplied, alpha) * weight;
             p_fragment_reveal = alpha;
@@ -371,6 +357,65 @@ class McGuirePass(BasePass):
         )
 
 
+class FrontmostTransparencyPass(BasePass):
+    """A render pass that renders the front-most transparent layer to
+    a custom render target. This can then later be used in the combine-pass.
+    """
+
+    depth_write_enabled = True
+
+    def get_pipeline_targets(self, blender):
+        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
+        return [
+            {
+                "format": blender.frontcolor_format,
+                "blend": {
+                    "alpha": (BF.one, BF.zero, BO.add),
+                    "color": (BF.one, BF.zero, BO.add),
+                },
+                "write_mask": wgpu.ColorWrite.ALL,
+            },
+        ]
+
+    def get_color_attachments(self, blender, clear):
+        if clear:
+            color_load_value = 0, 0, 0, 0
+        else:
+            color_load_value = wgpu.LoadOp.load
+
+        return [
+            {
+                "view": blender.frontcolor_view,
+                "resolve_target": None,
+                "load_value": color_load_value,
+                "store_op": wgpu.StoreOp.store,
+            },
+        ]
+
+    def get_shader_code(self, blender):
+        return """
+        var<private> p_fragment_color : vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
+        var<private> p_fragment_depth : f32 = 1.1;
+
+        struct FragmentOutput {
+            [[location(0)]] color: vec4<f32>;
+            [[location(1)]] pick: vec4<i32>;
+        };
+        fn add_fragment(depth: f32, color: vec4<f32>) {
+            if (color.a > 0.0 && color.a < 1.0) {
+                p_fragment_color = vec4<f32>(color.rgb * color.a, color.a);
+                p_fragment_depth = depth;
+            }
+        }
+        fn finalize_fragment() -> FragmentOutput {
+            if (p_fragment_depth > 1.0) { discard; }
+            var out : FragmentOutput;
+            out.color = p_fragment_color;
+            return out;
+        }
+        """
+
+
 # %%%%%%%%%% Define blenders
 
 
@@ -379,16 +424,13 @@ class BaseFragmentBlender:
     Each renderer has one blender object.
     """
 
-    pass1 = NullPass()
-    pass2 = NullPass()
+    # A list of passes
+    passes = []
 
     def __init__(self):
 
         # The size (2D in pixels) of the frame textures.
         self.size = (0, 0)
-
-        # Multi-sample anti-aliasing sample count.
-        self.msaa = 1
 
         # Pipeline objects
         self._combine_pass_info = None
@@ -444,19 +486,27 @@ class BaseFragmentBlender:
             setattr(self, name + "_tex", texture)
             setattr(self, name + "_view", texture.create_view())
 
-    # The three methods below represent the API that the render system uses.
+    # The five methods below represent the API that the render system uses.
 
-    def get_pipeline_targets(self, render_pass):
-        p = getattr(self, f"pass{render_pass}")
-        return p.get_pipeline_targets(self)
+    def get_pipeline_targets(self, pass_index):
+        return self.passes[pass_index].get_pipeline_targets(self)
 
-    def get_color_attachments(self, render_pass, clear):
-        p = getattr(self, f"pass{render_pass}")
-        return p.get_color_attachments(self, clear)
+    def get_color_attachments(self, pass_index, clear):
+        return self.passes[pass_index].get_color_attachments(self, clear)
 
-    def get_shader_code(self, render_pass):
-        p = getattr(self, f"pass{render_pass}")
-        return p.get_shader_code(self)
+    def get_shader_code(self, pass_index):
+        return self.passes[pass_index].get_shader_code(self)
+
+    def get_depth_write_enabled(self, pass_index):
+        return self.passes[pass_index].depth_write_enabled
+
+    def iter_pass_indices(self):
+        """Get an iterator that yield pass_index in the appropriate order.
+        Note that pass_index 0 (zero) is reserved for the "solid" pass in which
+        the pick info must be written. The index 0 is not necessarily the first
+        index of this iterator.
+        """
+        return range(len(self.passes))
 
     def perform_combine_pass(self, device, command_encoder):
         """Perform a render-pass to combine any multi-pass results, if needed."""
@@ -495,39 +545,40 @@ class OpaqueFragmentBlender(BaseFragmentBlender):
     even if they're not.
     """
 
-    pass1 = FullOpaquePass()
-    pass2 = NullPass()
+    passes = [FullOpaquePass()]
 
 
 class Simple1FragmentBlender(BaseFragmentBlender):
-    """A minimal fragment blender that does the minimal approach to blending:
-    use the OVER blend operation, without differentiating between opaque and
-    transparent objects. This is a common approach for applications using a single pass.
+    """A minimal fragment blender that uses the classic alpha blending
+    equation, without differentiating between opaque and transparent
+    objects. This is a common approach for applications using a single
+    pass.
     """
 
-    pass1 = SimpleSinglePass()
-    pass2 = NullPass()
+    passes = [SimpleSinglePass()]
 
 
 class Simple2FragmentBlender(BaseFragmentBlender):
-    """A first step towards better blending: separating the opaque
-    from the transparent fragments, and blending the latter using the
-    OVER operator. The second step has depth-testing, but no depth-writing.
-    Not order-independent.
+    """A first step towards better blending: separating the opaque from
+    the transparent fragments, and blending the latter using the alpha
+    blending equation. The second step has depth-testing, but no
+    depth-writing. Not order-independent.
     """
 
-    pass1 = OpaquePass()
-    pass2 = SimpleSecondPass()
+    passes = [OpaquePass(), SimpleTransparencyPass()]
 
 
-class BlendedFragmentBlender(BaseFragmentBlender):
-    """A blend approach that is order independent. This is the same
-    as the weighted blender (McGuire 2013), but without the depth
-    weights.
+class WeightedFragmentBlender(BaseFragmentBlender):
+    """Weighted blended order independent transparency (McGuire 2013),
+    using a weight function based only on alpha.
+
+    The opaque pass is followed by as pass that accumulates the
+    transparent fragments in two targets (4 channels) in a way that
+    weights the fragments. These are combined in the combine-pass,
+    realizing order independent blending.
     """
 
-    pass1 = OpaquePass()
-    pass2 = McGuirePass("alpha")
+    passes = [OpaquePass(), WeightedTransparencyPass("alpha")]
 
     def __init__(self):
         super().__init__()
@@ -557,20 +608,12 @@ class BlendedFragmentBlender(BaseFragmentBlender):
             {
                 "binding": 1,
                 "visibility": wgpu.ShaderStage.FRAGMENT,
-                "texture": {
-                    "sample_type": wgpu.TextureSampleType.float,
-                    "view_dimension": wgpu.TextureViewDimension.d2,
-                    "multisampled": False,
-                },
+                "texture": standard_texture_des,
             },
             {
                 "binding": 2,
                 "visibility": wgpu.ShaderStage.FRAGMENT,
-                "texture": {
-                    "sample_type": wgpu.TextureSampleType.float,
-                    "view_dimension": wgpu.TextureViewDimension.d2,
-                    "multisampled": False,
-                },
+                "texture": standard_texture_des,
             },
         ]
 
@@ -582,20 +625,13 @@ class BlendedFragmentBlender(BaseFragmentBlender):
             {"binding": 2, "resource": self.reveal_view},
         ]
 
+        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
         targets = [
             {
                 "format": self.color_format,
                 "blend": {
-                    "alpha": (
-                        wgpu.BlendFactor.src_alpha,
-                        wgpu.BlendFactor.one_minus_src_alpha,
-                        wgpu.BlendOperation.add,
-                    ),
-                    "color": (
-                        wgpu.BlendFactor.src_alpha,
-                        wgpu.BlendFactor.one_minus_src_alpha,
-                        wgpu.BlendOperation.add,
-                    ),
+                    "alpha": (BF.one, BF.one_minus_src_alpha, BO.add),
+                    "color": (BF.one, BF.one_minus_src_alpha, BO.add),
                 },
             },
         ]
@@ -611,10 +647,18 @@ class BlendedFragmentBlender(BaseFragmentBlender):
 
         fragment_code = """
             let epsilon = 0.00001;
+
+            // Sample
             let accum = textureSample(r_accum, r_sampler, texcoord).rgba;
             let reveal = textureSample(r_reveal, r_sampler, texcoord).r;
+
+            // Exit if no transparent fragments was written
+            if (reveal >= 1.0) { discard; }  // no transparent fragments here
+
+            // Reconstruct the color and alpha, and set final color, with premultiplied alpha
             let avg_color = accum.rgb / max(accum.a, epsilon);
-            out.color = vec4<f32>(avg_color, 1.0 - reveal);
+            let alpha = 1.0 - reveal;
+            out.color = vec4<f32>(avg_color * alpha, alpha);
         """
 
         wgsl = FULL_QUAD_SHADER
@@ -624,10 +668,138 @@ class BlendedFragmentBlender(BaseFragmentBlender):
         return _create_pipeline(device, binding_layouts, bindings, targets, wgsl)
 
 
-class WeightedFragmentBlender(BlendedFragmentBlender):
+class WeightedDepthFragmentBlender(WeightedFragmentBlender):
     """Weighted blended order independent transparency (McGuire 2013),
     using a general purpose depth weight function.
     """
 
-    pass1 = OpaquePass()
-    pass2 = McGuirePass("depth")
+    passes = [OpaquePass(), WeightedTransparencyPass("depth")]
+
+
+class WeightedPlusFragmentBlender(WeightedFragmentBlender):
+    """Three-pass weighted blended order independent transparency (McGuire 2013),
+    using a depth function based on alpha, and in which the top-most
+    transparent layer is actually in front.
+
+    This uses the same approach as WeightedFragmentBlender, but in a
+    3d pass we draw the front-most transparent layer. In the
+    combine-pass, we subtract the front layer from the accum and reveal
+    buffer, and add it again using the blend equation. In effect, the
+    front-most layer is actually correct, and all transparent fragments
+    behind it follow McGuire's approach. This looks a bit like a
+    single-layer depth peeling.
+
+    That 3d pass is actually drawn first, so that the final depth buffer
+    state matches the opaque content of the scene. Since we have a rule
+    that pass_index 0 means the opaque pass, we need to juggle the
+    indices in iter_pass_indices.
+    """
+
+    passes = [
+        OpaquePass(),
+        WeightedTransparencyPass("alpha"),
+        FrontmostTransparencyPass(),
+    ]
+
+    def __init__(self):
+        super().__init__()
+
+        usg = wgpu.TextureUsage
+
+        # One extra color buffer for the front-most semitransparent layer
+        self._texture_info["frontcolor"] = (
+            wgpu.TextureFormat.rgba8unorm,
+            usg.RENDER_ATTACHMENT | usg.TEXTURE_BINDING,
+        )
+
+    def iter_pass_indices(self):
+        return (2, 0, 1)
+
+    def _create_combination_pipeline(self, device):
+
+        binding_layouts = [
+            {
+                "binding": 0,
+                "visibility": wgpu.ShaderStage.FRAGMENT,
+                "sampler": {"type": wgpu.SamplerBindingType.filtering},
+            },
+            {
+                "binding": 1,
+                "visibility": wgpu.ShaderStage.FRAGMENT,
+                "texture": standard_texture_des,
+            },
+            {
+                "binding": 2,
+                "visibility": wgpu.ShaderStage.FRAGMENT,
+                "texture": standard_texture_des,
+            },
+            {
+                "binding": 3,
+                "visibility": wgpu.ShaderStage.FRAGMENT,
+                "texture": standard_texture_des,
+            },
+        ]
+
+        sampler = device.create_sampler(mag_filter="nearest", min_filter="nearest")
+
+        bindings = [
+            {"binding": 0, "resource": sampler},
+            {"binding": 1, "resource": self.accum_view},
+            {"binding": 2, "resource": self.reveal_view},
+            {"binding": 3, "resource": self.frontcolor_view},
+        ]
+
+        BF, BO = wgpu.BlendFactor, wgpu.BlendOperation
+        targets = [
+            {
+                "format": self.color_format,
+                "blend": {
+                    "alpha": (BF.one, BF.one_minus_src_alpha, BO.add),
+                    "color": (BF.one, BF.one_minus_src_alpha, BO.add),
+                },
+            },
+        ]
+
+        bindings_code = """
+            [[group(0), binding(0)]]
+            var r_sampler: sampler;
+            [[group(0), binding(1)]]
+            var r_accum: texture_2d<f32>;
+            [[group(0), binding(2)]]
+            var r_reveal: texture_2d<f32>;
+            [[group(0), binding(3)]]
+            var r_frontcolor: texture_2d<f32>;
+        """
+
+        fragment_code = """
+            let epsilon = 0.00001;
+
+            // Sample
+            var accum = textureSample(r_accum, r_sampler, texcoord).rgba;
+            var reveal = textureSample(r_reveal, r_sampler, texcoord).r;
+            let front = textureSample(r_frontcolor, r_sampler, texcoord).rgba;
+
+            // Exit if no transparent fragments was written - there also not be a front.
+            if (reveal >= 1.0) { discard; }  // no transparent fragments here
+
+            // Undo contribution of the front
+            let weight = front.a;  // This must match with the other pass!
+            accum = accum - front.rgba * weight;  // front is already pre-multiplied
+            reveal = reveal / (1.0 - front.a);
+
+            // Reconstruct the color and alpha, and set final color, with premultiplied alpha
+            let avg_color = accum.rgb / max(accum.a, epsilon);
+            let alpha = 1.0 - reveal;
+            out.color = vec4<f32>(avg_color * alpha, alpha);
+
+            // Blend in the front color (front is already premultiplied)
+            let out_rgb = (1.0 - front.a) * out.color.rgb + front.rgb;
+            let out_a = (1.0 - front.a) * out.color.a + front.a;
+            out.color = vec4<f32>(out_rgb, out_a);
+        """
+
+        wgsl = FULL_QUAD_SHADER
+        wgsl = wgsl.replace("BINDINGS_CODE", bindings_code)
+        wgsl = wgsl.replace("FRAGMENT_CODE", fragment_code)
+
+        return _create_pipeline(device, binding_layouts, bindings, targets, wgsl)

--- a/pygfx/renderers/wgpu/_flusher.py
+++ b/pygfx/renderers/wgpu/_flusher.py
@@ -32,8 +32,7 @@ FULL_QUAD_SHADER = """
     fn fs_main(varyings: Varyings) -> FragmentOutput {
         var out : FragmentOutput;
         let texcoord = varyings.texcoord;  // for textureSample
-        let position = varyings.position;
-        let texindex = vec2<i32>(position.xy);  // for textureLoad
+        let texindex = vec2<i32>(varyings.position.xy);  // for textureLoad
 
         FRAGMENT_CODE
 

--- a/pygfx/renderers/wgpu/_flusher.py
+++ b/pygfx/renderers/wgpu/_flusher.py
@@ -31,7 +31,9 @@ FULL_QUAD_SHADER = """
     [[stage(fragment)]]
     fn fs_main(varyings: Varyings) -> FragmentOutput {
         var out : FragmentOutput;
-        let texcoord = varyings.texcoord;
+        let texcoord = varyings.texcoord;  // for textureSample
+        let position = varyings.position;
+        let texindex = vec2<i32>(position.xy);  // for textureLoad
 
         FRAGMENT_CODE
 

--- a/pygfx/renderers/wgpu/_flusher.py
+++ b/pygfx/renderers/wgpu/_flusher.py
@@ -180,8 +180,6 @@ class RenderFlusher:
             [[group(0), binding(0)]]
             var<uniform> u_render: Render;
             [[group(0), binding(1)]]
-            var r_sampler: sampler;
-            [[group(0), binding(2)]]
             var r_color: texture_2d<f32>;
         """
 
@@ -190,24 +188,28 @@ class RenderFlusher:
             let sigma = u_render.sigma;
             let support = min(5, u_render.support);
 
-            // Determine distance between pixels in src texture
-            let stepp = vec2<f32>(1.0 / u_render.size.x, 1.0 / u_render.size.y);
-            // Get texcoord, and round it to the center of the source pixels.
-            // Thus, whether the sampler is linear or nearest, we get equal results.
-            let ref_coord = vec2<f32>(vec2<i32>(texcoord / stepp)) * stepp + 0.5 * stepp;
+            // The reference index is the subpixel index in the source texture that
+            // represents the location of this fragment.
+            let ref_index = texcoord * u_render.size;
+
+            // For the sampling, we work with integer coords. Also use min/max for the edges.
+            let base_index = vec2<i32>(ref_index);
+            let min_index = vec2<i32>(0, 0);
+            let max_index = vec2<i32>(u_render.size - 1.0);
 
             // Convolve. Here we apply a Gaussian kernel, the weight is calculated
-            // for each pixel individually based on the distance to the actual texture
-            // coordinate. This means that the textures don't even need to align.
+            // for each pixel individually based on the distance to the ref_index.
+            // This means that the textures don't need to align.
             var val: vec4<f32> = vec4<f32>(0.0, 0.0, 0.0, 0.0);
             var weight: f32 = 0.0;
             for (var y:i32 = -support; y <= support; y = y + 1) {
                 for (var x:i32 = -support; x <= support; x = x + 1) {
-                    let coord = ref_coord + vec2<f32>(f32(x), f32(y)) * stepp;
-                    let dist = length((texcoord - coord) / stepp);  // in src pixels
+                    let step = vec2<i32>(x, y);
+                    let index = clamp(base_index + step, min_index, max_index);
+                    let dist = length(ref_index - vec2<f32>(index));
                     let t = dist / sigma;
                     let w = exp(-0.5 * t * t);
-                    val = val + textureSample(r_color, r_sampler, coord) * w;
+                    val = val + textureLoad(r_color, index, 0) * w;
                     weight = weight + w;
                 }
             }
@@ -220,10 +222,6 @@ class RenderFlusher:
 
         # shader_module = device.create_shader_module(code=wgsl)
 
-        sampler = self._device.create_sampler(
-            mag_filter="nearest", min_filter="nearest"
-        )
-
         binding_layouts = [
             {
                 "binding": 0,
@@ -232,11 +230,6 @@ class RenderFlusher:
             },
             {
                 "binding": 1,
-                "visibility": wgpu.ShaderStage.FRAGMENT,
-                "sampler": {"type": wgpu.SamplerBindingType.filtering},
-            },
-            {
-                "binding": 2,
                 "visibility": wgpu.ShaderStage.FRAGMENT,
                 "texture": {
                     "sample_type": wgpu.TextureSampleType.float,
@@ -255,8 +248,7 @@ class RenderFlusher:
                     "size": self._uniform_data.nbytes,
                 },
             },
-            {"binding": 1, "resource": sampler},
-            {"binding": 2, "resource": src_texture_view},
+            {"binding": 1, "resource": src_texture_view},
         ]
 
         targets = [

--- a/pygfx/renderers/wgpu/_flusher.py
+++ b/pygfx/renderers/wgpu/_flusher.py
@@ -232,7 +232,7 @@ class RenderFlusher:
                 "binding": 1,
                 "visibility": wgpu.ShaderStage.FRAGMENT,
                 "texture": {
-                    "sample_type": wgpu.TextureSampleType.float,
+                    "sample_type": wgpu.TextureSampleType.unfilterable_float,
                     "view_dimension": wgpu.TextureViewDimension.d2,
                     "multisampled": False,
                 },

--- a/pygfx/renderers/wgpu/_pipelinebuilder.py
+++ b/pygfx/renderers/wgpu/_pipelinebuilder.py
@@ -321,8 +321,9 @@ def compose_render_pipeline(shared, blender, wobject, pipeline_info):
 
     pipelines = {}
     for pass_index in range(blender.get_pass_count()):
-        fragment_targets = blender.get_pipeline_targets(pass_index)
-        if not fragment_targets:
+        color_descriptors = blender.get_color_descriptors(pass_index)
+        depth_descriptor = blender.get_depth_descriptor(pass_index)
+        if not color_descriptors:
             continue
 
         # Compile shader
@@ -344,14 +345,9 @@ def compose_render_pipeline(shared, blender, wobject, pipeline_info):
                 "cull_mode": pipeline_info.get("cull_mode", wgpu.CullMode.none),
             },
             depth_stencil={
-                "format": blender.depth_format,
-                "depth_write_enabled": blender.get_depth_write_enabled(pass_index),
-                "depth_compare": wgpu.CompareFunction.less,
+                **depth_descriptor,
                 "stencil_front": {},  # use defaults
                 "stencil_back": {},  # use defaults
-                "depth_bias": 0,
-                "depth_bias_slope_scale": 0.0,
-                "depth_bias_clamp": 0.0,
             },
             multisample={
                 "count": 1,
@@ -361,7 +357,7 @@ def compose_render_pipeline(shared, blender, wobject, pipeline_info):
             fragment={
                 "module": shader_module,
                 "entry_point": "fs_main",
-                "targets": fragment_targets,
+                "targets": color_descriptors,
             },
         )
 

--- a/pygfx/renderers/wgpu/_pipelinebuilder.py
+++ b/pygfx/renderers/wgpu/_pipelinebuilder.py
@@ -320,14 +320,14 @@ def compose_render_pipeline(shared, blender, wobject, pipeline_info):
     # Instantiate the pipeline objects
 
     pipelines = {}
-    for pass_index in blender.iter_pass_indices():
+    for pass_index in range(blender.get_pass_count()):
         fragment_targets = blender.get_pipeline_targets(pass_index)
         if not fragment_targets:
             continue
 
         # Compile shader
         shader = pipeline_info["render_shader"]
-        wgsl = shader.generate_wgsl(pass_index=pass_index)
+        wgsl = shader.generate_wgsl(**blender.get_shader_kwargs(pass_index))
         shader_module = get_shader_module(shared, wgsl)
 
         pipelines[pass_index] = device.create_render_pipeline(

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -474,7 +474,7 @@ class WgpuRenderer(Renderer):
 
         # ----- render pipelines
 
-        for pass_index in self._blender.iter_pass_indices():
+        for pass_index in range(self._blender.get_pass_count()):
 
             if self._blender.get_depth_write_enabled(pass_index):
                 # Render pass 0 renders opaque fragments and picking info

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -221,18 +221,19 @@ class WgpuRenderer(Renderer):
         """The method for handling transparency:
         * "default" or None: Select the default: currently this is "simple2".
         * "opaque": single-pass approach that consider every fragment opaque.
-        * "simple1": single-pass approach that blends fragments (using OVER compositing).
+        * "simple1": single-pass approach that blends fragments (using alpha blending).
           Can only produce correct results if fragments are drawn from back to front.
         * "simple2": two-pass approach that first processes all opaque fragments and
-          then blends transparent fragments (using the OVER operator) with depth-write disabled.
-          Yields visually ok results, but is not order independent.
-        * "weighted": two-pass approach that yields order independent transparency, using alpha weights.
-        * "weighted_depth": two-pass approach that yields order independent
-          transparency, with weights based on alpha and depth (McGuire 2013). Note that the depth
+          then blends transparent fragments (using alpha blending) with depth-write disabled.
+          The visual results are usually better than simple1, but depend on the drawing order.
+        * "weighted": two-pass approach that for order independent transparency,
+          using alpha weights.
+        * "weighted_depth": two-pass approach for order independent transparency,
+          with weights based on alpha and depth (McGuire 2013). Note that the depth
           range affects the (quality of the) visual result.
-        * "weighted_plus": three-pass approach that yields order independent transparency,
-          in wich the front-most transparent layer is rendered correctly, while transparent
-          layers behind it are blended using "weighted".
+        * "weighted_plus": three-pass approach for order independent transparency,
+          in wich the front-most transparent layer is rendered correctly, while
+          transparent layers behind it are blended using alpha weights.
         """
         return self._blend_mode
 
@@ -409,7 +410,7 @@ class WgpuRenderer(Renderer):
         )
         command_buffers = [command_encoder.finish()]
 
-        # Let the blender to the combinatory pass
+        # Let the blender do the combinatory pass
         if flush:
             command_encoder = device.create_command_encoder()
             self._blender.perform_combine_pass(self._shared.device, command_encoder)

--- a/pygfx/renderers/wgpu/_shadercomposer.py
+++ b/pygfx/renderers/wgpu/_shadercomposer.py
@@ -543,14 +543,16 @@ class WorldObjectShader(BaseShader):
     def __init__(self, render_info, **kwargs):
         super().__init__(**kwargs)
 
-        self["render_pass"] = 1
+        self["pass_index"] = 0
         self["n_clipping_planes"] = len(render_info.wobject.material.clipping_planes)
         self["clipping_mode"] = render_info.wobject.material.clipping_mode
 
         # Get WGSL for blending.
         # Defines FragmentOutput2, add_fragment1, add_fragment2, finalize_fragment1, finalize_fragment2.
-        self["blending_code1"] = render_info.blender.get_shader_code(1)
-        self["blending_code2"] = render_info.blender.get_shader_code(2)
+        blender = render_info.blender
+        self._bending_codes = {}
+        for pass_index in blender.iter_pass_indices():
+            self._bending_codes[pass_index] = blender.get_shader_code(pass_index)
 
     def common_functions(self):
 
@@ -584,5 +586,6 @@ class WorldObjectShader(BaseShader):
         }
         """
 
-        blending_code = self["blending_code" + str(self["render_pass"])]
+        pass_index = self["pass_index"]
+        blending_code = self._bending_codes[pass_index]
         return clipping_plane_code + world_pos_code + blending_code

--- a/pygfx/renderers/wgpu/_shadercomposer.py
+++ b/pygfx/renderers/wgpu/_shadercomposer.py
@@ -543,16 +543,12 @@ class WorldObjectShader(BaseShader):
     def __init__(self, render_info, **kwargs):
         super().__init__(**kwargs)
 
-        self["pass_index"] = 0
         self["n_clipping_planes"] = len(render_info.wobject.material.clipping_planes)
         self["clipping_mode"] = render_info.wobject.material.clipping_mode
 
-        # Get WGSL for blending.
-        # Defines FragmentOutput2, add_fragment1, add_fragment2, finalize_fragment1, finalize_fragment2.
-        blender = render_info.blender
-        self._bending_codes = {}
-        for pass_index in blender.iter_pass_indices():
-            self._bending_codes[pass_index] = blender.get_shader_code(pass_index)
+        # Init values that get set when generate_wgsl() is called, using blender.get_shader_kwargs()
+        self["write_pick"] = True
+        self["blending_code"] = ""
 
     def common_functions(self):
 
@@ -586,6 +582,8 @@ class WorldObjectShader(BaseShader):
         }
         """
 
-        pass_index = self["pass_index"]
-        blending_code = self._bending_codes[pass_index]
+        blending_code = """
+        {{ blending_code }}
+        """
+
         return clipping_plane_code + world_pos_code + blending_code

--- a/pygfx/renderers/wgpu/backgroundrender.py
+++ b/pygfx/renderers/wgpu/backgroundrender.py
@@ -138,7 +138,7 @@ class BackgroundShader(WorldObjectShader):
             // We can apply clipping planes, but maybe a background should not be clipped?
             // apply_clipping_planes(in.world_pos);
 
-            $$ if render_pass == 1
+            $$ if pass_index == 0
                 // Fake being opaque - backgrounds should be backgrounds
                 add_fragment(varyings.position.z, vec4<f32>(final_color.rgb, 1.0));
                 var out = finalize_fragment();

--- a/pygfx/renderers/wgpu/backgroundrender.py
+++ b/pygfx/renderers/wgpu/backgroundrender.py
@@ -138,7 +138,7 @@ class BackgroundShader(WorldObjectShader):
             // We can apply clipping planes, but maybe a background should not be clipped?
             // apply_clipping_planes(in.world_pos);
 
-            $$ if pass_index == 0
+            $$ if write_pick
                 // Fake being opaque - backgrounds should be backgrounds
                 add_fragment(varyings.position.z, vec4<f32>(final_color.rgb, 1.0));
                 var out = finalize_fragment();

--- a/pygfx/renderers/wgpu/linerender.py
+++ b/pygfx/renderers/wgpu/linerender.py
@@ -473,7 +473,7 @@ class LineShader(WorldObjectShader):
             var out = finalize_fragment();
 
             // Set picking info. Yes, the vertex_id interpolates correctly in encoded form.
-            $$ if render_pass == 1
+            $$ if pass_index == 0
             let vf: f32 = varyings.pick_idx.x * 10000.0 + varyings.pick_idx.y;
             let vi = i32(vf + 0.5);
             out.pick = vec4<i32>(u_wobject.id, 0, vi, i32((vf - f32(vi)) * 1048576.0));

--- a/pygfx/renderers/wgpu/linerender.py
+++ b/pygfx/renderers/wgpu/linerender.py
@@ -473,7 +473,7 @@ class LineShader(WorldObjectShader):
             var out = finalize_fragment();
 
             // Set picking info. Yes, the vertex_id interpolates correctly in encoded form.
-            $$ if pass_index == 0
+            $$ if write_pick
             let vf: f32 = varyings.pick_idx.x * 10000.0 + varyings.pick_idx.y;
             let vi = i32(vf + 0.5);
             out.pick = vec4<i32>(u_wobject.id, 0, vi, i32((vf - f32(vi)) * 1048576.0));

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -428,7 +428,7 @@ class MeshShader(WorldObjectShader):
             add_fragment(varyings.position.z, final_color);
             var out = finalize_fragment();
 
-            $$ if pass_index == 0
+            $$ if write_pick
             let face_id = vec2<i32>(varyings.pick_idx.xz * 10000.0 + varyings.pick_idx.yw + 0.5);  // inst+face
             let w8 = vec3<i32>(varyings.pick_coords.xyz * 255.0 + 0.5);
             out.pick = vec4<i32>(u_wobject.id, face_id, w8.x * 65536 + w8.y * 256 + w8.z);
@@ -765,7 +765,7 @@ class MeshSliceShader(WorldObjectShader):
             add_fragment(varyings.position.z, final_color);
             var out = finalize_fragment();
 
-            $$ if pass_index == 0
+            $$ if write_pick
             let face_id = vec2<i32>(varyings.pick_idx.xz * 10000.0 + varyings.pick_idx.yw + 0.5);
             let w8 = vec3<i32>(varyings.pick_coords.xyz * 255.0 + 0.5);
             out.pick = vec4<i32>(u_wobject.id, face_id, w8.x * 65536 + w8.y * 256 + w8.z);

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -428,7 +428,7 @@ class MeshShader(WorldObjectShader):
             add_fragment(varyings.position.z, final_color);
             var out = finalize_fragment();
 
-            $$ if render_pass == 1
+            $$ if pass_index == 0
             let face_id = vec2<i32>(varyings.pick_idx.xz * 10000.0 + varyings.pick_idx.yw + 0.5);  // inst+face
             let w8 = vec3<i32>(varyings.pick_coords.xyz * 255.0 + 0.5);
             out.pick = vec4<i32>(u_wobject.id, face_id, w8.x * 65536 + w8.y * 256 + w8.z);
@@ -765,7 +765,7 @@ class MeshSliceShader(WorldObjectShader):
             add_fragment(varyings.position.z, final_color);
             var out = finalize_fragment();
 
-            $$ if render_pass == 1
+            $$ if pass_index == 0
             let face_id = vec2<i32>(varyings.pick_idx.xz * 10000.0 + varyings.pick_idx.yw + 0.5);
             let w8 = vec3<i32>(varyings.pick_coords.xyz * 255.0 + 0.5);
             out.pick = vec4<i32>(u_wobject.id, face_id, w8.x * 65536 + w8.y * 256 + w8.z);

--- a/pygfx/renderers/wgpu/pointsrender.py
+++ b/pygfx/renderers/wgpu/pointsrender.py
@@ -182,7 +182,7 @@ class PointsShader(WorldObjectShader):
             add_fragment(varyings.position.z, final_color);
             var out = finalize_fragment();
 
-            $$ if pass_index == 0
+            $$ if write_pick
             let vertex_id = i32(varyings.pick_idx.x * 10000.0 + varyings.pick_idx.y + 0.5);
             out.pick = vec4<i32>(u_wobject.id, 0, vertex_id, 0);
             $$ endif

--- a/pygfx/renderers/wgpu/pointsrender.py
+++ b/pygfx/renderers/wgpu/pointsrender.py
@@ -182,7 +182,7 @@ class PointsShader(WorldObjectShader):
             add_fragment(varyings.position.z, final_color);
             var out = finalize_fragment();
 
-            $$ if render_pass == 1
+            $$ if pass_index == 0
             let vertex_id = i32(varyings.pick_idx.x * 10000.0 + varyings.pick_idx.y + 0.5);
             out.pick = vec4<i32>(u_wobject.id, 0, vertex_id, 0);
             $$ endif

--- a/pygfx/renderers/wgpu/volumerender.py
+++ b/pygfx/renderers/wgpu/volumerender.py
@@ -327,7 +327,7 @@ class VolumeSliceShader(BaseVolumeShader):
             add_fragment(varyings.position.z, final_color);
             var out = finalize_fragment();
 
-            $$ if pass_index == 0
+            $$ if write_pick
             out.pick = vec4<i32>(u_wobject.id, vec3<i32>(varyings.texcoord * 1048576.0 + 0.5));
             $$ endif
             return out;
@@ -525,7 +525,7 @@ class VolumeRayShader(BaseVolumeShader):
             var out = finalize_fragment();
             out.depth = ndc_pos.z / ndc_pos.w;
 
-            $$ if pass_index == 0
+            $$ if write_pick
             out.pick = vec4<i32>(u_wobject.id, vec3<i32>(render_out.coord * 1048576.0 + 0.5));
             $$ endif
             return out;

--- a/pygfx/renderers/wgpu/volumerender.py
+++ b/pygfx/renderers/wgpu/volumerender.py
@@ -327,7 +327,7 @@ class VolumeSliceShader(BaseVolumeShader):
             add_fragment(varyings.position.z, final_color);
             var out = finalize_fragment();
 
-            $$ if render_pass == 1
+            $$ if pass_index == 0
             out.pick = vec4<i32>(u_wobject.id, vec3<i32>(varyings.texcoord * 1048576.0 + 0.5));
             $$ endif
             return out;
@@ -525,7 +525,7 @@ class VolumeRayShader(BaseVolumeShader):
             var out = finalize_fragment();
             out.depth = ndc_pos.z / ndc_pos.w;
 
-            $$ if render_pass == 1
+            $$ if pass_index == 0
             out.pick = vec4<i32>(u_wobject.id, vec3<i32>(render_out.coord * 1048576.0 + 0.5));
             $$ endif
             return out;


### PR DESCRIPTION
One step in #196 

This implements a new 3-pass approach to improve on the weighted blended blender. The idea is to do an extra pass in which the front-most transparent layer is captured. In the combine-pass, this layer is subtracted from the accum+reveal targets, and merged into the final result using the alpha bend equation.

In more detail:
* [x] Refactored so that the number of passes is defined by the blender.
* [x] Also drop a few other assumptions about the passes concerning depth.
* [x] Implement new 3-pass approach.
* [x] Fixed that the existing weighted blended methods were too dark.
* [x] Remove that weird rule that I introduced that `pass_index` 0 must be the opaque pass. Maybe use named passes?
* [x] Have a look at the depth handling in `_renderer.py`, I think it still makes some assumptions.
* [x] Double-check that the colors are correct (the pink seems a bit bright?)
* [x] Self-review / check for any todos.
* [x] Write up some notes about possible alternatives like mlab and depth-peeling.