### PR TITLE
Reduce memory footprint for picking

### DIFF
--- a/examples/picking_mesh.py
+++ b/examples/picking_mesh.py
@@ -23,7 +23,7 @@ class PickingWgpuCanvas(WgpuCanvas):
         if wobject and "face_index" in info:
             # Get what face was clicked
             face_index = info["face_index"]
-            coords = info["face_coords"]
+            coords = info["face_coord"]
             # Select which of the three vertices was closest
             # Note that you can also select all vertices for this face,
             # or use the coords to select the closest edge.

--- a/examples/picking_points.py
+++ b/examples/picking_points.py
@@ -15,6 +15,7 @@ class PickingWgpuCanvas(WgpuCanvas):
         # Get a dict with info about the clicked location
         xy = event.position().x(), event.position().y()
         info = renderer.get_pick_info(xy)
+        print(info)
         wobject = info["world_object"]
         # If a point was clicked ..
         if wobject and "vertex_index" in info:
@@ -33,9 +34,9 @@ xx = np.linspace(-50, 50, 10)
 yy = np.random.uniform(20, 50, 10)
 geometry = gfx.Geometry(positions=[(x, y, 0) for x, y in zip(xx, yy)])
 if True:  # Set to False to try this for a line
-    ob = gfx.Points(geometry, gfx.PointsMaterial(color=(0, 1, 1, 1), size=16))
+    ob = gfx.Points(geometry, gfx.PointsMaterial(color=(0, 1, 1, 1), size=20))
 else:
-    ob = gfx.Line(geometry, gfx.LineMaterial(color=(0, 1, 1, 1), thickness=10))
+    ob = gfx.Line(geometry, gfx.LineMaterial(color=(0, 1, 1, 1), thickness=12))
 scene.add(ob)
 
 camera = gfx.OrthographicCamera(120, 120)

--- a/examples/volume_render1.py
+++ b/examples/volume_render1.py
@@ -18,6 +18,9 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
 
     def mousePressEvent(self, event):  # noqa: N802
+        xy = event.position().x(), event.position().y()
+        # print(renderer.get_pick_info(xy))
+
         mode = self._drag_modes.get(event.button(), None)
         if self._mode or not mode:
             return
@@ -25,11 +28,7 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
         drag_start = (
             controls.pan_start if self._mode == "pan" else controls.rotate_start
         )
-        drag_start(
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
+        drag_start(xy, self.get_logical_size(), camera)
         app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
 
         # Picking. Note that this works on both the volume and the slice.

--- a/examples/volume_render1.py
+++ b/examples/volume_render1.py
@@ -19,8 +19,6 @@ class WgpuCanvasWithInputEvents(WgpuCanvas):
 
     def mousePressEvent(self, event):  # noqa: N802
         xy = event.position().x(), event.position().y()
-        # print(renderer.get_pick_info(xy))
-
         mode = self._drag_modes.get(event.button(), None)
         if self._mode or not mode:
             return

--- a/examples/volume_slice4.py
+++ b/examples/volume_slice4.py
@@ -19,8 +19,8 @@ class WgpuCanvasWithScroll(WgpuCanvas):
         # Print the voxel coordinate being clicked
         xy = event.position().x(), event.position().y()
         info = renderer.get_pick_info(xy)
-        if "voxel_index" in info:
-            print(info["voxel_index"])
+        if "index" in info:
+            print(info["index"], info["voxel_coord"])
 
 
 app = QtWidgets.QApplication([])

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -24,7 +24,7 @@ class LineMaterial(Material):
         values = unpack_bitfield(pick_value, 20, 26, 18)
         return {
             "vertex_index": values[1],
-            "line_coord": (values[2] - 100000) / 100000.0,
+            "segment_coord": (values[2] - 100000) / 100000.0,
         }
 
     @property

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -1,4 +1,5 @@
 from ._base import Material
+from ..utils import unpack_bitfield
 
 
 class LineMaterial(Material):
@@ -19,11 +20,12 @@ class LineMaterial(Material):
         self._vertex_colors = vertex_colors
 
     def _wgpu_get_pick_info(self, pick_value):
-        # The instance is zero while renderer doesn't support instancing
-        instance = pick_value[1]
-        vertex = pick_value[2]
-        vertex_sub = pick_value[3] / 1048576
-        return {"instance_index": instance, "vertex_index": vertex + vertex_sub}
+        # This should match with the shader
+        values = unpack_bitfield(pick_value, 20, 26, 18)
+        return {
+            "vertex_index": values[1],
+            "line_coord": (values[2] - 100000) / 100000.0,
+        }
 
     @property
     def color(self):

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -21,10 +21,10 @@ class LineMaterial(Material):
 
     def _wgpu_get_pick_info(self, pick_value):
         # This should match with the shader
-        values = unpack_bitfield(pick_value, 20, 26, 18)
+        values = unpack_bitfield(pick_value, wobject_id=20, index=26, coord=18)
         return {
-            "vertex_index": values[1],
-            "segment_coord": (values[2] - 100000) / 100000.0,
+            "vertex_index": values["index"],
+            "segment_coord": (values["coord"] - 100000) / 100000.0,
         }
 
     @property

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -1,5 +1,6 @@
 from ._base import Material
 from ..resources import TextureView
+from ..utils import unpack_bitfield
 
 
 def clim_from_format(texture):
@@ -67,15 +68,12 @@ class MeshBasicMaterial(Material):
         self.side = side
 
     def _wgpu_get_pick_info(self, pick_value):
-        values = []
-        for bits in (20, 26, 6, 6, 6):
-            mask = 2 ** bits - 1
-            values.append(pick_value & mask)
-            pick_value = pick_value >> bits
-
-        face = values[1]
-        coords = values[2] / 64, values[3] / 64, values[4] / 64
-        return {"face_index": face, "face_coords": coords}
+        # This should match with the shader
+        values = unpack_bitfield(pick_value, 20, 26, 6, 6, 6)
+        return {
+            "face_index": values[1],
+            "face_coord": (values[2] / 64, values[3] / 64, values[4] / 64),
+        }
 
     @property
     def color(self):

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -67,12 +67,19 @@ class MeshBasicMaterial(Material):
         self.side = side
 
     def _wgpu_get_pick_info(self, pick_value):
-        inst = pick_value[1]
-        face = pick_value[2]
-        coords = pick_value[3]
-        coords = (coords & 0xFF0000) / 65536, (coords & 0xFF00) / 256, coords & 0xFF
-        coords = coords[0] / 255, coords[1] / 255, coords[2] / 255
-        return {"instance_index": inst, "face_index": face, "face_coords": coords}
+        values = []
+        for bits in (20, 26, 6, 6, 6):
+            mask = 2 ** bits - 1
+            values.append(pick_value & mask)
+            pick_value = pick_value >> bits
+
+        face = values[1]
+        coords = (
+            values[2] / 64,
+            values[3] / 64,
+            values[4] / 64,
+        )
+        return {"face_index": face, "face_coords": coords}
 
     @property
     def color(self):

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -74,11 +74,7 @@ class MeshBasicMaterial(Material):
             pick_value = pick_value >> bits
 
         face = values[1]
-        coords = (
-            values[2] / 64,
-            values[3] / 64,
-            values[4] / 64,
-        )
+        coords = values[2] / 64, values[3] / 64, values[4] / 64
         return {"face_index": face, "face_coords": coords}
 
     @property

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -69,10 +69,16 @@ class MeshBasicMaterial(Material):
 
     def _wgpu_get_pick_info(self, pick_value):
         # This should match with the shader
-        values = unpack_bitfield(pick_value, 20, 26, 6, 6, 6)
+        values = unpack_bitfield(
+            pick_value, wobject_id=20, index=26, coord1=6, coord2=6, coord3=6
+        )
         return {
-            "face_index": values[1],
-            "face_coord": (values[2] / 64, values[3] / 64, values[4] / 64),
+            "face_index": values["index"],
+            "face_coord": (
+                values["coord1"] / 64,
+                values["coord2"] / 64,
+                values["coord3"] / 64,
+            ),
         }
 
     @property

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -33,7 +33,7 @@ class PointsMaterial(Material):
         values = unpack_bitfield(pick_value, 20, 26, 9, 9)
         return {
             "vertex_index": values[1],
-            "point_coord": (values[2] - 256, values[3] - 256),
+            "point_coord": (values[2] - 256.0, values[3] - 256.0),
         }
 
     @property

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -30,10 +30,10 @@ class PointsMaterial(Material):
 
     def _wgpu_get_pick_info(self, pick_value):
         # This should match with the shader
-        values = unpack_bitfield(pick_value, 20, 26, 9, 9)
+        values = unpack_bitfield(pick_value, wobject_id=20, index=26, x=9, y=9)
         return {
-            "vertex_index": values[1],
-            "point_coord": (values[2] - 256.0, values[3] - 256.0),
+            "vertex_index": values["index"],
+            "point_coord": (values["x"] - 256.0, values["y"] - 256.0),
         }
 
     @property

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -1,4 +1,5 @@
 from ._base import Material
+from ..utils import unpack_bitfield
 
 
 class PointsMaterial(Material):
@@ -28,10 +29,12 @@ class PointsMaterial(Material):
         self._vertex_sizes = vertex_sizes
 
     def _wgpu_get_pick_info(self, pick_value):
-        # The instance is zero while renderer doesn't support instancing
-        instance = pick_value[1]
-        vertex = pick_value[2]
-        return {"instance_index": instance, "vertex_index": vertex}
+        # This should match with the shader
+        values = unpack_bitfield(pick_value, 20, 26, 9, 9)
+        return {
+            "vertex_index": values[1],
+            "point_coord": (values[2] - 256, values[3] - 256),
+        }
 
     @property
     def color(self):

--- a/pygfx/objects/__init__.py
+++ b/pygfx/objects/__init__.py
@@ -1,5 +1,5 @@
 # flake8: noqa
 
-from ._base import WorldObject
+from ._base import WorldObject, id_provider
 from ._more import Group, Scene, Background, Points, Line, Mesh, Volume
 from ._instanced import InstancedMesh

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -31,11 +31,11 @@ class IdProvider:
         # by how many bits we use to store the id in the picking render target.
 
         # Max allowed id, inclusive
-        id_max = 16_777_216
+        id_max = 1_048_575  # 2*20 - 1
 
         # The max number of ids. This is a bit less to avoid choking
         # when there are few free id's left.
-        max_items = 0.9 * id_max
+        max_items = 1_000_000
 
         with self._lock:
             if len(self._ids_in_use) >= max_items:

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -26,6 +26,8 @@ class IdProvider:
         # * 2_147_483_647 (2**31 -1) max number for i32.
         # *    16_777_216 max integer that can be stored exactly in f32
         # *     4_000_000 max integer that survives being passed as a varying (in my tests)
+        # *     1_048_575 is ~1M is 2**20 seems like a good max scene objects.
+        # *   134_217_728 is ~100M is 2**27 seems like a good max vertex count.
         #
         # Anyway, we can use u32 for varyings, so this number is limited
         # by how many bits we use to store the id in the picking render target.

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -27,13 +27,11 @@ class IdProvider:
         # *    16_777_216 max integer that can be stored exactly in f32
         # *     4_000_000 max integer that survives being passed as a varying (in my tests)
         # *     1_048_575 is ~1M is 2**20 seems like a good max scene objects.
-        # *   134_217_728 is ~100M is 2**27 seems like a good max vertex count.
-        #
-        # Anyway, we can use u32 for varyings, so this number is limited
-        # by how many bits we use to store the id in the picking render target.
+        # *    67_108_864 is ~50M is 2**26 seems like a good max vertex count.
+        #                 which leaves 64-20-26=18 bits for any other picking info.
 
         # Max allowed id, inclusive
-        id_max = 1_048_575  # 2*20 - 1
+        id_max = 1_048_575  # 2*20-1
 
         # The max number of ids. This is a bit less to avoid choking
         # when there are few free id's left.

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -1,18 +1,65 @@
-import gc
 import random
 import weakref
+import threading
 
 from ..linalg import Vector3, Matrix4, Quaternion
 from ..resources import Resource, Buffer
 from ..utils import array_from_shadertype
 
 
-# Keep track of id's. About the max:
-# * 2_147_483_647 (2**31 -1) max number for signed i32.
-# *    16_777_216 max integer that can be stored exactly in f32
-# *     4_000_000 max integer that survives being passed as a varying (in my tests)
-_idmap = weakref.WeakKeyDictionary()
-_idmax = 16_777_217  # non-inclusive
+class IdProvider:
+    """Object for internal use to manage world object id's."""
+
+    def __init__(self):
+        self._ids_in_use = set([0])
+        self._map = weakref.WeakValueDictionary()
+        self._lock = threading.RLock()
+
+    def claim_id(self, wobject):
+        """Used by wobjects to claim an id."""
+        # We don't simply count up, but keep a pool of ids. This is
+        # because an application *could* create and discard objects at
+        # a high rate, so we want to be able to re-use these ids.
+        #
+        # Some numbers:
+        # * 4_294_967_296 (2**32) max number for u32
+        # * 2_147_483_647 (2**31 -1) max number for i32.
+        # *    16_777_216 max integer that can be stored exactly in f32
+        # *     4_000_000 max integer that survives being passed as a varying (in my tests)
+        #
+        # Anyway, we can use u32 for varyings, so this number is limited
+        # by how many bits we use to store the id in the picking render target.
+
+        # Max allowed id, inclusive
+        id_max = 16_777_216
+
+        # The max number of ids. This is a bit less to avoid choking
+        # when there are few free id's left.
+        max_items = 0.9 * id_max
+
+        with self._lock:
+            if len(self._ids_in_use) >= max_items:
+                raise RuntimeError("Max number of objects reached.")
+            id = 0
+            while id in self._ids_in_use:
+                id = random.randint(1, id_max)
+            self._ids_in_use.add(id)
+            self._map[id] = wobject
+
+        return id
+
+    def release_id(self, wobject, id):
+        """Release an id associated with a wobject."""
+        with self._lock:
+            self._ids_in_use.discard(id)
+            self._map.pop(id, None)
+
+    def get_object_from_id(self, id):
+        """Return the wobject associated with an id, or None."""
+        return self._map.get(id)
+
+
+id_provider = IdProvider()
 
 
 class ResourceContainer:
@@ -110,19 +157,12 @@ class WorldObject(ResourceContainer):
         # Render order is undocumented feature for now;l it may be removed if we have OIT.
         self.render_order = 0
 
-        # See if we reached max number of objects. If so, try cleanup and try again.
-        # Actually, stop earlier to prevent that while loop below to become slow.
-        max_items = 0.75 * _idmax
-        if len(_idmap) >= max_items:
-            gc.collect()
-            if len(_idmap) >= max_items:
-                raise RuntimeError("Max number of objects reached")
         # Set id
-        self._id = random.randint(1, _idmax - 1)
-        while self._id in _idmap.values():
-            self._id = (self._id + 1) % _idmax
-        _idmap[self] = self._id
+        self._id = id_provider.claim_id(self)
         self.uniform_buffer.data["id"] = self._id
+
+    def __del__(self):
+        id_provider.release_id(self, self.id)
 
     @property
     def id(self):

--- a/pygfx/objects/_instanced.py
+++ b/pygfx/objects/_instanced.py
@@ -43,8 +43,8 @@ class InstancedMesh(Mesh):
         self.instance_infos.data["matrix"][index] = matrix
 
     def _wgpu_get_pick_info(self, pick_value):
-        # In most cases the material handles this.
         info = self.material._wgpu_get_pick_info(pick_value)
-        wobject_id = pick_value & 1048575  # 2**20-1
-        info["instance_index"] = self._idmap.get(wobject_id)
+        # The id maps to one of our instances
+        id = pick_value & 1048575  # 2**20-1
+        info["instance_index"] = self._idmap.get(id)
         return info

--- a/pygfx/objects/_instanced.py
+++ b/pygfx/objects/_instanced.py
@@ -45,5 +45,6 @@ class InstancedMesh(Mesh):
     def _wgpu_get_pick_info(self, pick_value):
         # In most cases the material handles this.
         info = self.material._wgpu_get_pick_info(pick_value)
-        info["instance_index"] = self._idmap.get(pick_value[0], -1)
+        wobject_id = pick_value & 1048575
+        info["instance_index"] = self._idmap.get(wobject_id)
         return info

--- a/pygfx/objects/_instanced.py
+++ b/pygfx/objects/_instanced.py
@@ -45,6 +45,6 @@ class InstancedMesh(Mesh):
     def _wgpu_get_pick_info(self, pick_value):
         # In most cases the material handles this.
         info = self.material._wgpu_get_pick_info(pick_value)
-        wobject_id = pick_value & 1048575
+        wobject_id = pick_value & 1048575  # 2**20-1
         info["instance_index"] = self._idmap.get(wobject_id)
         return info

--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -1,4 +1,5 @@
 from ._base import WorldObject
+from ..utils import unpack_bitfield
 
 
 class Group(WorldObject):
@@ -72,6 +73,8 @@ class Volume(WorldObject):
         tex = self.geometry.grid
         if hasattr(tex, "texture"):
             tex = tex.texture  # tex was a view
+        # This should match with the shader
+        _, *texcoords_encoded = unpack_bitfield(pick_value, 20, 14, 14, 14)
         size = tex.size
-        x, y, z = [(v / 1048576) * s - 0.5 for v, s in zip(pick_value[1:], size)]
-        return {"instance_index": 0, "voxel_index": (x, y, z)}
+        x, y, z = [(v / 16384) * s - 0.5 for v, s in zip(texcoords_encoded, size)]
+        return {"instance_index": 0, "voxel_coord": (x, y, z)}

--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -74,7 +74,8 @@ class Volume(WorldObject):
         if hasattr(tex, "texture"):
             tex = tex.texture  # tex was a view
         # This should match with the shader
-        _, *texcoords_encoded = unpack_bitfield(pick_value, 20, 14, 14, 14)
+        values = unpack_bitfield(pick_value, wobject_id=20, x=14, y=14, z=14)
+        texcoords_encoded = values["x"], values["y"], values["z"]
         size = tex.size
         x, y, z = [(v / 16384) * s - 0.5 for v, s in zip(texcoords_encoded, size)]
         ix, iy, iz = int(x + 0.5), int(y + 0.5), int(z + 0.5)

--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -33,8 +33,7 @@ class Line(WorldObject):
 
     The picking info of a Line (the result of
     ``renderer.get_pick_info()``) will for most materials include
-    ``vertex_index`` (float). Note that ``vertex_index`` is not integer;
-    round the number to obtain the nearest vertex.
+    ``vertex_index`` (int) and ``segment_coord`` (float, sub-segment coordinate).
     """
 
 
@@ -43,8 +42,8 @@ class Points(WorldObject):
 
     The picking info of a Points object (the result of
     ``renderer.get_pick_info()``) will for most materials include
-    ``vertex_index`` (int).
-
+    ``vertex_index`` (int) and ``point_coord`` (tuple of 2 float coordinates
+    in logical pixels).
     """
 
 
@@ -54,7 +53,7 @@ class Mesh(WorldObject):
 
     The picking info of a Mesh (the result of
     ``renderer.get_pick_info()``) will for most materials include
-    ``instance_index`` (int), ``face_index`` (int), and ``face_coords``
+    ``instance_index`` (int), ``face_index`` (int), and ``face_coord``
     (tuple of 3 floats). The latter are the barycentric coordinates for
     each vertex of the face (with values 0..1).
     """
@@ -66,7 +65,8 @@ class Volume(WorldObject):
     The geometry for this object consists only of `geometry.grid`: a texture with the 3D data.
 
     The picking info of a Volume (the result of ``renderer.get_pick_info()``)
-    will for most materials include ``voxel_index`` (tuple of 3 floats).
+    will for most materials include ``index`` (tuple of 3 int),
+    and ``voxel_coord`` (tuple of float subpixel coordinates).
     """
 
     def _wgpu_get_pick_info(self, pick_value):
@@ -77,4 +77,8 @@ class Volume(WorldObject):
         _, *texcoords_encoded = unpack_bitfield(pick_value, 20, 14, 14, 14)
         size = tex.size
         x, y, z = [(v / 16384) * s - 0.5 for v, s in zip(texcoords_encoded, size)]
-        return {"instance_index": 0, "voxel_coord": (x, y, z)}
+        ix, iy, iz = int(x + 0.5), int(y + 0.5), int(z + 0.5)
+        return {
+            "index": (ix, iy, iz),
+            "voxel_coord": (x - ix, y - iy, z - iz),
+        }

--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -523,7 +523,7 @@ class BaseFragmentBlender:
         # The pick texture has 4 channels: object id, and then 3 more, e.g.
         # the instance nr, vertex nr and weights.
         self._texture_info["pick"] = (
-            wgpu.TextureFormat.rgba32uint,
+            wgpu.TextureFormat.rgba16uint,
             usg.RENDER_ATTACHMENT | usg.COPY_SRC,
         )
 

--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -504,7 +504,7 @@ class BaseFragmentBlender:
 
         # The below targets are always present, and the renderer expects their
         # format, texture, and view to be present.
-        # These contribute to 4+4+16 = 24 bytes per pixel
+        # These contribute to 4+4+8 = 16 bytes per pixel
 
         usg = wgpu.TextureUsage
 
@@ -520,8 +520,8 @@ class BaseFragmentBlender:
             usg.RENDER_ATTACHMENT | usg.COPY_SRC,
         )
 
-        # The pick texture has 4 channels: object id, and then 3 more, e.g.
-        # the instance nr, vertex nr and weights.
+        # The pick texture has 4 16bit channels, adding up to 64 bits.
+        # These bits are divided over the pick data, e.g. 20 for the wobject id.
         self._texture_info["pick"] = (
             wgpu.TextureFormat.rgba16uint,
             usg.RENDER_ATTACHMENT | usg.COPY_SRC,
@@ -654,7 +654,7 @@ class WeightedFragmentBlender(BaseFragmentBlender):
 
         # Create two additional render targets.
         # These contribute 8+2 = 10 bytes per pixel
-        # So the total = 24 + 10 = 34 bytes per pixel
+        # So the total = 16 + 10 = 26 bytes per pixel
 
         # The accumulation buffer collects weighted fragments
         self._texture_info["accum"] = (
@@ -764,7 +764,7 @@ class WeightedPlusFragmentBlender(WeightedFragmentBlender):
 
         # Create one additional render target.
         # These contribute 4 bytes per pixel
-        # So the total = 24 + 10 + 4 = 38 bytes per pixel
+        # So the total = 16 + 10 + 4 = 30 bytes per pixel
 
         # Color buffer for the front-most semitransparent layer
         self._texture_info["frontcolor"] = (

--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -136,7 +136,7 @@ class OpaquePass(BasePass):
 
         struct FragmentOutput {
             [[location(0)]] color: vec4<f32>;
-            [[location(1)]] pick: vec4<i32>;
+            [[location(1)]] pick: vec4<u32>;
         };
         fn add_fragment(depth: f32, color: vec4<f32>) {
             if (color.a >= 1.0 && depth < p_fragment_depth) {
@@ -165,7 +165,7 @@ class FullOpaquePass(OpaquePass):
 
         struct FragmentOutput {
             [[location(0)]] color: vec4<f32>;
-            [[location(1)]] pick: vec4<i32>;
+            [[location(1)]] pick: vec4<u32>;
         };
         fn add_fragment(depth: f32, color: vec4<f32>) {
             if (depth < p_fragment_depth) {
@@ -213,7 +213,7 @@ class SimpleSinglePass(OpaquePass):
 
         struct FragmentOutput {
             [[location(0)]] color: vec4<f32>;
-            [[location(1)]] pick: vec4<i32>;
+            [[location(1)]] pick: vec4<u32>;
         };
         fn add_fragment(depth: f32, color: vec4<f32>) {
             if (depth < p_fragment_depth) {
@@ -463,7 +463,7 @@ class FrontmostTransparencyPass(BasePass):
 
         struct FragmentOutput {
             [[location(0)]] color: vec4<f32>;
-            [[location(1)]] pick: vec4<i32>;
+            [[location(1)]] pick: vec4<u32>;
         };
         fn add_fragment(depth: f32, color: vec4<f32>) {
             if (color.a > 0.0 && color.a < 1.0) {
@@ -523,7 +523,7 @@ class BaseFragmentBlender:
         # The pick texture has 4 channels: object id, and then 3 more, e.g.
         # the instance nr, vertex nr and weights.
         self._texture_info["pick"] = (
-            wgpu.TextureFormat.rgba32sint,
+            wgpu.TextureFormat.rgba32uint,
             usg.RENDER_ATTACHMENT | usg.COPY_SRC,
         )
 

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -599,7 +599,7 @@ class WgpuRenderer(Renderer):
         data = self._pixel_info_buffer.map_read()
         depth = data[0:4].cast("f")[0]
         color = tuple(data[8:12].cast("B"))
-        pick_value = tuple(data[16:32].cast("Q"))[0]
+        pick_value = tuple(data[16:24].cast("Q"))[0]
         wobject_id = pick_value & 1048575  # 2**20-1
         wobject = id_provider.get_object_from_id(wobject_id)
         # Note: the position in world coordinates is not included because

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -599,8 +599,9 @@ class WgpuRenderer(Renderer):
         data = self._pixel_info_buffer.map_read()
         depth = data[0:4].cast("f")[0]
         color = tuple(data[8:12].cast("B"))
-        pick_value = tuple(data[16:32].cast("i"))
-        wobject = id_provider.get_object_from_id(pick_value[0])
+        pick_value = tuple(data[16:32].cast("Q"))[0]
+        wobject_id = pick_value & 1048575  # 2**20-1
+        wobject = id_provider.get_object_from_id(wobject_id)
         # Note: the position in world coordinates is not included because
         # it depends on the camera, but we don't "own" the camera.
 

--- a/pygfx/renderers/wgpu/_shadercomposer.py
+++ b/pygfx/renderers/wgpu/_shadercomposer.py
@@ -585,18 +585,23 @@ class WorldObjectShader(BaseShader):
         var<private> p_pick_bits_used : i32 = 0;
 
         fn pick_pack(value: u32, bits: i32) -> vec4<u32> {
+            // Utility to pack multiple values into a rgba16uint (64 bits available).
+            // Note that we store in a vec4<u32> but this gets written to a 4xu16.
+            // See #212 for details.
+            //
+            // Clip the given value
             let v = min(value, u32(exp2(f32(bits))));
-
+            // Determine bit-shift for each component
             let shift = vec4<i32>(
                 p_pick_bits_used, p_pick_bits_used - 16, p_pick_bits_used - 32, p_pick_bits_used - 48,
             );
-
+            // Prepare for next pack
             p_pick_bits_used = p_pick_bits_used + bits;
-
+            // Apply the shift for each component
             let vv = vec4<u32>(v);
             let selector1 = vec4<bool>(shift[0] < 0, shift[1] < 0, shift[2] < 0, shift[3] < 0);
             let pick_new = select( vv << vec4<u32>(shift) , vv >> vec4<u32>(-shift) , selector1 );
-
+            // Mask the components
             let mask = vec4<u32>(65535u);
             let selector2 = vec4<bool>( abs(shift[0]) < 32, abs(shift[1]) < 32, abs(shift[2]) < 32, abs(shift[3]) < 32 );
             return select( vec4<u32>(0u) , pick_new & mask , selector2 );

--- a/pygfx/renderers/wgpu/_shadercomposer.py
+++ b/pygfx/renderers/wgpu/_shadercomposer.py
@@ -588,7 +588,7 @@ class WorldObjectShader(BaseShader):
             let v = min(value, u32(exp2(f32(bits))));
 
             let shift = vec4<i32>(
-                p_pick_bits_used, p_pick_bits_used - 32, p_pick_bits_used - 64, p_pick_bits_used - 96,
+                p_pick_bits_used, p_pick_bits_used - 16, p_pick_bits_used - 32, p_pick_bits_used - 48,
             );
 
             p_pick_bits_used = p_pick_bits_used + bits;
@@ -597,7 +597,7 @@ class WorldObjectShader(BaseShader):
             let selector1 = vec4<bool>(shift[0] < 0, shift[1] < 0, shift[2] < 0, shift[3] < 0);
             let pick_new = select( vv << vec4<u32>(shift) , vv >> vec4<u32>(-shift) , selector1 );
 
-            let mask = vec4<u32>(4294967295u);
+            let mask = vec4<u32>(65535u);
             let selector2 = vec4<bool>( abs(shift[0]) < 32, abs(shift[1]) < 32, abs(shift[2]) < 32, abs(shift[3]) < 32 );
             return select( vec4<u32>(0u) , pick_new & mask , selector2 );
         }

--- a/pygfx/renderers/wgpu/_shadercomposer.py
+++ b/pygfx/renderers/wgpu/_shadercomposer.py
@@ -552,27 +552,26 @@ class WorldObjectShader(BaseShader):
 
     def common_functions(self):
 
+        clipping_plane_code = """
+        fn check_clipping_planes(world_pos: vec3<f32>) -> bool {
+            var clipped: bool = {{ 'false' if clipping_mode == 'ANY' else 'true' }};
+            for (var i=0; i<{{ n_clipping_planes }}; i=i+1) {
+                let plane = u_material.clipping_planes[i];
+                let plane_clipped = dot( world_pos, plane.xyz ) < plane.w;
+                clipped = clipped {{ '||' if clipping_mode == 'ANY' else '&&' }} plane_clipped;
+            }
+            return !clipped;
+        }
+        fn apply_clipping_planes(world_pos: vec3<f32>) {
+            if (!(check_clipping_planes(world_pos))) { discard; }
+        }
+        """
+
         if not self["n_clipping_planes"]:
             clipping_plane_code = """
             fn check_clipping_planes(world_pos: vec3<f32>) -> bool { return true; }
+            fn apply_clipping_planes(world_pos: vec3<f32>) { }
             """
-        else:
-            clipping_plane_code = """
-            fn check_clipping_planes(world_pos: vec3<f32>) -> bool {
-                var clipped: bool = {{ 'false' if clipping_mode == 'ANY' else 'true' }};
-                for (var i=0; i<{{ n_clipping_planes }}; i=i+1) {
-                    let plane = u_material.clipping_planes[i];
-                    let plane_clipped = dot( world_pos, plane.xyz ) < plane.w;
-                    clipped = clipped {{ '||' if clipping_mode == 'ANY' else '&&' }} plane_clipped;
-                }
-                return !clipped;
-            }
-            """
-        clipping_plane_code += """
-            fn apply_clipping_planes(world_pos: vec3<f32>) {
-                if (!(check_clipping_planes(world_pos))) { discard; }
-            }
-        """
 
         world_pos_code = """
         fn ndc_to_world_pos(ndc_pos: vec4<f32>) -> vec3<f32> {
@@ -582,8 +581,30 @@ class WorldObjectShader(BaseShader):
         }
         """
 
+        picking_code = """
+        var<private> p_pick_bits_used : i32 = 0;
+
+        fn pick_pack(value: u32, bits: i32) -> vec4<u32> {
+            let v = min(value, u32(exp2(f32(bits))));
+
+            let shift = vec4<i32>(
+                p_pick_bits_used, p_pick_bits_used - 32, p_pick_bits_used - 64, p_pick_bits_used - 96,
+            );
+
+            p_pick_bits_used = p_pick_bits_used + bits;
+
+            let vv = vec4<u32>(v);
+            let selector1 = vec4<bool>(shift[0] < 0, shift[1] < 0, shift[2] < 0, shift[3] < 0);
+            let pick_new = select( vv << vec4<u32>(shift) , vv >> vec4<u32>(-shift) , selector1 );
+
+            let mask = vec4<u32>(4294967295u);
+            let selector2 = vec4<bool>( abs(shift[0]) < 32, abs(shift[1]) < 32, abs(shift[2]) < 32, abs(shift[3]) < 32 );
+            return select( vec4<u32>(0u) , pick_new & mask , selector2 );
+        }
+        """
+
         blending_code = """
         {{ blending_code }}
         """
 
-        return clipping_plane_code + world_pos_code + blending_code
+        return clipping_plane_code + world_pos_code + picking_code + blending_code

--- a/pygfx/renderers/wgpu/backgroundrender.py
+++ b/pygfx/renderers/wgpu/backgroundrender.py
@@ -139,7 +139,10 @@ class BackgroundShader(WorldObjectShader):
             // apply_clipping_planes(in.world_pos);
 
             $$ if write_pick
-                // Fake being opaque - backgrounds should be backgrounds
+                // This is the opaque pass.
+                // A fragment of the background could be transparent, but it should still be
+                // written in the opaque pass in order for it to really be background.
+                // So we fool the blender into thinking this fragment is opaque, even if its not.
                 add_fragment(varyings.position.z, vec4<f32>(final_color.rgb, 1.0));
                 var out = finalize_fragment();
                 out.color = final_color;

--- a/pygfx/renderers/wgpu/linerender.py
+++ b/pygfx/renderers/wgpu/linerender.py
@@ -195,12 +195,11 @@ class LineShader(WorldObjectShader):
             varyings.thickness_p = f32(result.thickness_p);
             varyings.vec_from_node_p = vec2<f32>(result.vec_from_node_p);
             varyings.color = vec4<f32>(load_s_colors(result.i));
-            // The vertex index is interpolated. Divide over 2 values to get more precision.
-
-            //let idx = result.i + 10000000;
-            //varyings.pick_idx = vec2<f32>(f32(idx / 10000), f32(idx % 10000));
+            // Note: in theory, we can store ints up to 16_777_216 in f32,
+            // but in practice, its about 4_000_000 for f32 varyings (in my tests).
+            // We use a real u32 to not lose presision, see frag shader for details.
             varyings.pick_idx = u32(result.i);
-            varyings.pick_coord = f32(select(0.0, 1.0, result.i % 2 == 0));
+            varyings.pick_zigzag = f32(select(0.0, 1.0, result.i % 2 == 0));
 
             return varyings;
         }
@@ -481,16 +480,16 @@ class LineShader(WorldObjectShader):
             $$ if write_pick
             // The wobject-id must be 20 bits. In total it must not exceed 64 bits.
             // The pick_idx is int-truncated, so going from a to b, it still has the value of a
-            // even right up to b. The pick_coord alternates between 0 (even indices) and 1 (odd indices).
+            // even right up to b. The pick_zigzag alternates between 0 (even indices) and 1 (odd indices).
             // Here we decode that. The result is that we can support vertex indices of ~32 bits if we want.
             let is_even = varyings.pick_idx % 2u == 0u;
-            let coord2 = select(varyings.pick_coord, 1.0 - varyings.pick_coord, is_even);
-            let coord3 = select(coord2, coord2 - 1.0, coord2 > 0.5);
-            let idx = varyings.pick_idx + select(0u, 1u, coord3 < 0.0);
+            var coord = select(varyings.pick_zigzag, 1.0 - varyings.pick_zigzag, is_even);
+            coord = select(coord, coord - 1.0, coord > 0.5);
+            let idx = varyings.pick_idx + select(0u, 1u, coord < 0.0);
             out.pick = (
                 pick_pack(u32(u_wobject.id), 20) +
                 pick_pack(u32(idx), 26) +
-                pick_pack(u32(coord3 * 100000.0 + 100000.0), 18)
+                pick_pack(u32(coord * 100000.0 + 100000.0), 18)
             );
             $$ endif
 

--- a/pygfx/renderers/wgpu/linerender.py
+++ b/pygfx/renderers/wgpu/linerender.py
@@ -195,7 +195,12 @@ class LineShader(WorldObjectShader):
             varyings.thickness_p = f32(result.thickness_p);
             varyings.vec_from_node_p = vec2<f32>(result.vec_from_node_p);
             varyings.color = vec4<f32>(load_s_colors(result.i));
-            varyings.pick_idx = vec2<f32>(f32(result.i / 10000), f32(result.i % 10000));
+            // The vertex index is interpolated. Divide over 2 values to get more precision.
+
+            //let idx = result.i + 10000000;
+            //varyings.pick_idx = vec2<f32>(f32(idx / 10000), f32(idx % 10000));
+            varyings.pick_idx = u32(result.i);
+            varyings.pick_coord = f32(select(0.0, 1.0, result.i % 2 == 0));
 
             return varyings;
         }
@@ -472,11 +477,21 @@ class LineShader(WorldObjectShader):
             add_fragment(varyings.position.z, final_color);
             var out = finalize_fragment();
 
-            // Set picking info. Yes, the vertex_id interpolates correctly in encoded form.
+            // Set picking info.
             $$ if write_pick
-            let vf: f32 = varyings.pick_idx.x * 10000.0 + varyings.pick_idx.y;
-            let vi = i32(vf + 0.5);
-            out.pick = vec4<i32>(u_wobject.id, 0, vi, i32((vf - f32(vi)) * 1048576.0));
+            // The wobject-id must be 20 bits. In total it must not exceed 64 bits.
+            // The pick_idx is int-truncated, so going from a to b, it still has the value of a
+            // even right up to b. The pick_coord alternates between 0 (even indices) and 1 (odd indices).
+            // Here we decode that. The result is that we can support vertex indices of ~32 bits if we want.
+            let is_even = varyings.pick_idx % 2u == 0u;
+            let coord2 = select(varyings.pick_coord, 1.0 - varyings.pick_coord, is_even);
+            let coord3 = select(coord2, coord2 - 1.0, coord2 > 0.5);
+            let idx = varyings.pick_idx + select(0u, 1u, coord3 < 0.0);
+            out.pick = (
+                pick_pack(u32(u_wobject.id), 20) +
+                pick_pack(u32(idx), 26) +
+                pick_pack(u32(coord3 * 100000.0 + 100000.0), 18)
+            );
             $$ endif
 
             // The outer edges with lower alpha for aa are pushed a bit back to avoid artifacts.

--- a/pygfx/renderers/wgpu/volumerender.py
+++ b/pygfx/renderers/wgpu/volumerender.py
@@ -328,8 +328,15 @@ class VolumeSliceShader(BaseVolumeShader):
             var out = finalize_fragment();
 
             $$ if write_pick
-            out.pick = vec4<i32>(u_wobject.id, vec3<i32>(varyings.texcoord * 1048576.0 + 0.5));
+            // The wobject-id must be 20 bits. In total it must not exceed 64 bits.
+            out.pick = (
+                pick_pack(u32(u_wobject.id), 20) +
+                pick_pack(u32(varyings.texcoord.x * 16384.0), 14) +
+                pick_pack(u32(varyings.texcoord.y * 16384.0), 14) +
+                pick_pack(u32(varyings.texcoord.z * 16384.0), 14)
+            );
             $$ endif
+
             return out;
         }
 
@@ -526,7 +533,13 @@ class VolumeRayShader(BaseVolumeShader):
             out.depth = ndc_pos.z / ndc_pos.w;
 
             $$ if write_pick
-            out.pick = vec4<i32>(u_wobject.id, vec3<i32>(render_out.coord * 1048576.0 + 0.5));
+            // The wobject-id must be 20 bits. In total it must not exceed 64 bits.
+            out.pick = (
+                pick_pack(u32(u_wobject.id), 20) +
+                pick_pack(u32(render_out.coord.x * 16384.0), 14) +
+                pick_pack(u32(render_out.coord.y * 16384.0), 14) +
+                pick_pack(u32(render_out.coord.z * 16384.0), 14)
+            );
             $$ endif
             return out;
         }

--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -61,12 +61,12 @@ def array_from_shadertype(shadertype):
     return uniform_data
 
 
-def unpack_bitfield(packed, *bit_counts):
+def unpack_bitfield(packed, **bit_counts):
     """Unpack values from an uint64 bitfield."""
-    values = []
-    for bits in bit_counts:
+    values = {}
+    for key, bits in bit_counts.items():
         mask = 2 ** bits - 1
-        values.append(packed & mask)
+        values[key] = packed & mask
         packed = packed >> bits
     return values
 

--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -61,6 +61,16 @@ def array_from_shadertype(shadertype):
     return uniform_data
 
 
+def unpack_bitfield(packed, *bit_counts):
+    """Unpack values from an uint64 bitfield."""
+    values = []
+    for bits in bit_counts:
+        mask = 2 ** bits - 1
+        values.append(packed & mask)
+        packed = packed >> bits
+    return values
+
+
 def normals_from_vertices(rr, tris):
     """Efficiently compute vertex normals for a triangulated surface."""
     # This code was taken from Vispy


### PR DESCRIPTION
Closes #208.

Changes:
* [x] Use object id's for instancing, so we don't need extra bits for that.
* [x] Provide some low-level bit juggling utils.
* [x] Reduce the used bits for picking to 64.
* [x] Use rgb16uint for the pick texture.
* [ ] Copy pick info to low-res texture, and reuse the rgba16uint for the other things. -> first address #209

This means that:
* We can now precisely allocate a certain amount of bits for each pick info field.
* The instance-index does not need any bits since its encoded via the wobject-id.
* The above points mean that we can now get away with 64bits (instead of 128), thus reducing the memory footprint of the pick buffer by 50%.
* The picking logic in the shader is also easier to read.

About the allocated bits:
* 20 bits are for the wobject id's, which means we can support up to 1M objects. This number if fixed, because the core renderer needs to get the object id.
* I have the vertex/face index 26 bits in all materials. That's up to 50M vertices. The 26 is a nice number, because it leaves 18 bits for other info, which is nicely divisible by both 2 and 3. 
* The mesh has 3 (barycentric) face coords of 6 bits each.
* The point has 2 point coords (in logical pixels) of 9 bits each (-255 - +255).
* The line has a 1 sub-coord of 18 bits (-0.5, 0.5).
* The volume has 3 tex_coords of 14 bits. 