### PR TITLE
Fix for Intel/Linux

### DIFF
--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -575,14 +575,17 @@ class BaseFragmentBlender:
         """Get the number of passes for this blender."""
         return len(self.passes)
 
-    def perform_combine_pass(self, device, command_encoder):
+    def perform_combine_pass(self, device):
         """Perform a render-pass to combine any multi-pass results, if needed."""
+
         # Get bindgroup and pipeline
         if not self._combine_pass_info:
             self._combine_pass_info = self._create_combination_pipeline(device)
         bind_group, render_pipeline = self._combine_pass_info
         if not render_pipeline:
-            return
+            return []
+
+        command_encoder = device.create_command_encoder()
 
         # Render
         render_pass = command_encoder.begin_render_pass(
@@ -601,6 +604,8 @@ class BaseFragmentBlender:
         render_pass.set_bind_group(0, bind_group, [], 0, 99)
         render_pass.draw(4, 1)
         render_pass.end_pass()
+
+        return [command_encoder.finish()]
 
     def _create_combination_pipeline(self, device):
         """Overload this to setup the specific combiner-pass."""

--- a/pygfx/renderers/wgpu/_flusher.py
+++ b/pygfx/renderers/wgpu/_flusher.py
@@ -112,7 +112,7 @@ class RenderFlusher:
             self._pipelines[dst_format] = hash, bind_group, render_pipeline
 
         self._update_uniforms(src_color_tex, dst_color_tex)
-        self._render(dst_color_tex, dst_format)
+        return self._render(dst_color_tex, dst_format)
 
     def _update_uniforms(self, src_color_tex, dst_color_tex):
         # Get factor between texture sizes
@@ -158,16 +158,15 @@ class RenderFlusher:
                 }
             ],
             depth_stencil_attachment=None,
-            occlusion_query_set=None,
         )
         render_pass.set_pipeline(render_pipeline)
         render_pass.set_bind_group(0, bind_group, [], 0, 99)
         render_pass.draw(4, 1)
         render_pass.end_pass()
-        device.queue.submit([command_encoder.finish()])
+
+        return [command_encoder.finish()]
 
     def _create_pipeline(self, src_texture_view, dst_format):
-
         device = self._device
 
         bindings_code = """
@@ -219,8 +218,6 @@ class RenderFlusher:
         wgsl = FULL_QUAD_SHADER
         wgsl = wgsl.replace("BINDINGS_CODE", bindings_code)
         wgsl = wgsl.replace("FRAGMENT_CODE", fragment_code)
-
-        # shader_module = device.create_shader_module(code=wgsl)
 
         binding_layouts = [
             {


### PR DESCRIPTION
I experienced that with Intel drivers on Linux all examples on pyggfx hanged, whereas the examples in wgpu worked fine. This was an interesting debugging experience. I found out that these drivers don't like it when the queue is submitted multiple times. So this PR fixes that.

* Instead of submitting the result of each command encoder, it now collects the results and submits it all the way at the end.
* Uploading buffers is done using the queue, without the need for a command encoder.

