### PR TITLE
Update weighted blended

### DIFF
--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -664,7 +664,7 @@ class WeightedFragmentBlender(BaseFragmentBlender):
 
         # The reveal buffer collects the weights
         self._texture_info["reveal"] = (
-            wgpu.TextureFormat.r16float,
+            wgpu.TextureFormat.r8unorm,
             usg.RENDER_ATTACHMENT | usg.TEXTURE_BINDING,
         )
 

--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -653,8 +653,8 @@ class WeightedFragmentBlender(BaseFragmentBlender):
         usg = wgpu.TextureUsage
 
         # Create two additional render targets.
-        # These contribute 8+2 = 10 bytes per pixel
-        # So the total = 16 + 10 = 26 bytes per pixel
+        # These contribute 8+1 = 9 bytes per pixel
+        # So the total = 16 + 9 = 25 bytes per pixel
 
         # The accumulation buffer collects weighted fragments
         self._texture_info["accum"] = (
@@ -662,7 +662,12 @@ class WeightedFragmentBlender(BaseFragmentBlender):
             usg.RENDER_ATTACHMENT | usg.TEXTURE_BINDING,
         )
 
-        # The reveal buffer collects the weights
+        # The reveal buffer collects the weights.
+        # McGuire: "Using R16F for the revealage render target will give slightly better
+        # precision and make it easier to tune the algorithm, but a 2x savings on bandwidth
+        # and memory footprint for that texture may make it worth compressing into R8 format."
+        # We also found that on Metal r16float produces a FormatNotBlendable error,
+        # while r8unorm and r32float do work. See #207.
         self._texture_info["reveal"] = (
             wgpu.TextureFormat.r8unorm,
             usg.RENDER_ATTACHMENT | usg.TEXTURE_BINDING,
@@ -764,7 +769,7 @@ class WeightedPlusFragmentBlender(WeightedFragmentBlender):
 
         # Create one additional render target.
         # These contribute 4 bytes per pixel
-        # So the total = 16 + 10 + 4 = 30 bytes per pixel
+        # So the total = 16 + 9 + 4 = 29 bytes per pixel
 
         # Color buffer for the front-most semitransparent layer
         self._texture_info["frontcolor"] = (


### PR DESCRIPTION
Closes #207.

This is an attempt to fix #207, and maybe implement the idea of re-using the rgba16uint picking texture for the accumulation texture.

In [McGuire's blog](http://casual-effects.blogspot.com/2015/03/implemented-weighted-blended-order.html) it says that the reveal texture can be r8unorm. The extra bits of r16float help a bit, but don't seem *that* necessary - he argues that the memory it requires may not be worth it.
