### PR TITLE
API for object sorting and providing transparency hints

### DIFF
--- a/examples/transparency2.py
+++ b/examples/transparency2.py
@@ -76,12 +76,28 @@ canvas._target_fps = 1000
 renderer = gfx.renderers.WgpuRenderer(canvas, show_fps=True)
 scene = gfx.Scene()
 
-sphere = gfx.Mesh(gfx.sphere_geometry(10), gfx.MeshPhongMaterial())
+sphere = gfx.Mesh(
+    gfx.sphere_geometry(10),
+    gfx.MeshPhongMaterial(),
+    render_pass="opaque",
+)
 
 geometry = gfx.plane_geometry(50, 50)
-plane1 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(1, 0, 0, 0.3)))
-plane2 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 1, 0, 0.5)))
-plane3 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 0, 1, 0.7)))
+plane1 = gfx.Mesh(
+    geometry,
+    gfx.MeshBasicMaterial(color=(1, 0, 0, 0.3)),
+    render_pass="transparent",
+)
+plane2 = gfx.Mesh(
+    geometry,
+    gfx.MeshBasicMaterial(color=(0, 1, 0, 0.5)),
+    render_pass="transparent",
+)
+plane3 = gfx.Mesh(
+    geometry,
+    gfx.MeshBasicMaterial(color=(0, 0, 1, 0.7)),
+    render_pass="transparent",
+)
 
 plane1.rotation.set_from_axis_angle(gfx.linalg.Vector3(1, 0, 0), 1.571)
 plane2.rotation.set_from_axis_angle(gfx.linalg.Vector3(0, 1, 0), 1.571)

--- a/examples/transparency2.py
+++ b/examples/transparency2.py
@@ -76,28 +76,12 @@ canvas._target_fps = 1000
 renderer = gfx.renderers.WgpuRenderer(canvas, show_fps=True)
 scene = gfx.Scene()
 
-sphere = gfx.Mesh(
-    gfx.sphere_geometry(10),
-    gfx.MeshPhongMaterial(),
-    render_pass="opaque",
-)
+sphere = gfx.Mesh(gfx.sphere_geometry(10), gfx.MeshPhongMaterial())
 
 geometry = gfx.plane_geometry(50, 50)
-plane1 = gfx.Mesh(
-    geometry,
-    gfx.MeshBasicMaterial(color=(1, 0, 0, 0.3)),
-    render_pass="transparent",
-)
-plane2 = gfx.Mesh(
-    geometry,
-    gfx.MeshBasicMaterial(color=(0, 1, 0, 0.5)),
-    render_pass="transparent",
-)
-plane3 = gfx.Mesh(
-    geometry,
-    gfx.MeshBasicMaterial(color=(0, 0, 1, 0.7)),
-    render_pass="transparent",
-)
+plane1 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(1, 0, 0, 0.3)))
+plane2 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 1, 0, 0.5)))
+plane3 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(0, 0, 1, 0.7)))
 
 plane1.rotation.set_from_axis_angle(gfx.linalg.Vector3(1, 0, 0), 1.571)
 plane2.rotation.set_from_axis_angle(gfx.linalg.Vector3(0, 1, 0), 1.571)

--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -76,7 +76,10 @@ class Material(ResourceContainer):
 
     @opacity.setter
     def opacity(self, value):
-        self.uniform_buffer.data["opacity"] = min(max(float(value), 0), 1)
+        value = min(max(float(value), 0), 1)
+        if (value == 1) != (self.uniform_buffer.data["opacity"] == 1):
+            self._bump_rev()  # rebuild pipeline if we become opaque/transparent
+        self.uniform_buffer.data["opacity"] = value
         self.uniform_buffer.update_range(0, 1)
 
     @property

--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -70,7 +70,7 @@ class Material(ResourceContainer):
     def opacity(self):
         """The opacity (a.k.a. alpha value) applied to this material, expressed
         as a value between 0 and 1. If the material contains any
-        non-opaque fragments, these are simply scaled by this value.
+        non-opaque fragments, their alphas are simply scaled by this value.
         """
         return float(self.uniform_buffer.data["opacity"])
 

--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -78,7 +78,7 @@ class Material(ResourceContainer):
     def opacity(self, value):
         value = min(max(float(value), 0), 1)
         if (value == 1) != (self.uniform_buffer.data["opacity"] == 1):
-            self._bump_rev()  # rebuild pipeline if we become opaque/transparent
+            self._bump_rev()  # rebuild pipeline if this becomes opaque/transparent
         self.uniform_buffer.data["opacity"] = value
         self.uniform_buffer.update_range(0, 1)
 

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -33,7 +33,10 @@ class LineMaterial(Material):
 
     @color.setter
     def color(self, color):
-        self.uniform_buffer.data["color"] = tuple(color)
+        color = tuple(color)
+        if (color[3] >= 1) != (self.uniform_buffer.data["color"][3] >= 1):
+            self._bump_rev()  # rebuild pipeline if we become opaque/transparent
+        self.uniform_buffer.data["color"] = color
         self.uniform_buffer.update_range(0, 1)
 
     @property

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -35,7 +35,7 @@ class LineMaterial(Material):
     def color(self, color):
         color = tuple(color)
         if (color[3] >= 1) != (self.uniform_buffer.data["color"][3] >= 1):
-            self._bump_rev()  # rebuild pipeline if we become opaque/transparent
+            self._bump_rev()  # rebuild pipeline if this becomes opaque/transparent
         self.uniform_buffer.data["color"] = color
         self.uniform_buffer.update_range(0, 1)
 

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -90,6 +90,9 @@ class MeshBasicMaterial(Material):
 
     @color.setter
     def color(self, color):
+        color = tuple(color)
+        if (color[3] >= 1) != (self.uniform_buffer.data["color"][3] >= 1):
+            self._bump_rev()  # rebuild pipeline if we become opaque/transparent
         self.uniform_buffer.data["color"] = color
         self.uniform_buffer.update_range(0, 1)
 

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -92,7 +92,7 @@ class MeshBasicMaterial(Material):
     def color(self, color):
         color = tuple(color)
         if (color[3] >= 1) != (self.uniform_buffer.data["color"][3] >= 1):
-            self._bump_rev()  # rebuild pipeline if we become opaque/transparent
+            self._bump_rev()  # rebuild pipeline if this becomes opaque/transparent
         self.uniform_buffer.data["color"] = color
         self.uniform_buffer.update_range(0, 1)
 

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -45,7 +45,7 @@ class PointsMaterial(Material):
     def color(self, color):
         color = tuple(color)
         if (color[3] >= 1) != (self.uniform_buffer.data["color"][3] >= 1):
-            self._bump_rev()  # rebuild pipeline if we become opaque/transparent
+            self._bump_rev()  # rebuild pipeline if this becomes opaque/transparent
         self.uniform_buffer.data["color"] = color
         self.uniform_buffer.update_range(0, 1)
 

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -43,7 +43,10 @@ class PointsMaterial(Material):
 
     @color.setter
     def color(self, color):
-        self.uniform_buffer.data["color"] = tuple(color)
+        color = tuple(color)
+        if (color[3] >= 1) != (self.uniform_buffer.data["color"][3] >= 1):
+            self._bump_rev()  # rebuild pipeline if we become opaque/transparent
+        self.uniform_buffer.data["color"] = color
         self.uniform_buffer.update_range(0, 1)
 
     @property

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -184,13 +184,6 @@ class WorldObject(ResourceContainer):
     @visible.setter
     def visible(self, visible):
         self._visible = bool(visible)
-        # Bump the revision, signalling to the renderer that it cannot
-        # use the cached information. We could use a seperate revision
-        # attribute here so the render can ditch the recorded commands
-        # while keeping the pipeline objects, but it would probably not
-        # matter because visibility is not something that people would
-        # change often.
-        self._bump_rev()
 
     @property
     def render_order(self):
@@ -203,7 +196,6 @@ class WorldObject(ResourceContainer):
     @render_order.setter
     def render_order(self, value):
         self._render_order = float(value)
-        self._bump_rev()
 
     @property
     def render_pass(self):
@@ -240,7 +232,6 @@ class WorldObject(ResourceContainer):
                 f"WorldObject.render_pass must be one of {options} not {value}"
             )
         self._render_pass = value
-        self._bump_rev()
 
     @property
     def geometry(self):

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -123,14 +123,24 @@ class WorldObject(ResourceContainer):
     _m = Matrix4()
     _q = Quaternion()
 
-    def __init__(self, geometry=None, material=None):
+    def __init__(
+        self,
+        geometry=None,
+        material=None,
+        *,
+        visible=True,
+        render_order=0,
+        render_pass="auto",
+    ):
         super().__init__()
 
         self.geometry = geometry
         self.material = material
 
-        # Init visibility
-        self._visible = True
+        # Init visibility and render props
+        self._visible = visible
+        self._render_order = render_order
+        self._render_pass = render_pass
 
         # Init parent and children
         self._parent = None
@@ -153,10 +163,6 @@ class WorldObject(ResourceContainer):
         for cls in reversed(self.__class__.mro()):
             self.uniform_type.update(getattr(cls, "uniform_type", {}))
         self.uniform_buffer = Buffer(array_from_shadertype(self.uniform_type))
-
-        # Render order is undocumented feature for now; it may be removed if we have OIT.
-        self.render_order = 0
-        self.render_pass = None
 
         # Set id
         self._id = id_provider.claim_id(self)

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -195,17 +195,8 @@ class WorldObject(ResourceContainer):
     @property
     def render_order(self):
         """This value allows the default rendering order of scene graph
-        objects to be controlled. Objects are sorted on this value
-        before rendering (lower values go first). Default 0.
-
-        The order in which a WorldObject is rendered is determined by:
-
-        * Its distance from the camera.
-        * Its render_order (this property).
-        * Its position in the scene graph (based on a depth-first search).
-
-        When the renderer uses a blend-mode that is order-independent,
-        the order is defined by the scene graph alone.
+        objects to be controlled. Default 0. See ``Renderer.sort_objects``
+        for details.
         """
         return self._render_order
 

--- a/pygfx/objects/_instanced.py
+++ b/pygfx/objects/_instanced.py
@@ -8,8 +8,8 @@ from ..resources import Buffer
 class InstancedMesh(Mesh):
     """An instanced mesh with a matrix for each instance."""
 
-    def __init__(self, geometry, material, count):
-        super().__init__(geometry, material)
+    def __init__(self, geometry, material, count, **kwargs):
+        super().__init__(geometry, material, **kwargs)
         count = int(count)
         # Create array of `count` instance_info objects
         dtype = np.dtype(

--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -20,10 +20,10 @@ class Background(WorldObject):
     Can be e.g. a gradient, a static image or a skybox.
     """
 
-    def __init__(self, geometry=None, material=None):
+    def __init__(self, geometry=None, material=None, **kwargs):
         if geometry is not None and material is None:
             raise TypeError("You need to instantiate using Background(None, material)")
-        super().__init__(None, material)
+        super().__init__(None, material, **kwargs)
 
 
 class Line(WorldObject):

--- a/pygfx/renderers/wgpu/_pipelinebuilder.py
+++ b/pygfx/renderers/wgpu/_pipelinebuilder.py
@@ -64,19 +64,11 @@ def ensure_pipeline(renderer, wobject):
 
     # Set in what passes this object must render
     if has_changed:
-        if wobject.render_pass == "auto":
-            # todo: a smarter auto
-            wobject_pipeline["render_opaque"] = True
-            wobject_pipeline["render_transparent"] = True
-        elif wobject.render_pass == "full":
-            wobject_pipeline["render_opaque"] = True
-            wobject_pipeline["render_transparent"] = True
-        elif wobject.render_pass == "opaque":
-            wobject_pipeline["render_opaque"] = True
-            wobject_pipeline["render_transparent"] = False
-        elif wobject.render_pass == "transparent":
-            wobject_pipeline["render_opaque"] = False
-            wobject_pipeline["render_transparent"] = True
+        m = {"auto": 0, "opaque": 1, "transparent": 2, "all": 3}
+        render_mask = m[wobject.render_mask]
+        if not render_mask:
+            render_mask = new_pipeline_infos[0].get("suggested_render_mask", 3)
+        wobject_pipeline["render_mask"] = render_mask
 
     return wobject_pipeline, has_changed
 

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -443,10 +443,9 @@ class WgpuRenderer(Renderer):
         # I *think* that (eventually?) it should be possible to record the commands
         # and re-submit them, resulting in better performance. But if I try this now
         # it panics with 'Cannot remove a vacant resource'.
-        # If we do get this to work, we should also trigger a recording
-        # when the wobject.children change.
-        need_recording = any_has_changed or not self._blender.is_order_independent
-        need_recording = True
+        # If we do get this to work, we should trigger a new recording
+        # when the wobject's children, visibile, render_order, or render_pass changes.
+        need_recording = any_has_changed or True
 
         # Sort objects
         if self.sort_objects:

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -530,7 +530,6 @@ class WgpuRenderer(Renderer):
         compute_pass.end_pass()
 
         # ----- render pipelines
-        n_passes = 0
 
         for pass_index in range(blender.get_pass_count()):
 
@@ -554,7 +553,6 @@ class WgpuRenderer(Renderer):
             for wobject, wobject_pipeline in wobject_tuples:
                 if not (render_mask & wobject_pipeline["render_mask"]):
                     continue
-                n_passes += 1
                 for pinfo in wobject_pipeline["render_pipelines"]:
                     render_pass.set_pipeline(pinfo["pipelines"][pass_index])
                     for slot, vbuffer in pinfo["vertex_buffers"].items():
@@ -576,7 +574,6 @@ class WgpuRenderer(Renderer):
 
             render_pass.end_pass()
 
-        print(n_passes)
         return [command_encoder.finish()]
 
     def _update_stdinfo_buffer(self, camera, physical_size, logical_size):

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -145,7 +145,15 @@ class WgpuRenderer(Renderer):
 
     _wobject_pipelines_collection = weakref.WeakValueDictionary()
 
-    def __init__(self, target, *, pixel_ratio=None, show_fps=False):
+    def __init__(
+        self,
+        target,
+        *,
+        pixel_ratio=None,
+        show_fps=False,
+        blend_mode="default",
+        sort_objects=False,
+    ):
 
         # Check and normalize inputs
         if not isinstance(target, (Texture, TextureView, wgpu.gui.WgpuCanvasBase)):
@@ -185,8 +193,8 @@ class WgpuRenderer(Renderer):
             self._target._wgpu_usage |= wgpu.TextureUsage.TEXTURE_BINDING
 
         # Prepare render targets.
-        self.blend_mode = "default"
-        self.sort_objects = False
+        self.blend_mode = blend_mode
+        self.sort_objects = sort_objects
 
         # Prepare object that performs the final render step into a texture
         self._flusher = RenderFlusher(self._shared.device)
@@ -239,6 +247,7 @@ class WgpuRenderer(Renderer):
     @property
     def blend_mode(self):
         """The method for handling transparency:
+
         * "default" or None: Select the default: currently this is "simple2".
         * "opaque": single-pass approach that consider every fragment opaque.
         * "simple1": single-pass approach that blends fragments (using alpha blending).
@@ -289,7 +298,7 @@ class WgpuRenderer(Renderer):
 
     @property
     def sort_objects(self):
-        """Whether to sort world objects before rendering.
+        """Whether to sort world objects before rendering. Default False.
 
         * ``True``: the render order is defined by 1) the object's ``render_order``
           property; 2) the object's distance to the camera; 3) the position object

--- a/pygfx/renderers/wgpu/backgroundrender.py
+++ b/pygfx/renderers/wgpu/backgroundrender.py
@@ -50,6 +50,7 @@ def background_renderer(render_info):
 
     return [
         {
+            "suggested_render_mask": 1,
             "render_shader": shader,
             "primitive_topology": wgpu.PrimitiveTopology.triangle_strip,
             "indices": 4,

--- a/pygfx/renderers/wgpu/pointsrender.py
+++ b/pygfx/renderers/wgpu/pointsrender.py
@@ -31,7 +31,9 @@ def points_renderer(render_info):
         "s_positions", "buffer/read_only_storage", geometry.positions, "VERTEX"
     )
 
+    only_color_and_opacity_determine_fragment_alpha = True
     if material.vertex_colors:
+        only_color_and_opacity_determine_fragment_alpha = False
         bindings[5] = Binding(
             "s_colors", "buffer/read_only_storage", geometry.colors, "VERTEX"
         )
@@ -50,9 +52,16 @@ def points_renderer(render_info):
     for i, binding in bindings.items():
         shader.define_binding(0, i, binding)
 
+    # The renderer use alpha for aa, so we are never opaque only.
+    suggested_render_mask = 3
+    if only_color_and_opacity_determine_fragment_alpha:
+        if material.opacity < 1 or material.color[3] < 1:
+            suggested_render_mask = 2
+
     # Put it together!
     return [
         {
+            "suggested_render_mask": suggested_render_mask,
             "render_shader": shader,
             "primitive_topology": wgpu.PrimitiveTopology.triangle_list,
             "indices": (range(n), range(1)),

--- a/pygfx/renderers/wgpu/volumerender.py
+++ b/pygfx/renderers/wgpu/volumerender.py
@@ -134,7 +134,7 @@ def volume_slice_renderer(render_info):
 
     # Get in what passes this needs rendering
     suggested_render_mask = 3
-    if "a" not in fmt and material.opacity >= 1:
+    if material.opacity >= 1 and shader["texture_nchannels"] in (1, 3):
         suggested_render_mask = 1
     elif material.opacity < 1:
         suggested_render_mask = 2
@@ -403,7 +403,7 @@ def volume_ray_renderer(render_info):
 
     # Get in what passes this needs rendering
     suggested_render_mask = 3
-    if "a" not in fmt and material.opacity >= 1:
+    if material.opacity >= 1 and shader["texture_nchannels"] in (1, 3):
         suggested_render_mask = 1
     elif material.opacity < 1:
         suggested_render_mask = 2

--- a/pygfx/renderers/wgpu/volumerender.py
+++ b/pygfx/renderers/wgpu/volumerender.py
@@ -132,9 +132,17 @@ def volume_slice_renderer(render_info):
     for i, binding in bindings.items():
         shader.define_binding(0, i, binding)
 
+    # Get in what passes this needs rendering
+    suggested_render_mask = 3
+    if "a" not in fmt and material.opacity >= 1:
+        suggested_render_mask = 1
+    elif material.opacity < 1:
+        suggested_render_mask = 2
+
     # Put it together!
     return [
         {
+            "suggested_render_mask": suggested_render_mask,
             "render_shader": shader,
             "primitive_topology": topology,
             "indices": (range(n), range(1)),
@@ -393,9 +401,17 @@ def volume_ray_renderer(render_info):
     for i, binding in bindings.items():
         shader.define_binding(0, i, binding)
 
+    # Get in what passes this needs rendering
+    suggested_render_mask = 3
+    if "a" not in fmt and material.opacity >= 1:
+        suggested_render_mask = 1
+    elif material.opacity < 1:
+        suggested_render_mask = 2
+
     # Put it together!
     return [
         {
+            "suggested_render_mask": suggested_render_mask,
             "render_shader": shader,
             "primitive_topology": wgpu.PrimitiveTopology.triangle_list,
             "cull_mode": wgpu.CullMode.front,  # the back planes are the ref


### PR DESCRIPTION
Todo:

* [x] A new `WorldObject.render_order` property.
* [x] A new `WorldObject.render_mask` property to tell the renderer whether the object is opaque or transparent (or let the renderer try figuring this out). 
* [x] A new `Renderer.sort_objects` property to control whether objects are sorted. 
* [x] Autodetermine in what passes an object must be rendered.
* [x] Cleanup
* [x] Remove `Blender.is_order_independent` attribute if we won't use it (to determine whether to sort or not).

The `Renderer.sort_objects` is False by default. If True, it will use the wobjects's `render_order` and distance from camera to sort.

The  `WorldObject.render_mask` is "auto" by default. In this case the renderer will try to establish that the object is either fully opaque or fully transparent. This cannot always be determined, e.g. because there is a texture mapping that has an alpha channel, or a color per vertex (which can also have alpha < 1). In these cases it will just render in both passes. The user can override this via `WorldObject.render_mask`. This can also be done for e.g. lines: setting the render_mask to "opaque" will effectively disable the aa for a line (though we still have the SSAA), making it a bit more performant when this matters.
