### PR TITLE
Update examples to use wgpu's auto gui (rebased)

### DIFF
--- a/examples/clipping_planes.py
+++ b/examples/clipping_planes.py
@@ -2,55 +2,13 @@
 Example demonstrating clipping planes on a mesh.
 """
 
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
-
-from PySide6 import QtWidgets, QtCore
-from wgpu.gui.qt import WgpuCanvas
-
-
-class WgpuCanvasWithInputEvents(WgpuCanvas):
-    _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
-    _mode = None
-
-    def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
-
-    def mousePressEvent(self, event):  # noqa: N802
-        mode = self._drag_modes.get(event.button(), None)
-        if self._mode or not mode:
-            return
-        self._mode = mode
-        drag_start = (
-            controls.pan_start if self._mode == "pan" else controls.rotate_start
-        )
-        drag_start(
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
-        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
-
-    def mouseReleaseEvent(self, event):  # noqa: N802
-        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
-            self._mode = None
-            drag_stop = (
-                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
-            )
-            drag_stop()
-            app.restoreOverrideCursor()
-
-    def mouseMoveEvent(self, event):  # noqa: N802
-        if self._mode is not None:
-            drag_move = (
-                controls.pan_move if self._mode == "pan" else controls.rotate_move
-            )
-            drag_move((event.position().x(), event.position().y()))
 
 
 # Create a canvas and a renderer
 
-app = QtWidgets.QApplication([])
-canvas = WgpuCanvasWithInputEvents(size=(800, 400))
+canvas = WgpuCanvas(size=(800, 400))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 # Compose two of the same scenes
@@ -81,6 +39,7 @@ camera = gfx.PerspectiveCamera(70, 16 / 9)
 camera.position.z = 250
 
 controls = gfx.OrbitControls(camera.position.clone())
+controls.add_default_event_handlers(canvas, camera)
 
 
 def animate():
@@ -97,4 +56,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/collection_line.py
+++ b/examples/collection_line.py
@@ -10,10 +10,8 @@ from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = WgpuCanvas(max_fps=999)
 renderer = gfx.WgpuRenderer(canvas, show_fps=True)
-
-canvas._target_fps = 9999  # don't limit fps
 
 scene = gfx.Scene()
 

--- a/examples/collection_line.py
+++ b/examples/collection_line.py
@@ -4,54 +4,13 @@ this is still performant.
 """
 
 import time  # noqa
-import numpy as np
 
+import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets, QtCore
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithInputEvents(WgpuCanvas):
-    _drag_modes = {QtCore.Qt.RightButton: "pan"}
-    _mode = None
-
-    def wheelEvent(self, event):  # noqa: N802
-        zoom_multiplier = 2 ** (event.angleDelta().y() * 0.0015)
-        controls.zoom_to_point(
-            zoom_multiplier,
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
-        self.request_draw()
-
-    def mousePressEvent(self, event):  # noqa: N802
-        mode = self._drag_modes.get(event.button(), None)
-        if self._mode or not mode:
-            return
-        self._mode = mode
-        controls.pan_start(
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
-        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
-
-    def mouseReleaseEvent(self, event):  # noqa: N802
-        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
-            self._mode = None
-            controls.pan_stop()
-            app.restoreOverrideCursor()
-
-    def mouseMoveEvent(self, event):  # noqa: N802
-        if self._mode is not None:
-            controls.pan_move((event.position().x(), event.position().y()))
-        self.request_draw()
-
-
-app = QtWidgets.QApplication([])
-canvas = WgpuCanvasWithInputEvents()
+canvas = WgpuCanvas()
 renderer = gfx.WgpuRenderer(canvas, show_fps=True)
 
 canvas._target_fps = 9999  # don't limit fps
@@ -88,6 +47,7 @@ camera = gfx.OrthographicCamera(cols, rows)
 camera.maintain_aspect = False
 controls = gfx.PanZoomControls(camera.position.clone())
 controls.pan(gfx.linalg.Vector3(cols / 2, rows / 2, 0))
+controls.add_default_event_handlers(canvas, camera)
 
 
 def animate():
@@ -100,4 +60,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/colormap_channels.py
+++ b/examples/colormap_channels.py
@@ -2,14 +2,10 @@
 Example demonstrating colormaps in 4 modes: grayscale, gray+alpha, RGB, RGBA.
 """
 
-import pygfx as gfx
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas(size=(900, 400))
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -64,4 +60,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/colormap_mesh.py
+++ b/examples/colormap_mesh.py
@@ -2,15 +2,11 @@
 Example demonstrating different colormap dimensions on a mesh.
 """
 
-import pygfx as gfx
 import numpy as np
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas(size=(900, 400))
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -114,4 +110,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -2,9 +2,8 @@
 Example showing a single geometric cube.
 """
 
-import pygfx as gfx
-
 from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
 
 
 canvas = WgpuCanvas()

--- a/examples/custom_object.py
+++ b/examples/custom_object.py
@@ -2,11 +2,9 @@
 Example that implements a custom object and renders it.
 """
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
-from pygfx.renderers.wgpu._shadercomposer import Binding
+from pygfx.renderers.wgpu._shadercomposer import Binding, WorldObjectShader
 
 
 # %% Custom object, material, and matching render function
@@ -22,64 +20,56 @@ class TriangleMaterial(gfx.Material):
     pass
 
 
-shader_source = """
+class TriangleShader(WorldObjectShader):
+    def get_code(self):
+        return (
+            self.get_definitions()
+            + self.common_functions()
+            + self.vertex_shader()
+            + self.fragment_shader()
+        )
 
-struct Stdinfo {
-    cam_transform: mat4x4<f32>;
-    cam_transform_inv: mat4x4<f32>;
-    projection_transform: mat4x4<f32>;
-    projection_transform_inv: mat4x4<f32>;
-    physical_size: vec2<f32>;
-    logical_size: vec2<f32>;
-};
+    def vertex_shader(self):
+        return """
+        [[stage(vertex)]]
+        fn vs_main([[builtin(vertex_index)]] index: u32) -> [[builtin(position)]] vec4<f32> {
+            var positions1 = array<vec2<f32>, 3>(vec2<f32>(0.0, -0.5), vec2<f32>(0.5, 0.5), vec2<f32>(-0.5, 0.7));
+            var positions2 = array<vec2<f32>, 3>(vec2<f32>(10.0, 10.0), vec2<f32>(90.0, 10.0), vec2<f32>(10.0, 90.0));
 
-[[group(0), binding(0)]]
-var<uniform> u_stdinfo: Stdinfo;
+            // let p = positions1[index];
+            let p = 2.0 * positions2[index] / u_stdinfo.logical_size - 1.0;
+            return vec4<f32>(p, 0.0, 1.0);
+        }
+        """
 
-[[stage(vertex)]]
-fn vs_main([[builtin(vertex_index)]] index: u32) -> [[builtin(position)]] vec4<f32> {
-    var positions1 = array<vec2<f32>, 3>(vec2<f32>(0.0, -0.5), vec2<f32>(0.5, 0.5), vec2<f32>(-0.5, 0.7));
-    var positions2 = array<vec2<f32>, 3>(vec2<f32>(10.0, 10.0), vec2<f32>(90.0, 10.0), vec2<f32>(10.0, 90.0));
-
-    // let p = positions1[index];
-    let p = 2.0 * positions2[index] / u_stdinfo.logical_size - 1.0;
-    return vec4<f32>(p, 0.0, 1.0);
-}
-
-struct FragmentOutput {
-    [[location(0)]] color: vec4<f32>;
-    [[location(1)]] pick: vec4<i32>;
-};
-
-[[stage(fragment)]]
-fn fs_main() -> FragmentOutput {
-    var out: FragmentOutput;
-    out.color = vec4<f32>(1.0, 0.7, 0.2, 1.0);
-    return out;
-}
-"""
+    def fragment_shader(self):
+        return """
+        [[stage(fragment)]]
+        fn fs_main() -> FragmentOutput {
+            var out: FragmentOutput;
+            out.color = vec4<f32>(1.0, 0.7, 0.2, 1.0);
+            return out;
+        }
+        """
 
 
 # Tell pygfx to use this render function for a Triangle with TriangleMaterial.
 @gfx.renderers.wgpu.register_wgpu_render_function(Triangle, TriangleMaterial)
-def triangle_render_function(wobject, render_info):
-    n = 3
+def triangle_render_function(render_info):
+    shader = TriangleShader(render_info)
+    binding = Binding("u_stdinfo", "buffer/uniform", render_info.stdinfo_uniform)
+    shader.define_binding(0, 0, binding)
     return [
         {
-            "vertex_shader": (shader_source, "vs_main"),
-            "fragment_shader": (shader_source, "fs_main"),
+            "render_shader": shader,
             "primitive_topology": "triangle-list",
-            "indices": range(n),
-            "bindings0": {
-                0: Binding("u_stdinfo", "buffer/uniform", render_info.stdinfo_uniform)
-            },
+            "indices": range(3),
+            "bindings0": {0: binding},
         },
     ]
 
 
 # %% Setup scene
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.WgpuRenderer(canvas)
@@ -95,5 +85,4 @@ camera = gfx.NDCCamera()  # This material does not actually use the camera
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
-    canvas.closeEvent = lambda *args: app.quit()
+    run()

--- a/examples/cylinder.py
+++ b/examples/cylinder.py
@@ -3,54 +3,11 @@ Example showing different types of geometric cylinders.
 """
 
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets, QtCore
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithInputEvents(WgpuCanvas):
-    _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
-    _mode = None
-
-    def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
-
-    def mousePressEvent(self, event):  # noqa: N802
-        mode = self._drag_modes.get(event.button(), None)
-        if self._mode or not mode:
-            return
-        self._mode = mode
-        drag_start = (
-            controls.pan_start if self._mode == "pan" else controls.rotate_start
-        )
-        drag_start(
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
-        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
-
-    def mouseReleaseEvent(self, event):  # noqa: N802
-        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
-            self._mode = None
-            drag_stop = (
-                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
-            )
-            drag_stop()
-            app.restoreOverrideCursor()
-
-    def mouseMoveEvent(self, event):  # noqa: N802
-        if self._mode is not None:
-            drag_move = (
-                controls.pan_move if self._mode == "pan" else controls.rotate_move
-            )
-            drag_move((event.position().x(), event.position().y()))
-
-
-app = QtWidgets.QApplication([])
-
-canvas = WgpuCanvasWithInputEvents()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -94,13 +51,16 @@ camera.position.set(0, -65, 50)
 controls = gfx.OrbitControls(camera.position.clone())
 
 
+@canvas.add_event_handler("pointer_down", "pointer_up", "pointer_move", "wheel")
+def handle_event(event):
+    controls.handle_event(event, canvas, camera)
+
+
 def animate():
     controls.update_camera(camera)
-
     renderer.render(scene, camera)
-    canvas.request_draw()
 
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/flat_shaded_torus.py
+++ b/examples/flat_shaded_torus.py
@@ -2,13 +2,9 @@
 Example showing a Torus knot, using flat shading.
 """
 
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -20,7 +16,6 @@ geometry.texcoords.data[:, 0] *= 10  # stretch the texture
 material = gfx.MeshFlatMaterial(color=(1, 0, 1, 1))
 obj = gfx.Mesh(geometry, material)
 scene.add(obj)
-
 
 camera = gfx.PerspectiveCamera(70, 1)
 camera.position.z = 4
@@ -36,4 +31,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/geometry_cubes.py
+++ b/examples/geometry_cubes.py
@@ -3,13 +3,9 @@ Example showing multiple rotating cubes. This also tests the depth buffer.
 """
 
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -45,4 +41,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/geometry_klein_bottle.py
+++ b/examples/geometry_klein_bottle.py
@@ -2,13 +2,9 @@
 Example showing a Klein Bottle.
 """
 
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -37,4 +33,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/geometry_plane.py
+++ b/examples/geometry_plane.py
@@ -3,13 +3,9 @@ Use a plane geometry to show a texture, which is continuously updated to show vi
 """
 
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -44,4 +40,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.draw_frame = animate
-    app.exec()
+    run()

--- a/examples/geometry_torus_knot.py
+++ b/examples/geometry_torus_knot.py
@@ -3,13 +3,9 @@ Example showing a Torus knot, with a texture and lighting.
 """
 
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -23,7 +19,6 @@ geometry.texcoords.data[:, 0] *= 10  # stretch the texture
 material = gfx.MeshPhongMaterial(map=tex, clim=(30, 240))
 obj = gfx.Mesh(geometry, material)
 scene.add(obj)
-
 
 camera = gfx.PerspectiveCamera(70, 1)
 camera.position.z = 4
@@ -39,4 +34,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/image_plus_points.py
+++ b/examples/image_plus_points.py
@@ -3,13 +3,9 @@ Show an image with points overlaid.
 """
 
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -25,9 +21,10 @@ material = gfx.MeshBasicMaterial(map=tex.get_view(filter="linear"))
 
 plane = gfx.Mesh(geometry, material)
 plane.position = gfx.linalg.Vector3(256, 256, 0)  # put corner at 0, 0
-
+plane.geometry.texcoords.data[:, 1] = (
+    1 - plane.geometry.texcoords.data[:, 1]
+)  # flip image
 scene.add(plane)
-
 
 # %% add points
 
@@ -40,12 +37,12 @@ points = gfx.Points(geometry_p, material_p)
 points.position.z = 1  # move points in front of the image
 scene.add(points)
 
-
 near, far = -400, 700
 camera = gfx.OrthographicCamera(512, 512)
 camera.position.set(256, 256, 0)
 camera.scale.y = -1
 
+
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/instancing_mesh.py
+++ b/examples/instancing_mesh.py
@@ -4,13 +4,9 @@ Example rendering the same mesh object multiple times, using instancing.
 
 import numpy as np
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -47,4 +43,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/line_basic.py
+++ b/examples/line_basic.py
@@ -3,13 +3,9 @@ Some basic line drawing.
 """
 
 import numpy as np
-
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.WgpuRenderer(canvas)
@@ -43,4 +39,4 @@ camera.position.set(300, 250, 0)
 if __name__ == "__main__":
     renderer_svg.render(scene, camera)
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/line_performance.py
+++ b/examples/line_performance.py
@@ -3,13 +3,9 @@ Display a line depicting a noisy signal consisting of a lot of points.
 """
 
 import numpy as np
-
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.WgpuRenderer(canvas)
@@ -27,11 +23,10 @@ line = gfx.Line(
 )
 scene.add(line)
 
-
 camera = gfx.OrthographicCamera(110, 110)
 camera.position.set(50, 0, 0)
 
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/line_segments.py
+++ b/examples/line_segments.py
@@ -3,13 +3,9 @@ Display line segments. Can be useful e.g. for visializing vector fields.
 """
 
 import numpy as np
-
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.WgpuRenderer(canvas)
@@ -23,7 +19,6 @@ positions = np.column_stack([x, y, np.zeros_like(x)])
 colors = np.random.uniform(0, 1, (x.size, 4)).astype(np.float32)
 geometry = gfx.Geometry(positions=positions, colors=colors)
 
-
 # Also see LineSegmentMaterial and LineThinSegmentMaterial
 material = gfx.LineSegmentMaterial(
     thickness=6.0, color=(0.0, 0.7, 0.3, 0.5), vertex_colors=True
@@ -36,4 +31,4 @@ camera = gfx.ScreenCoordsCamera()
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/line_thick.py
+++ b/examples/line_thick.py
@@ -3,13 +3,9 @@ Display very thick lines to show how lines stay pretty on large scales.
 """
 
 import random
-
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.WgpuRenderer(canvas)
@@ -41,4 +37,4 @@ camera = gfx.ScreenCoordsCamera()
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/line_thin.py
+++ b/examples/line_thin.py
@@ -3,13 +3,9 @@ Some thin line drawing.
 """
 
 import numpy as np
-
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.WgpuRenderer(canvas)
@@ -46,4 +42,4 @@ camera.position.set(300, 250, 0)
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/manual_matrix_update.py
+++ b/examples/manual_matrix_update.py
@@ -3,13 +3,9 @@ Example showing transform control flow without matrix auto updating.
 """
 
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -52,4 +48,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/mesh_slice.py
+++ b/examples/mesh_slice.py
@@ -2,13 +2,9 @@
 Example showing off the mesh slice material.
 """
 
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -40,4 +36,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/multi_slice1.py
+++ b/examples/multi_slice1.py
@@ -8,53 +8,11 @@ from time import time
 
 import imageio
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets, QtCore
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithInputEvents(WgpuCanvas):
-    _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
-    _mode = None
-
-    def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
-
-    def mousePressEvent(self, event):  # noqa: N802
-        mode = self._drag_modes.get(event.button(), None)
-        if self._mode or not mode:
-            return
-        self._mode = mode
-        drag_start = (
-            controls.pan_start if self._mode == "pan" else controls.rotate_start
-        )
-        drag_start(
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
-        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
-
-    def mouseReleaseEvent(self, event):  # noqa: N802
-        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
-            self._mode = None
-            drag_stop = (
-                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
-            )
-            drag_stop()
-            app.restoreOverrideCursor()
-
-    def mouseMoveEvent(self, event):  # noqa: N802
-        if self._mode is not None:
-            drag_move = (
-                controls.pan_move if self._mode == "pan" else controls.rotate_move
-            )
-            drag_move((event.position().x(), event.position().y()))
-
-
-app = QtWidgets.QApplication([])
-canvas = WgpuCanvasWithInputEvents()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -101,6 +59,7 @@ camera.look_at(gfx.linalg.Vector3())
 controls = gfx.OrbitControls(
     camera.position.clone(), up=gfx.linalg.Vector3(0, 0, 1), zoom_changes_distance=False
 )
+controls.add_default_event_handlers(canvas, camera)
 
 
 def animate():
@@ -117,4 +76,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/multi_slice2.py
+++ b/examples/multi_slice2.py
@@ -9,54 +9,12 @@ from time import time
 
 import imageio
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 from skimage.measure import marching_cubes
 
-from PySide6 import QtWidgets, QtCore
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithInputEvents(WgpuCanvas):
-    _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
-    _mode = None
-
-    def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
-
-    def mousePressEvent(self, event):  # noqa: N802
-        mode = self._drag_modes.get(event.button(), None)
-        if self._mode or not mode:
-            return
-        self._mode = mode
-        drag_start = (
-            controls.pan_start if self._mode == "pan" else controls.rotate_start
-        )
-        drag_start(
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
-        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
-
-    def mouseReleaseEvent(self, event):  # noqa: N802
-        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
-            self._mode = None
-            drag_stop = (
-                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
-            )
-            drag_stop()
-            app.restoreOverrideCursor()
-
-    def mouseMoveEvent(self, event):  # noqa: N802
-        if self._mode is not None:
-            drag_move = (
-                controls.pan_move if self._mode == "pan" else controls.rotate_move
-            )
-            drag_move((event.position().x(), event.position().y()))
-
-
-app = QtWidgets.QApplication([])
-canvas = WgpuCanvasWithInputEvents()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -97,6 +55,7 @@ controls = gfx.OrbitControls(
     up=gfx.linalg.Vector3(0, 0, 1),
     zoom_changes_distance=False,
 )
+controls.add_default_event_handlers(canvas, camera)
 
 # Add a slight tilt. This is to show that the slices are still orthogonal
 # to the world coordinates.
@@ -116,4 +75,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -3,53 +3,11 @@ Example showing orbit camera controls.
 """
 
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets, QtCore
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithInputEvents(WgpuCanvas):
-    _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
-    _mode = None
-
-    def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
-
-    def mousePressEvent(self, event):  # noqa: N802
-        mode = self._drag_modes.get(event.button(), None)
-        if self._mode or not mode:
-            return
-        self._mode = mode
-        drag_start = (
-            controls.pan_start if self._mode == "pan" else controls.rotate_start
-        )
-        drag_start(
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
-        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
-
-    def mouseReleaseEvent(self, event):  # noqa: N802
-        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
-            self._mode = None
-            drag_stop = (
-                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
-            )
-            drag_stop()
-            app.restoreOverrideCursor()
-
-    def mouseMoveEvent(self, event):  # noqa: N802
-        if self._mode is not None:
-            drag_move = (
-                controls.pan_move if self._mode == "pan" else controls.rotate_move
-            )
-            drag_move((event.position().x(), event.position().y()))
-
-
-app = QtWidgets.QApplication([])
-canvas = WgpuCanvasWithInputEvents()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -71,6 +29,7 @@ scene.add(background)
 camera = gfx.PerspectiveCamera(70, 16 / 9)
 camera.position.set(0, 0, 500)
 controls = gfx.OrbitControls(camera.position.clone())
+controls.add_default_event_handlers(canvas, camera)
 
 
 def animate():
@@ -88,4 +47,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -3,53 +3,11 @@ Example showing orbit camera controls.
 """
 
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets, QtCore
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithInputEvents(WgpuCanvas):
-    _drag_modes = {QtCore.Qt.RightButton: "pan"}
-    _mode = None
-
-    def wheelEvent(self, event):  # noqa: N802
-        zoom_multiplier = 2 ** (event.angleDelta().y() * 0.0015)
-        controls.zoom_to_point(
-            zoom_multiplier,
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
-        canvas.request_draw()
-
-    def mousePressEvent(self, event):  # noqa: N802
-        mode = self._drag_modes.get(event.button(), None)
-        if self._mode or not mode:
-            return
-        self._mode = mode
-        controls.pan_start(
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
-        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
-
-    def mouseReleaseEvent(self, event):  # noqa: N802
-        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
-            self._mode = None
-            controls.pan_stop()
-            app.restoreOverrideCursor()
-        canvas.request_draw()
-
-    def mouseMoveEvent(self, event):  # noqa: N802
-        if self._mode is not None:
-            controls.pan_move((event.position().x(), event.position().y()))
-        canvas.request_draw()
-
-
-app = QtWidgets.QApplication([])
-canvas = WgpuCanvasWithInputEvents()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -69,14 +27,14 @@ scene.add(plane)
 camera = gfx.OrthographicCamera(512, 512)
 camera.position.set(0, 0, 500)
 controls = gfx.PanZoomControls(camera.position.clone())
+controls.add_default_event_handlers(canvas, camera)
 
 
 def animate():
     controls.update_camera(camera)
     renderer.render(scene, camera)
-    # canvas.request_draw()  # not needed it we request a draw on user interaction
 
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/picking_color.py
+++ b/examples/picking_color.py
@@ -5,23 +5,11 @@ object being clicked, more detailed picking info is available.
 
 import numpy as np
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
-
-class PickingWgpuCanvas(WgpuCanvas):
-    def mousePressEvent(self, event):  # noqa: N802
-        # Get a dict with info about the clicked location
-        xy = event.position().x(), event.position().y()
-        info = renderer.get_pick_info(xy)
-        for key, val in info.items():
-            print(key, "=", val)
-
-
-app = QtWidgets.QApplication([])
-canvas = PickingWgpuCanvas()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -36,10 +24,16 @@ material = gfx.MeshBasicMaterial(map=tex)
 cube = gfx.Mesh(geometry, material)
 scene.add(cube)
 
-
 # camera = gfx.OrthographicCamera(300, 300)
 camera = gfx.PerspectiveCamera(70, 16 / 9)
 camera.position.z = 400
+
+
+@canvas.add_event_handler("pointer_down")
+def handle_event(event):
+    info = renderer.get_pick_info((event["x"], event["y"]))
+    for key, val in info.items():
+        print(key, "=", val)
 
 
 def animate():
@@ -52,4 +46,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/picking_mesh.py
+++ b/examples/picking_mesh.py
@@ -7,37 +7,11 @@ on. Upon clicking, the vertex closest to the pick location is moved.
 
 import numpy as np
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
-
-class PickingWgpuCanvas(WgpuCanvas):
-    def mousePressEvent(self, event):  # noqa: N802
-        # Get a dict with info about the clicked location
-        xy = event.position().x(), event.position().y()
-        info = renderer.get_pick_info(xy)
-        wobject = info["world_object"]
-        # If a mesh was clicked ..
-        if wobject and "face_index" in info:
-            # Get what face was clicked
-            face_index = info["face_index"]
-            coords = info["face_coord"]
-            # Select which of the three vertices was closest
-            # Note that you can also select all vertices for this face,
-            # or use the coords to select the closest edge.
-            sub_index = np.argmax(coords)
-            # Look up the vertex index
-            vertex_index = int(wobject.geometry.indices.data[face_index, sub_index])
-            # Change the position of that vertex
-            pos = wobject.geometry.positions.data[vertex_index]
-            pos[:] *= 1.1
-            wobject.geometry.positions.update_range(vertex_index, 1)
-
-
-app = QtWidgets.QApplication([])
-canvas = PickingWgpuCanvas()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -58,6 +32,27 @@ camera = gfx.PerspectiveCamera(70, 16 / 9)
 camera.position.z = 400
 
 
+@canvas.add_event_handler("pointer_down")
+def handle_event(event):
+    info = renderer.get_pick_info((event["x"], event["y"]))
+    wobject = info["world_object"]
+    # If a mesh was clicked ..
+    if wobject and "face_index" in info:
+        # Get what face was clicked
+        face_index = info["face_index"]
+        coords = info["face_coord"]
+        # Select which of the three vertices was closest
+        # Note that you can also select all vertices for this face,
+        # or use the coords to select the closest edge.
+        sub_index = np.argmax(coords)
+        # Look up the vertex index
+        vertex_index = int(wobject.geometry.indices.data[face_index, sub_index])
+        # Change the position of that vertex
+        pos = wobject.geometry.positions.data[vertex_index]
+        pos[:] *= 1.1
+        wobject.geometry.positions.update_range(vertex_index, 1)
+
+
 def animate():
     rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.005, 0.01))
     cube.rotation.multiply(rot)
@@ -69,4 +64,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/picking_points.py
+++ b/examples/picking_points.py
@@ -4,29 +4,11 @@ is changed. With a small change, a line is shown instead.
 """
 
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
-
-class PickingWgpuCanvas(WgpuCanvas):
-    def mousePressEvent(self, event):  # noqa: N802
-        # Get a dict with info about the clicked location
-        xy = event.position().x(), event.position().y()
-        info = renderer.get_pick_info(xy)
-        print(info)
-        wobject = info["world_object"]
-        # If a point was clicked ..
-        if wobject and "vertex_index" in info:
-            i = int(round(info["vertex_index"]))
-            geometry.positions.data[i, 1] *= -1
-            geometry.positions.update_range(i)
-            canvas.request_draw()
-
-
-app = QtWidgets.QApplication([])
-canvas = PickingWgpuCanvas()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -42,6 +24,18 @@ scene.add(ob)
 camera = gfx.OrthographicCamera(120, 120)
 
 
+@canvas.add_event_handler("pointer_down")
+def handle_event(event):
+    info = renderer.get_pick_info((event["x"], event["y"]))
+    wobject = info["world_object"]
+    # If a point was clicked ..
+    if wobject and "vertex_index" in info:
+        i = int(round(info["vertex_index"]))
+        geometry.positions.data[i, 1] *= -1
+        geometry.positions.update_range(i)
+        canvas.request_draw()
+
+
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/points_basic.py
+++ b/examples/points_basic.py
@@ -1,10 +1,7 @@
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.WgpuRenderer(canvas)
@@ -29,4 +26,4 @@ camera = gfx.NDCCamera()
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/post_processing1.py
+++ b/examples/post_processing1.py
@@ -14,11 +14,12 @@ import time
 
 import numpy as np
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
-
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 from pygfx.renderers.wgpu._shadercomposer import Binding
+
+
+raise RuntimeError("Post-processing needs to be redesigned")
 
 
 # %% Create a custom object + material
@@ -128,8 +129,6 @@ def triangle_render_function(wobject, render_info):
 
 # %% The application
 
-app = QtWidgets.QApplication([])
-
 # The canvas for eventual display
 canvas = WgpuCanvas(size=(640, 480))
 
@@ -172,4 +171,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/post_processing2.py
+++ b/examples/post_processing2.py
@@ -11,13 +11,11 @@ future.
 
 import numpy as np
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
-
-app = QtWidgets.QApplication([])
+raise RuntimeError("Post-processing needs to be redesigned")
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -69,4 +67,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/scene_in_a_scene.py
+++ b/examples/scene_in_a_scene.py
@@ -11,13 +11,8 @@ surface of the cube in the outer scene.
 
 import numpy as np
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
-
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 
 # First create the subscene, that reders into a texture
@@ -70,4 +65,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas2.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/scene_overlay.py
+++ b/examples/scene_overlay.py
@@ -6,15 +6,12 @@ the overlay, so that it's always on top.
 """
 
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
-
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
 
 # Create a canvas and renderer
 
-app = QtWidgets.QApplication([])
 canvas = WgpuCanvas(size=(500, 300))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
@@ -64,4 +61,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/scene_side_by_side.py
+++ b/examples/scene_side_by_side.py
@@ -5,15 +5,12 @@ This is a feature necessary to implement e.g. subplots.
 """
 
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
-
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
 
 # Create a anvas and a renderer
 
-app = QtWidgets.QApplication([])
 canvas = WgpuCanvas(size=(500, 300))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
@@ -61,4 +58,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/skybox.py
+++ b/examples/skybox.py
@@ -5,10 +5,8 @@ Inspired by https://github.com/gfx-rs/wgpu-rs/blob/master/examples/skybox/main.r
 """
 
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
-
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
 # Read the image
 # The order of the images is already correct for GPU cubemap texture sampling
@@ -18,7 +16,6 @@ im = imageio.imread("imageio:meadow_cube.jpg")
 width = height = im.shape[1]
 im.shape = -1, width, height, 3
 
-app = QtWidgets.QApplication([])
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
@@ -61,4 +58,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/spheres.py
+++ b/examples/spheres.py
@@ -3,54 +3,11 @@ Example showing different types of geometric cylinders.
 """
 
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets, QtCore
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithInputEvents(WgpuCanvas):
-    _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
-    _mode = None
-
-    def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
-
-    def mousePressEvent(self, event):  # noqa: N802
-        mode = self._drag_modes.get(event.button(), None)
-        if self._mode or not mode:
-            return
-        self._mode = mode
-        drag_start = (
-            controls.pan_start if self._mode == "pan" else controls.rotate_start
-        )
-        drag_start(
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
-        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
-
-    def mouseReleaseEvent(self, event):  # noqa: N802
-        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
-            self._mode = None
-            drag_stop = (
-                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
-            )
-            drag_stop()
-            app.restoreOverrideCursor()
-
-    def mouseMoveEvent(self, event):  # noqa: N802
-        if self._mode is not None:
-            drag_move = (
-                controls.pan_move if self._mode == "pan" else controls.rotate_move
-            )
-            drag_move((event.position().x(), event.position().y()))
-
-
-app = QtWidgets.QApplication([])
-
-canvas = WgpuCanvasWithInputEvents()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -83,15 +40,15 @@ for pos, color, geometry in spheres:
 camera = gfx.PerspectiveCamera(70, 16 / 9)
 camera.position.set(6, 16, -22)
 controls = gfx.OrbitControls(camera.position.clone())
+controls.add_default_event_handlers(canvas, camera)
 
 
 def animate():
     controls.update_camera(camera)
-
     renderer.render(scene, camera)
     canvas.request_draw()
 
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/transparency1.py
+++ b/examples/transparency1.py
@@ -1,7 +1,7 @@
 """
 Example showing transparency using three overlapping planes.
 Press space to toggle the order of the planes.
-Press 1,2,3 to select the blend mode.
+Press 1-6 to select the blend mode.
 """
 
 from wgpu.gui.auto import WgpuCanvas, run

--- a/examples/transparency1.py
+++ b/examples/transparency1.py
@@ -4,38 +4,11 @@ Press space to toggle the order of the planes.
 Press 1,2,3 to select the blend mode.
 """
 
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithInputEvents(WgpuCanvas):
-    def keyPressEvent(self, event):  # noqa: N802
-        if not event.text():
-            pass
-        elif event.text() == " ":
-            print("Rotating scene element order")
-            scene.add(scene.children[0])
-            canvas.request_draw()
-        elif event.text() in "0123456789":
-            m = [
-                None,
-                "opaque",
-                "ordered1",
-                "ordered2",
-                "weighted",
-                "weighted_depth",
-                "weighted_plus",
-            ]
-            mode = m[int(event.text())]
-            renderer.blend_mode = mode
-            print("Selecting blend_mode", mode)
-
-
-app = QtWidgets.QApplication([])
-
-canvas = WgpuCanvasWithInputEvents()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -53,7 +26,28 @@ scene.add(plane1, plane2, plane3)
 camera = gfx.OrthographicCamera(100, 100)
 
 
+@canvas.add_event_handler("key_down")
+def handle_event(event):
+    if event["key"] == " ":
+        print("Rotating scene element order")
+        scene.add(scene.children[0])
+        canvas.request_draw()
+    elif event["key"] in "0123456789":
+        m = [
+            None,
+            "opaque",
+            "ordered1",
+            "ordered2",
+            "weighted",
+            "weighted_depth",
+            "weighted_plus",
+        ]
+        mode = m[int(event["key"])]
+        renderer.blend_mode = mode
+        print("Selecting blend_mode", mode)
+
+
 if __name__ == "__main__":
     print(__doc__)
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/transparency2.py
+++ b/examples/transparency2.py
@@ -1,16 +1,14 @@
 """
 Example showing transparency using three orthogonal planes.
 Press space to toggle the order of the planes.
-Press 1,2,3 to select the blend mode.
+Press 1-6 to select the blend mode.
 """
 
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-
 canvas = WgpuCanvas()
-canvas._target_fps = 1000
-renderer = gfx.renderers.WgpuRenderer(canvas, show_fps=True)
+renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
 sphere = gfx.Mesh(gfx.sphere_geometry(10), gfx.MeshPhongMaterial())

--- a/examples/transparency2.py
+++ b/examples/transparency2.py
@@ -4,74 +4,11 @@ Press space to toggle the order of the planes.
 Press 1,2,3 to select the blend mode.
 """
 
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets, QtCore
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithInputEvents(WgpuCanvas):
-    _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
-    _mode = None
-
-    def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
-
-    def mousePressEvent(self, event):  # noqa: N802
-        mode = self._drag_modes.get(event.button(), None)
-        if self._mode or not mode:
-            return
-        self._mode = mode
-        drag_start = (
-            controls.pan_start if self._mode == "pan" else controls.rotate_start
-        )
-        drag_start(
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
-        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
-
-    def keyPressEvent(self, event):  # noqa: N802
-        if not event.text():
-            pass
-        elif event.text() == " ":
-            print("Rotating scene element order")
-            scene.add(scene.children[0])
-        elif event.text() in "0123456789":
-            m = [
-                None,
-                "opaque",
-                "ordered1",
-                "ordered2",
-                "weighted",
-                "weighted_depth",
-                "weighted_plus",
-            ]
-            mode = m[int(event.text())]
-            renderer.blend_mode = mode
-            print("Selecting blend_mode", mode)
-
-    def mouseReleaseEvent(self, event):  # noqa: N802
-        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
-            self._mode = None
-            drag_stop = (
-                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
-            )
-            drag_stop()
-            app.restoreOverrideCursor()
-
-    def mouseMoveEvent(self, event):  # noqa: N802
-        if self._mode is not None:
-            drag_move = (
-                controls.pan_move if self._mode == "pan" else controls.rotate_move
-            )
-            drag_move((event.position().x(), event.position().y()))
-
-
-app = QtWidgets.QApplication([])
-
-canvas = WgpuCanvasWithInputEvents()
+canvas = WgpuCanvas()
 canvas._target_fps = 1000
 renderer = gfx.renderers.WgpuRenderer(canvas, show_fps=True)
 scene = gfx.Scene()
@@ -94,6 +31,30 @@ camera.position.z = 70
 controls = gfx.OrbitControls(camera.position.clone())
 
 
+@canvas.add_event_handler("key_down", "pointer_down", "pointer_up", "pointer_move")
+def handle_event(event):
+    if event["event_type"] == "key_down":
+        if event["key"] == " ":
+            print("Rotating scene element order")
+            scene.add(scene.children[0])
+            canvas.request_draw()
+        elif event["key"] in "0123456789":
+            m = [
+                None,
+                "opaque",
+                "ordered1",
+                "ordered2",
+                "weighted",
+                "weighted_depth",
+                "weighted_plus",
+            ]
+            mode = m[int(event["key"])]
+            renderer.blend_mode = mode
+            print("Selecting blend_mode", mode)
+    else:
+        controls.handle_event(event, canvas, camera)
+
+
 def animate():
     controls.update_camera(camera)
     renderer.render(scene, camera)
@@ -103,4 +64,4 @@ def animate():
 if __name__ == "__main__":
     print(__doc__)
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/two_canvases.py
+++ b/examples/two_canvases.py
@@ -3,15 +3,12 @@ Example demonstrating rendering the same scene into two different canvases.
 """
 
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
-
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
 
 # Create two canvases and two renderers
 
-app = QtWidgets.QApplication([])
 canvas_a = WgpuCanvas(size=(500, 300))
 canvas_b = WgpuCanvas(size=(300, 500))
 
@@ -57,4 +54,4 @@ def animate_b():
 if __name__ == "__main__":
     canvas_a.request_draw(animate_a)
     canvas_b.request_draw(animate_b)
-    app.exec()
+    run()

--- a/examples/validate_culling.py
+++ b/examples/validate_culling.py
@@ -7,12 +7,9 @@ Example test to validate winding and culling.
 
 """
 
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas(size=(600, 600))
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -57,4 +54,4 @@ def animate():
 if __name__ == "__main__":
     print(__doc__)
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/validate_depth_clipping.py
+++ b/examples/validate_depth_clipping.py
@@ -6,13 +6,9 @@ rectangles near the near and far clipping planes.
 * The greener square should be in the upper-left.
 """
 
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -62,4 +58,4 @@ for plane in (plane1, plane2, plane3, plane4):
 if __name__ == "__main__":
     print(__doc__)
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/validate_helpers1.py
+++ b/examples/validate_helpers1.py
@@ -7,13 +7,9 @@ Example showing the axes helper.
 * The blue axes (z) is not visible.
 """
 
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -26,4 +22,4 @@ camera = gfx.OrthographicCamera(100, 100)
 if __name__ == "__main__":
     print(__doc__)
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/validate_helpers2.py
+++ b/examples/validate_helpers2.py
@@ -5,13 +5,9 @@ Example showing the axes and grid helpers with a perspective camera.
 * The yellow axis (y) stick up from the plane.
 """
 
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -31,4 +27,4 @@ camera.look_at(gfx.linalg.Vector3())
 if __name__ == "__main__":
     print(__doc__)
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/validate_volume.py
+++ b/examples/validate_volume.py
@@ -6,13 +6,10 @@ Render a volume and volume slices. You should see:
 """
 
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
-
-app = QtWidgets.QApplication([])
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
@@ -72,4 +69,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/volume_render1.py
+++ b/examples/volume_render1.py
@@ -35,8 +35,8 @@ controls.rotate(-0.5, -0.5)
 def handle_event(event):
     if event["event_type"] == "pointer_down" and "Shift" in event["modifiers"]:
         info = renderer.get_pick_info((event["x"], event["y"]))
-        if "voxel_index" in info:
-            x, y, z = (max(1, int(i)) for i in info["voxel_index"])
+        if "index" in info:
+            x, y, z = (max(1, int(i)) for i in info["index"])
             print("Picking", x, y, z)
             tex.data[z - 1 : z + 1, y - 1 : y + 1, x - 1 : x + 1] = 2000
             tex.update_range((x - 1, y - 1, z - 1), (3, 3, 3))

--- a/examples/volume_render1.py
+++ b/examples/volume_render1.py
@@ -4,59 +4,11 @@ Render a volume. Shift-click to draw white blobs inside the volume.
 
 import imageio
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets, QtCore
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithInputEvents(WgpuCanvas):
-    _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
-    _mode = None
-
-    def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
-
-    def mousePressEvent(self, event):  # noqa: N802
-        xy = event.position().x(), event.position().y()
-        mode = self._drag_modes.get(event.button(), None)
-        if self._mode or not mode:
-            return
-        self._mode = mode
-        drag_start = (
-            controls.pan_start if self._mode == "pan" else controls.rotate_start
-        )
-        drag_start(xy, self.get_logical_size(), camera)
-        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
-
-        # Picking. Note that this works on both the volume and the slice.
-        if event.modifiers() and QtCore.Qt.Key_Shift:
-            info = renderer.get_pick_info((event.position().x(), event.position().y()))
-            if "voxel_index" in info:
-                x, y, z = (max(1, int(i)) for i in info["voxel_index"])
-                print("Picking", x, y, z)
-                tex.data[z - 1 : z + 1, y - 1 : y + 1, x - 1 : x + 1] = 2000
-                tex.update_range((x - 1, y - 1, z - 1), (3, 3, 3))
-
-    def mouseReleaseEvent(self, event):  # noqa: N802
-        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
-            self._mode = None
-            drag_stop = (
-                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
-            )
-            drag_stop()
-            app.restoreOverrideCursor()
-
-    def mouseMoveEvent(self, event):  # noqa: N802
-        if self._mode is not None:
-            drag_move = (
-                controls.pan_move if self._mode == "pan" else controls.rotate_move
-            )
-            drag_move((event.position().x(), event.position().y()))
-
-
-app = QtWidgets.QApplication([])
-canvas = WgpuCanvasWithInputEvents()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -79,13 +31,25 @@ controls = gfx.OrbitControls(camera.position.clone(), up=gfx.linalg.Vector3(0, 0
 controls.rotate(-0.5, -0.5)
 
 
+@canvas.add_event_handler("pointer_down", "pointer_up", "pointer_move", "wheel")
+def handle_event(event):
+    if event["event_type"] == "pointer_down" and "Shift" in event["modifiers"]:
+        info = renderer.get_pick_info((event["x"], event["y"]))
+        if "voxel_index" in info:
+            x, y, z = (max(1, int(i)) for i in info["voxel_index"])
+            print("Picking", x, y, z)
+            tex.data[z - 1 : z + 1, y - 1 : y + 1, x - 1 : x + 1] = 2000
+            tex.update_range((x - 1, y - 1, z - 1), (3, 3, 3))
+    else:
+        controls.handle_event(event, canvas, camera)
+
+
 def animate():
     controls.update_camera(camera)
-
     renderer.render(scene, camera)
     canvas.request_draw()
 
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/volume_render2.py
+++ b/examples/volume_render2.py
@@ -4,53 +4,11 @@ Render three volumes using different world transforms.
 
 import imageio
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets, QtCore
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithInputEvents(WgpuCanvas):
-    _drag_modes = {QtCore.Qt.RightButton: "pan", QtCore.Qt.LeftButton: "rotate"}
-    _mode = None
-
-    def wheelEvent(self, event):  # noqa: N802
-        controls.zoom(2 ** (event.angleDelta().y() * 0.0015))
-
-    def mousePressEvent(self, event):  # noqa: N802
-        mode = self._drag_modes.get(event.button(), None)
-        if self._mode or not mode:
-            return
-        self._mode = mode
-        drag_start = (
-            controls.pan_start if self._mode == "pan" else controls.rotate_start
-        )
-        drag_start(
-            (event.position().x(), event.position().y()),
-            self.get_logical_size(),
-            camera,
-        )
-        app.setOverrideCursor(QtCore.Qt.ClosedHandCursor)
-
-    def mouseReleaseEvent(self, event):  # noqa: N802
-        if self._mode and self._mode == self._drag_modes.get(event.button(), None):
-            self._mode = None
-            drag_stop = (
-                controls.pan_stop if self._mode == "pan" else controls.rotate_stop
-            )
-            drag_stop()
-            app.restoreOverrideCursor()
-
-    def mouseMoveEvent(self, event):  # noqa: N802
-        if self._mode is not None:
-            drag_move = (
-                controls.pan_move if self._mode == "pan" else controls.rotate_move
-            )
-            drag_move((event.position().x(), event.position().y()))
-
-
-app = QtWidgets.QApplication([])
-canvas = WgpuCanvasWithInputEvents()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -73,6 +31,7 @@ camera = gfx.PerspectiveCamera(70, 16 / 9)
 camera.position.y = 500
 controls = gfx.OrbitControls(camera.position.clone(), up=gfx.linalg.Vector3(0, 0, 1))
 controls.rotate(-0.5, -0.5)
+controls.add_default_event_handlers(canvas, camera)
 
 # A clipping plane at z=0 - only the rotating volume will be affected
 material.clipping_planes = [(0, 0, 1, 0)]
@@ -89,4 +48,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/volume_slice1.py
+++ b/examples/volume_slice1.py
@@ -4,20 +4,11 @@ Simple and ... slow.
 """
 
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithScroll(WgpuCanvas):
-    def wheelEvent(self, event):  # noqa: N802
-        degrees = event.angleDelta().y() / 8
-        scroll(degrees)
-
-
-app = QtWidgets.QApplication([])
-canvas = WgpuCanvasWithScroll()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -36,9 +27,10 @@ scene.add(plane)
 camera = gfx.OrthographicCamera(200, 200)
 
 
-def scroll(degrees):
+@canvas.add_event_handler("wheel")
+def handle_event(event):
     global index
-    index = index + int(degrees / 15)
+    index = index + int(event["dy"] / 90)
     index = max(0, min(nslices - 1, index))
     im = vol[index]
     tex.data[:] = im
@@ -48,4 +40,4 @@ def scroll(degrees):
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/volume_slice2.py
+++ b/examples/volume_slice2.py
@@ -4,20 +4,11 @@ Simple and relatively fast, but no subslices.
 """
 
 import imageio
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithScroll(WgpuCanvas):
-    def wheelEvent(self, event):  # noqa: N802
-        degrees = event.angleDelta().y() / 8
-        scroll(degrees)
-
-
-app = QtWidgets.QApplication([])
-canvas = WgpuCanvasWithScroll()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -37,9 +28,10 @@ scene.add(plane)
 camera = gfx.OrthographicCamera(200, 200)
 
 
-def scroll(degrees):
+@canvas.add_event_handler("wheel")
+def handle_event(event):
     global index
-    index = index + int(degrees / 15)
+    index = index + int(event["dy"] / 90)
     index = max(0, min(nslices - 1, index))
     view = tex.get_view(
         filter="linear", view_dim="2d", layer_range=range(index, index + 1)
@@ -50,4 +42,4 @@ def scroll(degrees):
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/volume_slice3.py
+++ b/examples/volume_slice3.py
@@ -5,20 +5,11 @@ a plane geometry. Simple, fast and subpixel!
 
 import imageio
 import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
 
-
-class WgpuCanvasWithScroll(WgpuCanvas):
-    def wheelEvent(self, event):  # noqa: N802
-        degrees = event.angleDelta().y() / 8
-        scroll(degrees)
-
-
-app = QtWidgets.QApplication([])
-canvas = WgpuCanvasWithScroll()
+canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -40,9 +31,10 @@ scene.add(plane)
 camera = gfx.OrthographicCamera(200, 200)
 
 
-def scroll(degrees):
+@canvas.add_event_handler("wheel")
+def handle_event(event):
     global index
-    index = index + degrees / 30
+    index = index + event["dy"] / 90
     index = max(0, min(nslices - 1, index))
     geometry.texcoords.data[:, 2] = index / nslices
     geometry.texcoords.update_range(0, geometry.texcoords.nitems)
@@ -51,4 +43,4 @@ def scroll(degrees):
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    app.exec()
+    run()

--- a/examples/wireframe1.py
+++ b/examples/wireframe1.py
@@ -6,13 +6,9 @@ producing a look of a metalic frame around a soft tube.
 
 """
 
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -45,4 +41,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/examples/wireframe2.py
+++ b/examples/wireframe2.py
@@ -4,13 +4,9 @@ one for the front, bright blue and lit, and one for the back, unlit and
 gray.
 """
 
+from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
-
-
-app = QtWidgets.QApplication([])
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -45,4 +41,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    run()

--- a/pygfx/controls/_orbit.py
+++ b/pygfx/controls/_orbit.py
@@ -175,3 +175,43 @@ class OrbitControls:
         camera.position.copy(pos)
         camera.zoom = zoom
         return self
+
+    def add_default_event_handlers(self, canvas, camera):
+        """Apply the default interaction mechanism to a wgpu autogui canvas."""
+        canvas.add_event_handler(
+            lambda event: self.handle_event(event, canvas, camera),
+            "pointer_down",
+            "pointer_move",
+            "pointer_up",
+            "wheel",
+        )
+
+    def handle_event(self, event, canvas, camera):
+        """Implements a default interaction mode that consumes wgpu autogui events
+        (compatible with the jupyter_rfb event specification).
+        """
+        type = event["event_type"]
+        if type == "pointer_down":
+            xy = event["x"], event["y"]
+            if event["button"] == 1:
+                self.rotate_start(xy, canvas.get_logical_size(), camera)
+            elif event["button"] == 2:
+                self.pan_start(xy, canvas.get_logical_size(), camera)
+        elif type == "pointer_up":
+            if event["button"] == 1:
+                self.rotate_stop()
+            elif event["button"] == 2:
+                self.pan_stop()
+            canvas.request_draw()
+        elif type == "pointer_move":
+            xy = event["x"], event["y"]
+            if 1 in event["buttons"]:
+                self.rotate_move(xy),
+            if 2 in event["buttons"]:
+                self.pan_move(xy),
+            canvas.request_draw()
+        elif type == "wheel":
+            xy = event["x"], event["y"]
+            f = 2 ** (-event["dy"] * 0.0015)
+            self.zoom(f)
+            canvas.request_draw()

--- a/pygfx/controls/_panzoom.py
+++ b/pygfx/controls/_panzoom.py
@@ -115,3 +115,37 @@ class PanZoomControls:
         camera.position.copy(pos)
         camera.zoom = zoom
         return self
+
+    def add_default_event_handlers(self, canvas, camera):
+        """Apply the default interaction mechanism to a wgpu autogui canvas."""
+        canvas.add_event_handler(
+            lambda event: self.handle_event(event, canvas, camera),
+            "pointer_down",
+            "pointer_move",
+            "pointer_up",
+            "wheel",
+        )
+
+    def handle_event(self, event, canvas, camera):
+        """Implements a default interaction mode that consumes wgpu autogui events
+        (compatible with the jupyter_rfb event specification).
+        """
+        type = event["event_type"]
+        if type == "pointer_down":
+            if event["button"] == 1:
+                xy = event["x"], event["y"]
+                self.pan_start(xy, canvas.get_logical_size(), camera)
+        elif type == "pointer_up":
+            if event["button"] == 1:
+                self.pan_stop()
+                canvas.request_draw()
+        elif type == "pointer_move":
+            if 1 in event["buttons"]:
+                xy = event["x"], event["y"]
+                self.pan_move(xy)
+                canvas.request_draw()
+        elif type == "wheel":
+            xy = event["x"], event["y"]
+            f = 2 ** (-event["dy"] * 0.0015)
+            self.zoom_to_point(f, xy, canvas.get_logical_size(), camera)
+            canvas.request_draw()

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -377,7 +377,7 @@ class MeshShader(WorldObjectShader):
             $$ if texture_dim
                 $$ if texture_dim == '1d'
                     $$ if texture_format == 'f32'
-                        color_value = textureSample(r_tex, r_sampler, varyings.texcoord.x);
+                        color_value = textureSample(r_tex, r_sampler, varyings.texcoord);
                     $$ else
                         let texcoords_dim = f32(textureDimensions(r_tex);
                         let texcoords_u = i32(varyings.texcoord.x * texcoords_dim % texcoords_dim);

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(f"{NAME}/__init__.py") as fh:
 
 runtime_deps = [
     "numpy",
-    "wgpu>=0.7.0,<0.8.0",
+    "wgpu>=0.7.1,<0.8.0",
     "Jinja2",
 ]
 


### PR DESCRIPTION
Closes #223.

* [x] Waiting for https://github.com/pygfx/wgpu-py/pull/224
* [x] Implement default interaction for controllers.
* [x] Update all examples that do not have interaction.
* [x] Update cylinder and panzoom examples.
* [x] Update all examples that have interaction.
* [x] Fix shader for colormap.
* [x] Fixed broken examples: custom_object, validate_ndc, image_plus_point, validate_image
* [x] Post-processing examples are broken - these need love later
* [x] Tweak default control behaviour.
* [ ] Allow user to specify behaviour? -> maybe later
* [x] The volume_render1.py example is broken because the modifier does not work on pointer_down. May be a bug in the glfw canvas. https://github.com/pygfx/wgpu-py/pull/227