### PR TITLE
Add BoxHelper

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -85,6 +85,10 @@ Helper objects
     :members:
     :member-order: bysource
 
+.. autoclass:: pygfx.BoxHelper
+    :members:
+    :member-order: bysource
+
 .. autoclass:: pygfx.GridHelper
     :members:
     :member-order: bysource

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -89,6 +89,8 @@ Helper objects
     :members:
     :member-order: bysource
 
+    .. automethod:: __init__
+
 .. autoclass:: pygfx.GridHelper
     :members:
     :member-order: bysource

--- a/examples/object_bounding_box.py
+++ b/examples/object_bounding_box.py
@@ -17,11 +17,18 @@ mesh = gfx.Mesh(
     gfx.trimesh_geometry(teapot),
     gfx.MeshPhongMaterial(),
 )
+mesh.rotation.set_from_euler(gfx.linalg.Euler(0.71, 0.91))
 scene.add(mesh)
 
-box = gfx.BoxHelper()
-box.set_object_world(mesh)
-scene.add(box)
+box_world = gfx.BoxHelper()
+box_world.set_object_world(mesh)
+scene.add(box_world)
+
+box_local = gfx.BoxHelper()
+box_local.set_object_local(mesh)
+mesh.add(box_local)
+
+box_local.material.color = (0, 1, 0, 1)
 
 
 if __name__ == "__main__":

--- a/examples/object_bounding_box.py
+++ b/examples/object_bounding_box.py
@@ -8,8 +8,7 @@ import trimesh
 import pygfx as gfx
 
 
-TEAPOT = Path(__file__).parent / "models" / "teapot.stl"
-teapot = trimesh.load(TEAPOT)
+teapot = trimesh.load(Path(__file__).parent / "models" / "teapot.stl")
 
 scene = gfx.Scene()
 

--- a/examples/object_bounding_box.py
+++ b/examples/object_bounding_box.py
@@ -1,0 +1,28 @@
+"""
+Demonstrates show utility with an STL file
+"""
+from pathlib import Path
+
+import trimesh
+
+import pygfx as gfx
+
+
+TEAPOT = Path(__file__).parent / "models" / "teapot.stl"
+teapot = trimesh.load(TEAPOT)
+
+scene = gfx.Scene()
+
+mesh = gfx.Mesh(
+    gfx.trimesh_geometry(teapot),
+    gfx.MeshPhongMaterial(),
+)
+scene.add(mesh)
+
+box = gfx.BoxHelper()
+box.set_object_world(mesh)
+scene.add(box)
+
+
+if __name__ == "__main__":
+    gfx.show(scene, up=gfx.linalg.Vector3(0, 0, 1))

--- a/examples/object_bounding_box.py
+++ b/examples/object_bounding_box.py
@@ -20,11 +20,11 @@ mesh.rotation.set_from_euler(gfx.linalg.Euler(0.71, 0.91))
 scene.add(mesh)
 
 box_world = gfx.BoxHelper()
-box_world.set_object_world(mesh)
+box_world.set_transform_by_object(mesh)
 scene.add(box_world)
 
 box_local = gfx.BoxHelper()
-box_local.set_object_local(mesh)
+box_local.set_transform_by_object(mesh, space="local")
 mesh.add(box_local)  # note that the parent is `mesh` here, not `scene`
 
 box_local.material.color = (0, 1, 0, 1)

--- a/examples/object_bounding_box.py
+++ b/examples/object_bounding_box.py
@@ -1,5 +1,5 @@
 """
-Demonstrates show utility with an STL file
+Demonstrates visualizing object bounding boxes
 """
 from pathlib import Path
 

--- a/examples/object_bounding_box.py
+++ b/examples/object_bounding_box.py
@@ -26,7 +26,7 @@ scene.add(box_world)
 
 box_local = gfx.BoxHelper()
 box_local.set_object_local(mesh)
-mesh.add(box_local)
+mesh.add(box_local)  # note that the parent is `mesh` here, not `scene`
 
 box_local.material.color = (0, 1, 0, 1)
 

--- a/examples/validate_helpers2.py
+++ b/examples/validate_helpers2.py
@@ -3,6 +3,7 @@ Example showing the axes and grid helpers with a perspective camera.
 
 * The grid spans the x-z plane (orange and blue axis).
 * The yellow axis (y) stick up from the plane.
+* The red box fits snugly around the grid.
 """
 
 from wgpu.gui.auto import WgpuCanvas, run
@@ -13,18 +14,35 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+background = gfx.Background(
+    None, gfx.BackgroundMaterial((0, 0.1, 0, 1), (0, 0.1, 0.1, 1))
+)
 scene.add(background)
 
-scene.add(gfx.AxesHelper(length=40))
-scene.add(gfx.GridHelper(size=100))
+axes = gfx.AxesHelper(length=40)
+scene.add(axes)
+
+grid = gfx.GridHelper(size=100)
+scene.add(grid)
+
+box = gfx.BoxHelper(size=100)
+scene.add(box)
 
 camera = gfx.PerspectiveCamera(70, 16 / 9)
-camera.position.set(50, 50, 50)
+camera.position.set(75, 75, 75)
 camera.look_at(gfx.linalg.Vector3())
+
+controls = gfx.OrbitControls(camera.position.clone())
+controls.add_default_event_handlers(canvas, camera)
+
+
+def animate():
+    controls.update_camera(camera)
+    renderer.render(scene, camera)
+    canvas.request_draw()
 
 
 if __name__ == "__main__":
     print(__doc__)
-    canvas.request_draw(lambda: renderer.render(scene, camera))
+    canvas.request_draw(animate)
     run()

--- a/pygfx/geometries/_base.py
+++ b/pygfx/geometries/_base.py
@@ -34,7 +34,9 @@ class Geometry(ResourceContainer):
     * ``grid``: A 2D or 3D Texture/TextureView that contains a regular grid of
       data. I.e. for images and volumes.
 
-    Example:
+    :Example:
+
+    .. code-block:: py
 
         g = Geometry(positions=[[1, 2], [2, 4], [3, 5], [4, 1]])
         g.positions.data  # numpy array

--- a/pygfx/helpers/__init__.py
+++ b/pygfx/helpers/__init__.py
@@ -2,3 +2,4 @@
 
 from ._axes import AxesHelper
 from ._grid import GridHelper
+from ._box import BoxHelper

--- a/pygfx/helpers/_axes.py
+++ b/pygfx/helpers/_axes.py
@@ -1,12 +1,12 @@
 import numpy as np
 
-from .. import Geometry, Line, LineSegmentMaterial
+from .. import Geometry, Line, LineThinSegmentMaterial
 
 
 class AxesHelper(Line):
     """An object indicating the axes directions."""
 
-    def __init__(self, length=1.0, thickness=6.0):
+    def __init__(self, length=1.0):
         positions = np.array(
             [
                 [0, 0, 0],
@@ -33,6 +33,15 @@ class AxesHelper(Line):
         )
 
         geometry = Geometry(positions=positions, colors=colors)
-        material = LineSegmentMaterial(thickness=thickness, vertex_colors=True)
+        material = LineThinSegmentMaterial(vertex_colors=True)
 
         super().__init__(geometry, material)
+
+    def set_colors(self, x, y, z):
+        self._geometry.colors.data[0] = x
+        self._geometry.colors.data[1] = x
+        self._geometry.colors.data[2] = y
+        self._geometry.colors.data[3] = y
+        self._geometry.colors.data[4] = z
+        self._geometry.colors.data[5] = z
+        self._geometry.colors.update_range(0, self._geometry.colors.nitems)

--- a/pygfx/helpers/_box.py
+++ b/pygfx/helpers/_box.py
@@ -113,8 +113,10 @@ class BoxHelper(Line):
         """
         aabb = None
         if space not in {"world", "local"}:
-            raise ValueError('Space argument must be either "world"'
-                             f'or "local". Given value: {space}')
+            raise ValueError(
+                'Space argument must be either "world"'
+                f'or "local". Given value: {space}'
+            )
         if space == "world":
             aabb = object.get_world_bounding_box()
         elif space == "local" and object.geometry is not None:

--- a/pygfx/helpers/_box.py
+++ b/pygfx/helpers/_box.py
@@ -48,22 +48,22 @@ class BoxHelper(Line):
 
     def set_object_world(self, object):
         aabb = object.get_world_bounding_box()
+        self.set_aabb(aabb)
+
+    def set_object_local(self, object):
+        if object.geometry:
+            aabb = object.geometry.bounding_box()
+        else:
+            aabb = None
+        self.set_aabb(aabb)
+
+    def set_aabb(self, aabb):
         if aabb is None:
             raise ValueError("Object has no geometry")
 
-        self._set_aabb(aabb)
-
-    def _set_aabb(self, aabb):
         diagonal = aabb[1] - aabb[0]
         center = aabb[0] + diagonal * 0.5
         scale = diagonal / self._size
 
         self.position.set(*center)
         self.scale.set(*scale)
-
-    def set_object_local(self, object):
-        if not object.geometry:
-            raise ValueError("Object has no geometry")
-        aabb = object.geometry.bounding_box()
-
-        self._set_aabb(aabb)

--- a/pygfx/helpers/_box.py
+++ b/pygfx/helpers/_box.py
@@ -7,6 +7,8 @@ class BoxHelper(Line):
     """An object visualizing a box."""
 
     def __init__(self, size=1.0):
+        self._size = size
+
         positions = np.array(
             [
                 [0, 0, 0],  # bottom edges
@@ -37,9 +39,19 @@ class BoxHelper(Line):
             dtype="f4",
         )
         positions -= 0.5
-        positions *= size
+        positions *= self._size
 
         geometry = Geometry(positions=positions)
         material = LineThinSegmentMaterial(color=(1, 0, 0, 1))
 
         super().__init__(geometry, material)
+
+    def set_object_world(self, object):
+        aabb = object.get_world_bounding_box()
+
+        diagonal = aabb[1] - aabb[0]
+        center = aabb[0] + diagonal * 0.5
+        scale = diagonal / self._size
+
+        self.position.set(*center)
+        self.scale.set(*scale)

--- a/pygfx/helpers/_box.py
+++ b/pygfx/helpers/_box.py
@@ -48,10 +48,22 @@ class BoxHelper(Line):
 
     def set_object_world(self, object):
         aabb = object.get_world_bounding_box()
+        if aabb is None:
+            raise ValueError("Object has no geometry")
 
+        self._set_aabb(aabb)
+
+    def _set_aabb(self, aabb):
         diagonal = aabb[1] - aabb[0]
         center = aabb[0] + diagonal * 0.5
         scale = diagonal / self._size
 
         self.position.set(*center)
         self.scale.set(*scale)
+
+    def set_object_local(self, object):
+        if not object.geometry:
+            raise ValueError("Object has no geometry")
+        aabb = object.geometry.bounding_box()
+
+        self._set_aabb(aabb)

--- a/pygfx/helpers/_box.py
+++ b/pygfx/helpers/_box.py
@@ -1,0 +1,45 @@
+import numpy as np
+
+from .. import Geometry, Line, LineThinSegmentMaterial
+
+
+class BoxHelper(Line):
+    """An object visualizing a box."""
+
+    def __init__(self, size=1.0):
+        positions = np.array(
+            [
+                [0, 0, 0],  # bottom edges
+                [1, 0, 0],
+                [0, 0, 0],
+                [0, 0, 1],
+                [1, 0, 1],
+                [1, 0, 0],
+                [1, 0, 1],
+                [0, 0, 1],
+                [0, 1, 0],  # top edges
+                [1, 1, 0],
+                [0, 1, 0],
+                [0, 1, 1],
+                [1, 1, 1],
+                [1, 1, 0],
+                [1, 1, 1],
+                [0, 1, 1],
+                [0, 0, 0],  # side edges
+                [0, 1, 0],
+                [1, 0, 0],
+                [1, 1, 0],
+                [0, 0, 1],
+                [0, 1, 1],
+                [1, 0, 1],
+                [1, 1, 1],
+            ],
+            dtype="f4",
+        )
+        positions -= 0.5
+        positions *= size
+
+        geometry = Geometry(positions=positions)
+        material = LineThinSegmentMaterial(color=(1, 0, 0, 1))
+
+        super().__init__(geometry, material)

--- a/pygfx/helpers/_box.py
+++ b/pygfx/helpers/_box.py
@@ -4,9 +4,14 @@ from .. import Geometry, Line, LineThinSegmentMaterial
 
 
 class BoxHelper(Line):
-    """An object visualizing a box."""
+    """A line box object. Commonly used to visualize bounding boxes."""
 
     def __init__(self, size=1.0):
+        """Construct a box line visual centered around the origin.
+
+        Parameters:
+            size (float): The length of the box' edges.
+        """
         self._size = size
 
         positions = np.array(
@@ -46,20 +51,26 @@ class BoxHelper(Line):
 
         super().__init__(geometry, material)
 
-    def set_object_world(self, object):
-        aabb = object.get_world_bounding_box()
-        self.set_aabb(aabb)
+    def set_transform_by_aabb(self, aabb):
+        """Set the position and scale attributes
+        based on a given bounding box.
 
-    def set_object_local(self, object):
-        if object.geometry:
-            aabb = object.geometry.bounding_box()
-        else:
-            aabb = None
-        self.set_aabb(aabb)
-
-    def set_aabb(self, aabb):
-        if aabb is None:
-            raise ValueError("Object has no geometry")
+        Parameters:
+            aabb (ndarray): The position and scale attributes
+                will be configured such that the helper
+                will match the given bounding box. The array
+                is expected to have shape (2, 3), where the
+                two vectors represent the minimum and maximum
+                coordinates of the axis-aligned bounding box.
+        """
+        aabb = np.asarray(aabb)
+        if aabb.shape != (2, 3):
+            raise ValueError(
+                "The given array does not appear to represent "
+                "an axis-aligned bounding box, ensure "
+                "the shape is (2, 3). Shape given: "
+                f"{aabb.shape}"
+            )
 
         diagonal = aabb[1] - aabb[0]
         center = aabb[0] + diagonal * 0.5
@@ -67,3 +78,51 @@ class BoxHelper(Line):
 
         self.position.set(*center)
         self.scale.set(*scale)
+
+    def set_transform_by_object(self, object, space="world"):
+        """Set the position and scale attributes
+        based on the bounding box of another object.
+
+        Parameters:
+            object (WorldObject): The position and scale attributes
+                will be configured such that the helper
+                will match the bounding box of the given object.
+            space (string, optional): If set to "world"
+                (the default) the world space bounding box will
+                be used as reference. If equal to "local", the
+                object's local space bounding box of its geometry
+                will be used instead.
+
+        :Examples:
+
+        World-space bounding box visualization:
+
+        .. code-block:: py
+
+            box = gfx.BoxHelper()
+            box.set_transform_by_object(mesh)
+            scene.add(box)
+
+        Local-space bounding box visualization:
+
+        .. code-block:: py
+
+            box = gfx.BoxHelper()
+            box.set_transform_by_object(mesh, space="local")
+            mesh.add(box)
+        """
+        aabb = None
+        if space not in {"world", "local"}:
+            raise ValueError('Space argument must be either "world"'
+                             f'or "local". Given value: {space}')
+        if space == "world":
+            aabb = object.get_world_bounding_box()
+        elif space == "local" and object.geometry is not None:
+            aabb = object.geometry.bounding_box()
+        if aabb is None:
+            raise ValueError(
+                "No bounding box could be determined "
+                "for the given object, it (and its "
+                "children) may not define any geometry"
+            )
+        self.set_transform_by_aabb(aabb)


### PR DESCRIPTION
Closes #187

* Add AxesHelper.set_colors
* Remove AxesHelper thickness kwarg and switch to thin lines
* Add BoxHelper
* Add BoxHelper.set_transform_by_object(object)
* Add BoxHelper.set_transform_by_aabb(aabb)
* Extend validate_helpers2 example
  ![image](https://user-images.githubusercontent.com/1882046/147550793-df2b13a1-0ec1-4760-831f-5826874cef50.png)
* Add object_bounding_box example
  ![image](https://user-images.githubusercontent.com/1882046/147552909-c5e63759-f64c-4eae-8708-18352d3bb466.png)

The two utility methods on BoxHelper allow you to configure the transform appropriately for world space or local space. See the example for usage.
