### PR TITLE
Improved colormaps support

### DIFF
--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1,3 +1,4 @@
+===============
 The pygfx guide
 ===============
 
@@ -157,6 +158,55 @@ Materials
 Each world object also has a material. This material object defines the
 appearance of the object. Examples can be its color, how it behaves under lighting,
 what render-mode is applied, etc. Multiple world objects may share a material.
+
+
+Colors
+------
+
+Colors in Pygfx can be specified in various ways, e.g.:
+
+.. code-block:: python
+
+    material.color = "red"
+    material.color = "#ff0000"
+    material.color = 1, 0, 0
+
+Most colors in Pygfx contain four components (including alpha), but can be specified
+with 1-4 components:
+
+* a scalar: a grayscale intensity (alpha 1).
+* two values: grayscale intensity plus alpha.
+* three values: red, green, and blue (i.e. rgb).
+* four values: rgb and alpha (i.e. rgba).
+
+
+Colors for the Mesh, Point, and Line
+====================================
+
+These objects can be made a uniform color using `material.color`. More
+sophisticated coloring is possible using colormapping and per-vertex
+colors.
+
+For Colormapping, the geometry must have a `.texcoords` attribute that
+specifies the per-vertex texture coordinates, and the material should
+have a `.map` attribute that is a texture in which the final color
+will be looked up. The texture can be 1D, 2D or 3D, and the number of columns
+in the `geometry.texcoords` should match. This allows for a wide variety of
+visualizations.
+
+Per-vertex colors can be specified as `geometry.colors`. They must be enabled
+by setting `material.vertex_colors` to `True`.
+
+The colors specified in `material.map` and in `geometry.colors` can have 1-4 values.
+
+
+Colors in Image and Volume
+==========================
+
+The values of the Image and Volume can be either directly interpreted as a color
+or can be mapped through a colormap set at `material.map`. If a colormap is used,
+it's dimension should match the number of channels in the data. Again,
+both direct and colormapped colors can be 1-4 values.
 
 
 Using Pygfx in Jupyter

--- a/examples/colormap_channels.py
+++ b/examples/colormap_channels.py
@@ -10,6 +10,7 @@ import pygfx as gfx
 canvas = WgpuCanvas(size=(900, 400))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
+scene.add(gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1))))
 
 geometry = gfx.torus_knot_geometry(1, 0.3, 128, 32)
 geometry.texcoords = gfx.Buffer(geometry.texcoords.data[:, 0])

--- a/examples/colormap_channels.py
+++ b/examples/colormap_channels.py
@@ -19,7 +19,7 @@ camera = gfx.OrthographicCamera(16, 3)
 
 
 def create_object(tex, xpos):
-    material = gfx.MeshPhongMaterial(map=tex, clim=(-0.05, 1))
+    material = gfx.MeshPhongMaterial(map=tex)
     obj = gfx.Mesh(geometry, material)
     obj.position.x = xpos
     scene.add(obj)

--- a/examples/colormap_image.py
+++ b/examples/colormap_image.py
@@ -1,0 +1,94 @@
+"""
+Example demonstrating different colormap dimensions on an image.
+"""
+
+import numpy as np
+import imageio
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+
+
+canvas = WgpuCanvas(size=(900, 400))
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+camera = gfx.OrthographicCamera(1800, 550)
+camera.position.y = 256
+camera.scale.y = -1
+camera.position.x = 1736 / 2
+
+
+# === 1D colormap
+#
+# For the image data we use the green channel of a common image. For
+# the colormap data we use a colormap that goes from red to green to
+# blue (1D). A classic image colormap use-case.
+
+img_data1 = imageio.imread("imageio:astronaut.png")[:, :, 1]
+
+colormap_data1 = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], np.float32)
+
+colormap1 = gfx.Texture(colormap_data1, dim=1).get_view(filter="linear")
+image1 = gfx.Image(
+    gfx.Geometry(grid=gfx.Texture(img_data1, dim=2)),
+    gfx.ImageBasicMaterial(clim=(0, 255), map=colormap1),
+)
+
+image1.position.x = 0
+scene.add(image1)
+
+
+# === 2D colormap
+#
+# For the image data we use a mesh with two channels, which represent
+# the x and y coordinate in the colormap. The mesh simply runs from 0
+# to 1, but we add a little swirl to it. For the colormap data we use
+# the astronaut image again (2D). Note that while that image was
+# previously used as image data, it is now used as a colormap.
+
+xx, yy = np.meshgrid(np.linspace(0, 1, 512), np.linspace(0, 1, 512))
+xx += np.sin(yy * 10) * 0.1
+img_data2 = np.stack([xx, yy], 2).astype(np.float32)
+colormap_data2 = img_data1
+
+colormap2 = gfx.Texture(colormap_data2, dim=2).get_view(filter="linear")
+image2 = gfx.Image(
+    gfx.Geometry(grid=gfx.Texture(img_data2, dim=2)),
+    gfx.ImageBasicMaterial(clim=(0, 1), map=colormap2),
+)
+
+image2.position.x = 612
+scene.add(image2)
+
+
+# === 3D colormap
+#
+# For the image data we use a mesh with 3 channels that represent
+# positions in 3D, forming a cylinder. For the colormap we used a CT
+# volume (3D). In effect we get an image that shows a rolled-out
+# cylindrical slice through the volume.
+
+rr, zz = np.meshgrid(np.linspace(0, 2 * np.pi, 512), np.linspace(0, 1, 512))
+xx = np.sin(rr) * 0.4 + 0.5
+yy = np.cos(rr) * 0.4 + 0.5
+img_data3 = np.stack([xx, yy, zz], 2).astype(np.float32)
+# img_data3 = np.stack([xx, yy, zz], 2).astype(np.float32)
+colormap_data3 = imageio.volread("imageio:stent.npz").astype(np.float32) / 1500
+
+colormap3 = gfx.Texture(colormap_data3, dim=3).get_view(filter="linear")
+image3 = gfx.Image(
+    gfx.Geometry(grid=gfx.Texture(img_data3, dim=2)),
+    gfx.ImageBasicMaterial(clim=(0, 1), map=colormap3),
+)
+
+image3.position.x = 1224
+scene.add(image3)
+
+
+def animate():
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    run()

--- a/examples/colormap_mesh.py
+++ b/examples/colormap_mesh.py
@@ -26,13 +26,13 @@ def get_geometry(**kwargs):
     return geo
 
 
-def WobjectClass(geometry, material):
+def WobjectClass(geometry, material):  # noqa
     return gfx.Mesh(geometry, material)
     # return gfx.Points(geometry, material)
     # return gfx.Line(geometry, material)
 
 
-def MaterialClass(**kwargs):
+def MaterialClass(**kwargs):  # noqa
     return gfx.MeshPhongMaterial(**kwargs)
     # return gfx.PointsMaterial(size=10, **kwargs)
     # return gfx.LineArrowMaterial(thickness=5, **kwargs)

--- a/examples/colormap_mesh.py
+++ b/examples/colormap_mesh.py
@@ -20,7 +20,7 @@ def get_geometry():
 def create_object(texcoords, tex, xpos):
     geometry = get_geometry()
     geometry.texcoords = gfx.Buffer(texcoords)
-    material = gfx.MeshPhongMaterial(map=tex, clim=(-0.05, 1))
+    material = gfx.MeshPhongMaterial(map=tex)
     obj = gfx.Mesh(geometry, material)
     obj.position.x = xpos
     scene.add(obj)

--- a/examples/colormap_mesh.py
+++ b/examples/colormap_mesh.py
@@ -1,5 +1,9 @@
 """
-Example demonstrating different colormap dimensions on a mesh.
+Example demonstrating different colormap dimensions on a mesh, and
+per-vertex colors as a bonus.
+
+The default visiualization is a mesh, but by (un)commenting a few lines,
+this can also be applied for points and lines.
 """
 
 import numpy as np
@@ -13,17 +17,25 @@ renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
 
-def get_geometry():
-    return gfx.cylinder_geometry(height=2, radial_segments=32, open_ended=True)
+def get_geometry(**kwargs):
+    geo = gfx.cylinder_geometry(
+        height=2, radial_segments=32, height_segments=4, open_ended=False
+    )
+    for key, val in kwargs.items():
+        setattr(geo, key, val)
+    return geo
 
 
-def create_object(texcoords, tex, xpos):
-    geometry = get_geometry()
-    geometry.texcoords = gfx.Buffer(texcoords)
-    material = gfx.MeshPhongMaterial(map=tex)
-    obj = gfx.Mesh(geometry, material)
-    obj.position.x = xpos
-    scene.add(obj)
+def WobjectClass(geometry, material):
+    return gfx.Mesh(geometry, material)
+    # return gfx.Points(geometry, material)
+    # return gfx.Line(geometry, material)
+
+
+def MaterialClass(**kwargs):
+    return gfx.MeshPhongMaterial(**kwargs)
+    # return gfx.PointsMaterial(size=10, **kwargs)
+    # return gfx.LineArrowMaterial(thickness=5, **kwargs)
 
 
 geometry = get_geometry()
@@ -42,7 +54,13 @@ texcoords1 = geometry.texcoords.data[:, 1].copy()
 cmap1 = np.array([(1, 1, 0), (0, 1, 1)], np.float32)
 tex1 = gfx.Texture(cmap1, dim=1).get_view(filter="linear")
 
-create_object(texcoords1, tex1, -6)
+ob1 = WobjectClass(
+    get_geometry(texcoords=gfx.Buffer(texcoords1)),
+    MaterialClass(map=tex1),
+)
+scene.add(ob1)
+ob1.position.x = -6
+
 
 # === 2D colormap
 #
@@ -54,7 +72,12 @@ texcoords2 = geometry.texcoords.data.copy()
 cmap2 = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
 tex2 = gfx.Texture(cmap2, dim=2).get_view(address_mode="repeat")
 
-create_object(texcoords2, tex2, -2)
+ob2 = WobjectClass(
+    get_geometry(texcoords=gfx.Buffer(texcoords2)),
+    MaterialClass(map=tex2),
+)
+scene.add(ob2)
+ob2.position.x = -2
 
 
 # === 3D colormap
@@ -70,33 +93,28 @@ texcoords3 = geometry.positions.data * 0.4 + 0.5
 cmap3 = imageio.volread("imageio:stent.npz").astype(np.float32) / 2000
 tex3 = gfx.Texture(cmap3, dim=3).get_view()
 
-create_object(texcoords3, tex3, +2)
+ob3 = WobjectClass(
+    get_geometry(texcoords=gfx.Buffer(texcoords3)),
+    MaterialClass(map=tex3),
+)
+scene.add(ob3)
+ob3.position.x = +2
 
 
 # === Per vertex coloring
 #
-# To specify a color for each vertex, we also use 3D texture coordinates.
-# In this case we use the normals (a normal in the x direction would be red).
-# To make this work, we use a 3D colormap that represents an RGB color cube.
+# To specify a color for each vertex, provide a geometry.colors buffer and
+# enable the material.vertex_colors flag. We use the normals as input.
 
-texcoords4 = geometry.normals.data * 0.4 + 0.5
+colors = geometry.normals.data * 0.4 + 0.5
+colors = colors[:, :3]  # Colors can be Nx1, Nx2, Nx3, Nx4
 
-cmap4 = np.array(
-    [
-        [
-            [(0, 0, 0), (1, 0, 0)],
-            [(0, 1, 0), (1, 1, 0)],
-        ],
-        [
-            [(0, 0, 1), (1, 0, 1)],
-            [(0, 1, 1), (1, 1, 1)],
-        ],
-    ],
-    np.float32,
+ob4 = WobjectClass(
+    get_geometry(colors=gfx.Buffer(colors)),
+    MaterialClass(vertex_colors=True),
 )
-tex4 = gfx.Texture(cmap4, dim=3).get_view(filter="linear")
-
-create_object(texcoords4, tex4, +6)
+scene.add(ob4)
+ob4.position.x = +6
 
 
 def animate():

--- a/examples/geometry_image.py
+++ b/examples/geometry_image.py
@@ -1,0 +1,29 @@
+"""
+Show an image.
+"""
+
+import imageio
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+
+
+canvas = WgpuCanvas()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+im = imageio.imread("imageio:astronaut.png")[:, :, 1]
+
+image = gfx.Image(
+    gfx.Geometry(grid=gfx.Texture(im, dim=2)),
+    gfx.ImageBasicMaterial(clim=(0, 255)),
+)
+scene.add(image)
+
+camera = gfx.OrthographicCamera(512, 512)
+camera.position.set(256, 256, 0)
+camera.scale.y = -1
+
+
+if __name__ == "__main__":
+    canvas.request_draw(lambda: renderer.render(scene, camera))
+    run()

--- a/examples/geometry_torus_knot.py
+++ b/examples/geometry_torus_knot.py
@@ -16,7 +16,7 @@ tex = gfx.Texture(im, dim=2).get_view(filter="linear", address_mode="repeat")
 
 geometry = gfx.torus_knot_geometry(1, 0.3, 128, 32)
 geometry.texcoords.data[:, 0] *= 10  # stretch the texture
-material = gfx.MeshPhongMaterial(map=tex, clim=(30, 240))
+material = gfx.MeshPhongMaterial(map=tex)
 obj = gfx.Mesh(geometry, material)
 scene.add(obj)
 

--- a/examples/multi_slice1.py
+++ b/examples/multi_slice1.py
@@ -21,10 +21,10 @@ scene.add(background)
 
 scene.add(gfx.AxesHelper(length=50))
 
-vol = imageio.volread("imageio:stent.npz")
+vol = imageio.volread("imageio:stent.npz").astype("float32") / 2000
 tex = gfx.Texture(vol, dim=3)
 view = tex.get_view(filter="linear")
-material = gfx.MeshBasicMaterial(map=view, clim=(0, 2000))
+material = gfx.MeshBasicMaterial(map=view)
 
 # TODO: also add a mesh slice for each plane
 

--- a/examples/multi_slice2.py
+++ b/examples/multi_slice2.py
@@ -23,7 +23,7 @@ scene.add(background)
 
 scene.add(gfx.AxesHelper(length=50))
 
-vol = imageio.volread("imageio:stent.npz")
+vol = imageio.volread("imageio:stent.npz").astype("float32")
 tex = gfx.Texture(vol, dim=3)
 
 surface = marching_cubes(vol[0:], 200)

--- a/examples/validate_image1.py
+++ b/examples/validate_image1.py
@@ -18,21 +18,24 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = np.array(
-    [
-        [0, 1, 1, 1],
-        [1, 1, 1, 1],
-        [1, 1, 1, 1],
-        [1, 1, 1, 2],
-    ],
-    np.float32,
+im = (
+    np.array(
+        [
+            [0, 1, 1, 1],
+            [1, 1, 1, 1],
+            [1, 1, 1, 1],
+            [1, 1, 1, 2],
+        ],
+        np.float32,
+    )
+    / 2.0
 )
 
 tex = gfx.Texture(im, dim=2)
 
 plane = gfx.Mesh(
     gfx.plane_geometry(4, 4),
-    gfx.MeshBasicMaterial(map=tex.get_view(filter="nearest"), clim=(0, 2)),
+    gfx.MeshBasicMaterial(map=tex.get_view(filter="nearest")),
 )
 plane.position = gfx.linalg.Vector3(2, 2)  # put corner at 0, 0
 scene.add(plane)

--- a/examples/validate_image_colormap.py
+++ b/examples/validate_image_colormap.py
@@ -4,6 +4,7 @@ Show an image with a simple colormap.
 * You should see a square image with 3 equally sized vertical bands.
 * The bands should be red, green, and blue.
 """
+# test_example = true
 
 import numpy as np
 from wgpu.gui.auto import WgpuCanvas, run

--- a/examples/validate_image_colormap.py
+++ b/examples/validate_image_colormap.py
@@ -29,7 +29,7 @@ scene.add(image)
 camera = gfx.OrthographicCamera(99, 99)
 camera.position.set(50, 50, 0)
 
+canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
-    canvas.request_draw(lambda: renderer.render(scene, camera))
     run()

--- a/examples/validate_image_colormap.py
+++ b/examples/validate_image_colormap.py
@@ -1,0 +1,34 @@
+"""
+Show an image with a simple colormap.
+
+* You should see a square image with 3 equally sized vertical bands.
+* The bands should be red, green, and blue.
+"""
+
+import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+
+
+canvas = WgpuCanvas()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+im = np.repeat(np.linspace(0, 1, 99).reshape(1, -1), 99, 0).astype(np.float32)
+
+colormap_data = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]], np.float32)
+colormap = gfx.Texture(colormap_data, dim=1).get_view(filter="nearest")
+
+image = gfx.Image(
+    gfx.Geometry(grid=gfx.Texture(im, dim=2)),
+    gfx.ImageBasicMaterial(clim=(0, 1), map=colormap),
+)
+scene.add(image)
+
+camera = gfx.OrthographicCamera(99, 99)
+camera.position.set(50, 50, 0)
+
+
+if __name__ == "__main__":
+    canvas.request_draw(lambda: renderer.render(scene, camera))
+    run()

--- a/examples/volume_slice1.py
+++ b/examples/volume_slice1.py
@@ -12,7 +12,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-vol = imageio.volread("imageio:stent.npz")
+vol = imageio.volread("imageio:stent.npz").astype("float32") / 2000
 nslices = vol.shape[0]
 index = nslices // 2
 im = vol[index].copy()
@@ -20,7 +20,7 @@ im = vol[index].copy()
 tex = gfx.Texture(im, dim=2)
 
 geometry = gfx.plane_geometry(200, 200, 12, 12)
-material = gfx.MeshBasicMaterial(map=tex.get_view(filter="linear"), clim=(0, 2000))
+material = gfx.MeshBasicMaterial(map=tex.get_view(filter="linear"))
 plane = gfx.Mesh(geometry, material)
 scene.add(plane)
 

--- a/examples/volume_slice2.py
+++ b/examples/volume_slice2.py
@@ -12,7 +12,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-vol = imageio.volread("imageio:stent.npz")
+vol = imageio.volread("imageio:stent.npz").astype("float32") / 2000
 nslices = vol.shape[0]
 index = nslices // 2
 
@@ -21,7 +21,7 @@ tex = gfx.Texture(vol, dim=2, size=tex_size)
 view = tex.get_view(filter="linear", view_dim="2d", layer_range=range(index, index + 1))
 
 geometry = gfx.plane_geometry(200, 200, 12, 12)
-material = gfx.MeshBasicMaterial(map=view, clim=(0, 2000))
+material = gfx.MeshBasicMaterial(map=view)
 plane = gfx.Mesh(geometry, material)
 scene.add(plane)
 

--- a/examples/volume_slice3.py
+++ b/examples/volume_slice3.py
@@ -13,7 +13,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-vol = imageio.volread("imageio:stent.npz")
+vol = imageio.volread("imageio:stent.npz").astype("float32") / 2000
 nslices = vol.shape[0]
 index = nslices // 2
 
@@ -24,7 +24,7 @@ geometry = gfx.plane_geometry(200, 200, 1, 1)
 texcoords = np.hstack([geometry.texcoords.data, np.ones((4, 1), np.float32) * 0.5])
 geometry.texcoords = gfx.Buffer(texcoords)
 
-material = gfx.MeshBasicMaterial(map=view, clim=(0, 2000))
+material = gfx.MeshBasicMaterial(map=view)
 plane = gfx.Mesh(geometry, material)
 scene.add(plane)
 

--- a/examples/volume_slice4.py
+++ b/examples/volume_slice4.py
@@ -12,7 +12,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-voldata = imageio.volread("imageio:stent.npz")
+voldata = imageio.volread("imageio:stent.npz").astype("float32")
 nslices = voldata.shape[0]
 index = nslices // 2
 

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -44,8 +44,8 @@ class PerspectiveCamera(Camera):
         # Get the reference width / height
         size = 2 * self.near * tan(pi / 180 * 0.5 * self.fov) / self.zoom
         # Pre-apply the reference aspect ratio
-        width = size * self.aspect ** 0.5
-        height = size / self.aspect ** 0.5
+        width = size * self.aspect**0.5
+        height = size / self.aspect**0.5
         # Increase eihter the width or height, depending on the view size
         if self.aspect < self._view_aspect:
             width *= self._view_aspect / self.aspect

--- a/pygfx/geometries/_base.py
+++ b/pygfx/geometries/_base.py
@@ -29,7 +29,8 @@ class Geometry(ResourceContainer):
     * ``normals``: Nx3 normal vectors. These may or may not be unit.
     * ``texcoords``: Texture coordinates used to lookup the color for a vertex.
       Can be Nx1, Nx2 or Nx3, corresponding to a 1D, 2D and 3D texture map.
-    * ``colors``: Nx4 per-vertex colors (rgba).
+    * ``colors``: Per-vertex) colors. Must be NxM, with M 1-4 for gray,
+      gray+alpha, rgb, rgba, respectively.
     * ``sizes``: Scalar size per-vertex.
     * ``grid``: A 2D or 3D Texture/TextureView that contains a regular grid of
       data. I.e. for images and volumes.

--- a/pygfx/geometries/_base.py
+++ b/pygfx/geometries/_base.py
@@ -29,7 +29,7 @@ class Geometry(ResourceContainer):
     * ``normals``: Nx3 normal vectors. These may or may not be unit.
     * ``texcoords``: Texture coordinates used to lookup the color for a vertex.
       Can be Nx1, Nx2 or Nx3, corresponding to a 1D, 2D and 3D texture map.
-    * ``colors``: Per-vertex) colors. Must be NxM, with M 1-4 for gray,
+    * ``colors``: Per-vertex colors. Must be NxM, with M 1-4 for gray,
       gray+alpha, rgb, rgba, respectively.
     * ``sizes``: Scalar size per-vertex.
     * ``grid``: A 2D or 3D Texture/TextureView that contains a regular grid of

--- a/pygfx/geometries/_polyhedron.py
+++ b/pygfx/geometries/_polyhedron.py
@@ -288,7 +288,7 @@ def polyhedron_geometry(
         grid /= np.linalg.norm(grid, axis=-1)[..., None]
 
     # create an index array for a single face's plane of quads
-    indices = np.arange(n ** 2, dtype=np.uint32).reshape((n, n))
+    indices = np.arange(n**2, dtype=np.uint32).reshape((n, n))
     index = np.empty((n - 1, n - 1, 2, 3), dtype=np.uint32)
     index[:, :, 0, 0] = indices[np.arange(n - 1)[:, None], np.arange(n - 1)[None, :]]
     # the remainder of the indices for every panel are relative

--- a/pygfx/linalg/quaternion.py
+++ b/pygfx/linalg/quaternion.py
@@ -265,7 +265,7 @@ class Quaternion:
             self.normalize()
             return self
 
-        sin_half_theta = sqr_sin_half_theta ** 0.5
+        sin_half_theta = sqr_sin_half_theta**0.5
         half_theta = atan2(sin_half_theta, cos_half_theta)
         ratio_a = sin((1 - t) * half_theta) / sin_half_theta
         ratio_b = sin(t * half_theta) / sin_half_theta

--- a/pygfx/linalg/spherical.py
+++ b/pygfx/linalg/spherical.py
@@ -16,7 +16,7 @@ class Spherical:
         return self.set_from_cartesian_coords(v.x, v.y, v.z)
 
     def set_from_cartesian_coords(self, x: float, y: float, z: float) -> "Spherical":
-        self.radius = math.sqrt(x ** 2 + y ** 2 + z ** 2)
+        self.radius = math.sqrt(x**2 + y**2 + z**2)
         if self.radius == 0:
             self.theta, self.phi = 0, 0
         else:

--- a/pygfx/linalg/vector3.py
+++ b/pygfx/linalg/vector3.py
@@ -279,7 +279,7 @@ class Vector3:
         return self.x * v.x + self.y * v.y + self.z * v.z
 
     def length_sq(self) -> float:
-        return self.x ** 2 + self.y ** 2 + self.z ** 2
+        return self.x**2 + self.y**2 + self.z**2
 
     def length(self) -> float:
         return self.length_sq() ** 0.5

--- a/pygfx/materials/_image.py
+++ b/pygfx/materials/_image.py
@@ -16,7 +16,7 @@ class ImageBasicMaterial(Material):
     @property
     def map(self):
         """The colormap to turn the image values into its final color.
-        If not given or None, the image values directly represents the color.
+        If not given or None, the values themselves represents the color.
         The dimensionality of the map can be 1D, 2D or 3D, but should match the
         number of channels in the image.
         """

--- a/pygfx/materials/_image.py
+++ b/pygfx/materials/_image.py
@@ -1,3 +1,4 @@
+from ..resources import TextureView
 from ._base import Material
 
 
@@ -14,26 +15,30 @@ class ImageBasicMaterial(Material):
 
     @property
     def map(self):
-        """The colormap for the image."""
-        # todo: not implemented in the renderer
+        """The colormap to turn the image values into its final color.
+        If not given or None, the image values directly represents the color.
+        The dimensionality of the map can be 1D, 2D or 3D, but should match the
+        number of channels in the image.
+        """
         return self._map
 
     @map.setter
     def map(self, map):
+        assert map is None or isinstance(map, TextureView)
         self._map = map
 
     @property
     def clim(self):
-        """The contrast limits to scale the data values with before the colormap is applied."""
-        return self.uniform_buffer.data["clim"]
+        """The contrast limits to scale the data values with. Default (0, 1)."""
+        v1, v2 = self.uniform_buffer.data["clim"]
+        return float(v1), float(v2)
 
     @clim.setter
     def clim(self, clim):
         # Check and store given clim
-        if clim is not None:
-            clim = float(clim[0]), float(clim[1])
-        else:
-            clim = 0.0, 1.0
+        if clim is None:
+            clim = 0, 1
+        clim = float(clim[0]), float(clim[1])
         # Update uniform data
         self.uniform_buffer.data["clim"] = clim
         self.uniform_buffer.update_range(0, 1)

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -99,7 +99,10 @@ class MeshBasicMaterial(Material):
 
     @property
     def map(self):
-        """The texture map specifying the color for each texture coordinate."""
+        """The texture map specifying the color for each texture coordinate.
+        The dimensionality of the map can be 1D, 2D or 3D, but should match the
+        number of columns in the geometry's texcoords.
+        """
         return self._map
 
     @map.setter

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -17,6 +17,7 @@ class MeshBasicMaterial(Material):
     def __init__(
         self,
         color=(1, 1, 1, 1),
+        vertex_colors=False,
         map=None,
         wireframe=False,
         wireframe_thickness=1,
@@ -25,8 +26,9 @@ class MeshBasicMaterial(Material):
     ):
         super().__init__(**kwargs)
 
-        self.map = map
         self.color = color
+        self._vertex_colors = bool(vertex_colors)
+        self.map = map
         self.wireframe = wireframe
         self.wireframe_thickness = wireframe_thickness
         self.side = side
@@ -59,6 +61,18 @@ class MeshBasicMaterial(Material):
             self._bump_rev()  # rebuild pipeline if this becomes opaque/transparent
         self.uniform_buffer.data["color"] = color
         self.uniform_buffer.update_range(0, 1)
+
+    @property
+    def vertex_colors(self):
+        """Whether to use the vertex colors provided in the geometry."""
+        return self._vertex_colors
+
+    @vertex_colors.setter
+    def vertex_colors(self, value):
+        value = bool(value)
+        if value != self._vertex_colors:
+            self._vertex_colors = value
+            self._bump_rev()
 
     @property
     def map(self):

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -1,4 +1,5 @@
 from ._base import Material
+from ..resources import TextureView
 from ..utils import unpack_bitfield, Color
 
 
@@ -18,15 +19,16 @@ class PointsMaterial(Material):
         size=1,
         vertex_colors=False,
         vertex_sizes=False,
+        map=None,
         **kwargs
     ):
         super().__init__(**kwargs)
 
-        self._map = None
         self.color = color
+        self._vertex_colors = bool(vertex_colors)
+        self.map = map
         self.size = size
-        self._vertex_colors = vertex_colors
-        self._vertex_sizes = vertex_sizes
+        self._vertex_sizes = bool(vertex_sizes)
 
     def _wgpu_get_pick_info(self, pick_value):
         # This should match with the shader
@@ -56,6 +58,7 @@ class PointsMaterial(Material):
 
     @vertex_colors.setter
     def vertex_colors(self, value):
+        value = bool(value)
         if value != self._vertex_colors:
             self._vertex_colors = value
             self._bump_rev()
@@ -63,7 +66,7 @@ class PointsMaterial(Material):
     @property
     def size(self):
         """The size (diameter) of the points, in logical pixels."""
-        return self.uniform_buffer.data["size"]
+        return float(self.uniform_buffer.data["size"])
 
     @size.setter
     def size(self, size):
@@ -77,19 +80,24 @@ class PointsMaterial(Material):
 
     @vertex_sizes.setter
     def vertex_sizes(self, value):
+        value = bool(value)
         if value != self._vertex_sizes:
             self._vertex_sizes = value
             self._bump_rev()
 
-    # @property
-    # def map(self):
-    #     """ The 1D texture map specifying the color for each point.
-    #     """
-    #     return self._map
-    #
-    # @map.setter
-    # def map(self, map):
-    #     self._map = map
+    @property
+    def map(self):
+        """The texture map specifying the color for each texture coordinate.
+        The dimensionality of the map can be 1D, 2D or 3D, but should match the
+        number of columns in the geometry's texcoords.
+        """
+        return self._map
+
+    @map.setter
+    def map(self, map):
+        assert map is None or isinstance(map, TextureView)
+        self._map = map
+
     # todo: sizeAttenuation
 
 

--- a/pygfx/materials/_volume.py
+++ b/pygfx/materials/_volume.py
@@ -1,3 +1,4 @@
+from ..resources import TextureView
 from ._base import Material
 
 
@@ -15,26 +16,30 @@ class VolumeBasicMaterial(Material):
 
     @property
     def map(self):
-        """The colormap for the volume."""
-        # todo: not implemented in the renderer
+        """The colormap to turn the volume values into its final color.
+        If not given or None, the values themselves represents the color.
+        The dimensionality of the map can be 1D, 2D or 3D, but should match the
+        number of channels in the volume.
+        """
         return self._map
 
     @map.setter
     def map(self, map):
+        assert map is None or isinstance(map, TextureView)
         self._map = map
 
     @property
     def clim(self):
-        """The contrast limits to scale the data values with before the colormap is applied."""
-        return self.uniform_buffer.data["clim"]
+        """The contrast limits to scale the data values with. Default (0, 1)."""
+        v1, v2 = self.uniform_buffer.data["clim"]
+        return float(v1), float(v2)
 
     @clim.setter
     def clim(self, clim):
         # Check and store given clim
-        if clim is not None:
-            clim = float(clim[0]), float(clim[1])
-        else:
-            clim = 0.0, 1.0
+        if clim is None:
+            clim = 0, 1
+        clim = float(clim[0]), float(clim[1])
         # Update uniform data
         self.uniform_buffer.data["clim"] = clim
         self.uniform_buffer.update_range(0, 1)

--- a/pygfx/renderers/wgpu/imagerender.py
+++ b/pygfx/renderers/wgpu/imagerender.py
@@ -46,24 +46,48 @@ class BaseImageShader(WorldObjectShader):
         }
 
         fn sample(texcoord: vec2<f32>, sizef: vec2<f32>) -> vec4<f32> {
-            var color_value: vec4<f32>;
 
-            $$ if texture_format == 'f32'
-                color_value = textureSample(r_tex, r_sampler, texcoord.xy);
+            // Sample the color, always produces a vec4
+            $$ if img_format == 'f32'
+                let value_rgba = textureSample(r_tex, r_sampler, texcoord.xy);
             $$ else
                 let texcoords_u = vec2<i32>(texcoord.xy * sizef.xy);
-                color_value = vec4<f32>(textureLoad(r_tex, texcoords_u, 0));
+                let value_rgba = vec4<f32>(textureLoad(r_tex, texcoords_u, 0));
             $$ endif
 
-            $$ if climcorrection
-                color_value = vec4<f32>(color_value.rgb {{ climcorrection }}, color_value.a);
+            // Make it the correct dimension
+            $$ if img_nchannels == 1
+                let value_raw = value_rgba.r;
+            $$ elif img_nchannels == 2
+                let value_raw = value_rgba.rg;
+            $$ elif img_nchannels == 3
+                let value_raw = value_rgba.rgb;
+            $$ else
+                let value_raw = value_rgba.rgba;
             $$ endif
-            $$ if texture_nchannels == 1
-                color_value = vec4<f32>(color_value.rrr, 1.0);
-            $$ elif texture_nchannels == 2
-                color_value = vec4<f32>(color_value.rrr, color_value.g);
+
+            // Apply contrast limits
+            let value_cor = value_raw {{ climcorrection }};
+            let value_clim = (value_cor - u_material.clim[0]) / (u_material.clim[1] - u_material.clim[0]);
+
+            // Apply colormap or compose final color
+            $$ if colormap_dim
+                // In the render function we make sure that colormap_dim matches img_nchannels
+                let color = sample_colormap(value_clim);
+            $$ else
+                $$ if img_nchannels == 1
+                    let r = value_clim;
+                    let color = vec4<f32>(r, r, r, 1.0);
+                $$ elif img_nchannels == 2
+                    let color = vec4<f32>(value_clim.rrr, value_raw.g);
+                $$ elif img_nchannels == 3
+                    let color = vec4<f32>(value_clim.rgb, 1.0);
+                $$ else
+                    let color = vec4<f32>(value_clim.rgb, value_raw.a);
+                $$ endif
             $$ endif
-            return color_value;
+
+            return color;
         }
     """
 
@@ -75,7 +99,7 @@ def image_renderer(render_info):
     wobject = render_info.wobject
     geometry = wobject.geometry
     material = wobject.material  # noqa
-    shader = ImageShader(render_info, climcorrection=False)
+    shader = ImageShader(render_info, climcorrection="")
 
     bindings = {}
 
@@ -101,17 +125,17 @@ def image_renderer(render_info):
         # Sampling type
         fmt = to_texture_format(geometry.grid.format)
         if "norm" in fmt or "float" in fmt:
-            shader["texture_format"] = "f32"
+            shader["img_format"] = "f32"
             if "unorm" in fmt:
                 shader["climcorrection"] = " * 255.0"
             elif "snorm" in fmt:
                 shader["climcorrection"] = " * 255.0 - 128.0"
         elif "uint" in fmt:
-            shader["texture_format"] = "u32"
+            shader["img_format"] = "u32"
         else:
-            shader["texture_format"] = "i32"
+            shader["img_format"] = "i32"
         # Channels
-        shader["texture_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
+        shader["img_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
 
     bindings[3] = Binding("r_sampler", "sampler/filtering", view, "FRAGMENT")
     bindings[4] = Binding("r_tex", "texture/auto", view, vertex_and_fragment)
@@ -122,7 +146,7 @@ def image_renderer(render_info):
 
     # Get in what passes this needs rendering
     suggested_render_mask = 3
-    if material.opacity >= 1 and shader["texture_nchannels"] in (1, 3):
+    if material.opacity >= 1 and shader["img_nchannels"] in (1, 3):
         suggested_render_mask = 1
     elif material.opacity < 1:
         suggested_render_mask = 2
@@ -187,7 +211,7 @@ class ImageShader(BaseImageShader):
         fn fs_main(varyings: Varyings) -> FragmentOutput {
             let sizef = vec2<f32>(textureDimensions(r_tex));
             let color_value = sample(varyings.texcoord.xy, sizef);
-            let albeido = (color_value.rgb - u_material.clim[0]) / (u_material.clim[1] - u_material.clim[0]);
+            let albeido = color_value.rgb;
 
             let final_color = vec4<f32>(albeido, color_value.a * u_material.opacity);
 

--- a/pygfx/renderers/wgpu/imagerender.py
+++ b/pygfx/renderers/wgpu/imagerender.py
@@ -11,6 +11,37 @@ from ...resources import Texture, TextureView
 vertex_and_fragment = wgpu.ShaderStage.VERTEX | wgpu.ShaderStage.FRAGMENT
 
 
+def handle_colormap(geometry, material, shader):
+    if isinstance(material.map, Texture):
+        raise TypeError("material.map is a Texture, but must be a TextureView")
+    elif not isinstance(material.map, TextureView):
+        raise TypeError("material.map must be a TextureView")
+    # Dimensionality
+    shader["colormap_dim"] = view_dim = material.map.view_dim
+    if material.map.view_dim not in ("1d", "2d", "3d"):
+        raise ValueError("Unexpected colormap texture dimension")
+    # Texture dim matches image channels
+    if int(view_dim[0]) != shader["img_nchannels"]:
+        raise ValueError(
+            f"Image channels {shader['img_nchannels']} does not match material.map {view_dim}"
+        )
+    # Sampling type
+    fmt = to_texture_format(material.map.format)
+    if "norm" in fmt or "float" in fmt:
+        shader["colormap_format"] = "f32"
+    elif "uint" in fmt:
+        shader["colormap_format"] = "u32"
+    else:
+        shader["colormap_format"] = "i32"
+    # Channels
+    shader["colormap_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
+    # Return bindinhs
+    return [
+        Binding("s_colormap", "sampler/filtering", material.map, "FRAGMENT"),
+        Binding("t_colormap", "texture/auto", material.map, "FRAGMENT"),
+    ]
+
+
 @register_wgpu_render_function(Image, ImageBasicMaterial)
 def image_renderer(render_info):
     """Render function capable of rendering images."""
@@ -20,11 +51,11 @@ def image_renderer(render_info):
     material = wobject.material  # noqa
     shader = ImageShader(render_info, climcorrection="")
 
-    bindings = {}
-
-    bindings[0] = Binding("u_stdinfo", "buffer/uniform", render_info.stdinfo_uniform)
-    bindings[1] = Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer)
-    bindings[2] = Binding("u_material", "buffer/uniform", material.uniform_buffer)
+    bindings = [
+        Binding("u_stdinfo", "buffer/uniform", render_info.stdinfo_uniform),
+        Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer),
+        Binding("u_material", "buffer/uniform", material.uniform_buffer),
+    ]
 
     topology = wgpu.PrimitiveTopology.triangle_strip
     n = 4
@@ -56,41 +87,15 @@ def image_renderer(render_info):
         # Channels
         shader["img_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
 
-    bindings[3] = Binding("s_img", "sampler/filtering", view, "FRAGMENT")
-    bindings[4] = Binding("t_img", "texture/auto", view, vertex_and_fragment)
+    bindings.append(Binding("s_img", "sampler/filtering", view, "FRAGMENT"))
+    bindings.append(Binding("t_img", "texture/auto", view, vertex_and_fragment))
 
     # If a colormap is applied ...
     if material.map is not None:
-        if isinstance(material.map, Texture):
-            raise TypeError("material.map is a Texture, but must be a TextureView")
-        elif not isinstance(material.map, TextureView):
-            raise TypeError("material.map must be a TextureView")
-        bindings[5] = Binding(
-            "s_colormap", "sampler/filtering", material.map, "FRAGMENT"
-        )
-        bindings[6] = Binding("t_colormap", "texture/auto", material.map, "FRAGMENT")
-        # Dimensionality
-        shader["colormap_dim"] = view_dim = material.map.view_dim
-        if material.map.view_dim not in ("1d", "2d", "3d"):
-            raise ValueError("Unexpected colormap texture dimension")
-        # Texture dim matches image channels
-        if int(view_dim[0]) != shader["img_nchannels"]:
-            raise ValueError(
-                f"Image channels {shader['img_nchannels']} does not match material.map {view_dim}"
-            )
-        # Sampling type
-        fmt = to_texture_format(material.map.format)
-        if "norm" in fmt or "float" in fmt:
-            shader["colormap_format"] = "f32"
-        elif "uint" in fmt:
-            shader["colormap_format"] = "u32"
-        else:
-            shader["colormap_format"] = "i32"
-        # Channels
-        shader["colormap_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
+        bindings.extend(handle_colormap(geometry, material, shader))
 
     # Let the shader generate code for our bindings
-    for i, binding in bindings.items():
+    for i, binding in enumerate(bindings):
         shader.define_binding(0, i, binding)
 
     # Get in what passes this needs rendering

--- a/pygfx/renderers/wgpu/imagerender.py
+++ b/pygfx/renderers/wgpu/imagerender.py
@@ -11,87 +11,6 @@ from ...resources import Texture, TextureView
 vertex_and_fragment = wgpu.ShaderStage.VERTEX | wgpu.ShaderStage.FRAGMENT
 
 
-class BaseImageShader(WorldObjectShader):
-    def image_helpers(self):
-        return """
-        struct ImGeometry {
-            indices: array<i32,6>;
-            positions: array<vec3<f32>,4>;
-            texcoords: array<vec2<f32>,4>;
-        };
-
-        fn get_im_geometry() -> ImGeometry {
-            let size = textureDimensions(t_img);
-            var geo: ImGeometry;
-
-            geo.indices = array<i32,6>(0, 1, 2,   3, 2, 1);
-
-            let pos1 = vec2<f32>(-0.5);
-            let pos2 = vec2<f32>(size.xy) + pos1;
-            geo.positions = array<vec3<f32>,4>(
-                vec3<f32>(pos2.x, pos1.y, 0.0),
-                vec3<f32>(pos2.x, pos2.y, 0.0),
-                vec3<f32>(pos1.x, pos1.y, 0.0),
-                vec3<f32>(pos1.x, pos2.y, 0.0),
-            );
-
-            geo.texcoords = array<vec2<f32>,4>(
-                vec2<f32>(1.0, 0.0),
-                vec2<f32>(1.0, 1.0),
-                vec2<f32>(0.0, 0.0),
-                vec2<f32>(0.0, 1.0),
-            );
-
-            return geo;
-        }
-
-        fn sample(texcoord: vec2<f32>, sizef: vec2<f32>) -> vec4<f32> {
-
-            // Sample the color, always produces a vec4
-            $$ if img_format == 'f32'
-                let value_rgba = textureSample(t_img, s_img, texcoord.xy);
-            $$ else
-                let texcoords_u = vec2<i32>(texcoord.xy * sizef.xy);
-                let value_rgba = vec4<f32>(textureLoad(t_img, texcoords_u, 0));
-            $$ endif
-
-            // Make it the correct dimension
-            $$ if img_nchannels == 1
-                let value_raw = value_rgba.r;
-            $$ elif img_nchannels == 2
-                let value_raw = value_rgba.rg;
-            $$ elif img_nchannels == 3
-                let value_raw = value_rgba.rgb;
-            $$ else
-                let value_raw = value_rgba.rgba;
-            $$ endif
-
-            // Apply contrast limits
-            let value_cor = value_raw {{ climcorrection }};
-            let value_clim = (value_cor - u_material.clim[0]) / (u_material.clim[1] - u_material.clim[0]);
-
-            // Apply colormap or compose final color
-            $$ if colormap_dim
-                // In the render function we make sure that colormap_dim matches img_nchannels
-                let color = sample_colormap(value_clim);
-            $$ else
-                $$ if img_nchannels == 1
-                    let r = value_clim;
-                    let color = vec4<f32>(r, r, r, 1.0);
-                $$ elif img_nchannels == 2
-                    let color = vec4<f32>(value_clim.rrr, value_raw.g);
-                $$ elif img_nchannels == 3
-                    let color = vec4<f32>(value_clim.rgb, 1.0);
-                $$ else
-                    let color = vec4<f32>(value_clim.rgb, value_raw.a);
-                $$ endif
-            $$ endif
-
-            return color;
-        }
-    """
-
-
 @register_wgpu_render_function(Image, ImageBasicMaterial)
 def image_renderer(render_info):
     """Render function capable of rendering images."""
@@ -153,7 +72,7 @@ def image_renderer(render_info):
         # Dimensionality
         shader["colormap_dim"] = view_dim = material.map.view_dim
         if material.map.view_dim not in ("1d", "2d", "3d"):
-            raise ValueError("Unexpected texture dimension")
+            raise ValueError("Unexpected colormap texture dimension")
         # Texture dim matches image channels
         if int(view_dim[0]) != shader["img_nchannels"]:
             raise ValueError(
@@ -196,6 +115,94 @@ def image_renderer(render_info):
             "bindings0": bindings,
         }
     ]
+
+
+sampled_value_to_color = """
+        fn sampled_value_to_color(value_rgba: vec4<f32>) -> vec4<f32> {
+
+            // Make it the correct dimension
+            $$ if img_nchannels == 1
+                let value_raw = value_rgba.r;
+            $$ elif img_nchannels == 2
+                let value_raw = value_rgba.rg;
+            $$ elif img_nchannels == 3
+                let value_raw = value_rgba.rgb;
+            $$ else
+                let value_raw = value_rgba.rgba;
+            $$ endif
+
+            // Apply contrast limits
+            let value_cor = value_raw {{ climcorrection }};
+            let value_clim = (value_cor - u_material.clim[0]) / (u_material.clim[1] - u_material.clim[0]);
+
+            // Apply colormap or compose final color
+            $$ if colormap_dim
+                // In the render function we make sure that colormap_dim matches img_nchannels
+                let color = sample_colormap(value_clim);
+            $$ else
+                $$ if img_nchannels == 1
+                    let r = value_clim;
+                    let color = vec4<f32>(r, r, r, 1.0);
+                $$ elif img_nchannels == 2
+                    let color = vec4<f32>(value_clim.rrr, value_raw.g);
+                $$ elif img_nchannels == 3
+                    let color = vec4<f32>(value_clim.rgb, 1.0);
+                $$ else
+                    let color = vec4<f32>(value_clim.rgb, value_raw.a);
+                $$ endif
+            $$ endif
+
+            return color;
+        }
+"""
+
+
+class BaseImageShader(WorldObjectShader):
+    def image_helpers(self):
+        return (
+            sampled_value_to_color
+            + """
+        struct ImGeometry {
+            indices: array<i32,6>;
+            positions: array<vec3<f32>,4>;
+            texcoords: array<vec2<f32>,4>;
+        };
+
+        fn get_im_geometry() -> ImGeometry {
+            let size = textureDimensions(t_img);
+            var geo: ImGeometry;
+
+            geo.indices = array<i32,6>(0, 1, 2,   3, 2, 1);
+
+            let pos1 = vec2<f32>(-0.5);
+            let pos2 = vec2<f32>(size.xy) + pos1;
+            geo.positions = array<vec3<f32>,4>(
+                vec3<f32>(pos2.x, pos1.y, 0.0),
+                vec3<f32>(pos2.x, pos2.y, 0.0),
+                vec3<f32>(pos1.x, pos1.y, 0.0),
+                vec3<f32>(pos1.x, pos2.y, 0.0),
+            );
+
+            geo.texcoords = array<vec2<f32>,4>(
+                vec2<f32>(1.0, 0.0),
+                vec2<f32>(1.0, 1.0),
+                vec2<f32>(0.0, 0.0),
+                vec2<f32>(0.0, 1.0),
+            );
+
+            return geo;
+        }
+
+        fn sample_im(texcoord: vec2<f32>, sizef: vec2<f32>) -> vec4<f32> {
+            $$ if img_format == 'f32'
+                return textureSample(t_img, s_img, texcoord.xy);
+            $$ else
+                let texcoords_u = vec2<i32>(texcoord.xy * sizef.xy);
+                return vec4<f32>(textureLoad(t_img, texcoords_u, 0));
+            $$ endif
+        }
+    """
+        )
 
 
 class ImageShader(BaseImageShader):
@@ -244,10 +251,11 @@ class ImageShader(BaseImageShader):
         [[stage(fragment)]]
         fn fs_main(varyings: Varyings) -> FragmentOutput {
             let sizef = vec2<f32>(textureDimensions(t_img));
-            let color_value = sample(varyings.texcoord.xy, sizef);
-            let albeido = color_value.rgb;
+            let value = sample_im(varyings.texcoord.xy, sizef);
+            let color = sampled_value_to_color(value);
+            let albeido = color.rgb;
 
-            let final_color = vec4<f32>(albeido, color_value.a * u_material.opacity);
+            let final_color = vec4<f32>(albeido, color.a * u_material.opacity);
 
             // Wrap up
             apply_clipping_planes(varyings.world_pos);

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -2,7 +2,7 @@ import wgpu  # only for flags/enums
 
 from . import register_wgpu_render_function
 from ._shadercomposer import Binding, WorldObjectShader
-from ._utils import to_vertex_format, to_texture_format
+from .pointsrender import handle_colormap
 from ...objects import Mesh, InstancedMesh
 from ...materials import (
     MeshBasicMaterial,
@@ -12,7 +12,7 @@ from ...materials import (
     MeshNormalLinesMaterial,
     MeshSliceMaterial,
 )
-from ...resources import Buffer, Texture, TextureView
+from ...resources import Buffer
 from ...utils import normals_from_vertices
 
 
@@ -31,7 +31,7 @@ def mesh_renderer(render_info):
         colormap_format="f32",
         instanced=False,
         wireframe=material.wireframe,
-        normal_color=False,
+        vertex_color_channels=0,
     )
 
     # We're assuming the presence of an index buffer for now
@@ -50,77 +50,45 @@ def mesh_renderer(render_info):
     # We're using storage buffers for everything; no vertex nor index buffers.
     vertex_buffers = {}
     index_buffer = None
-    bindings0 = {}
-    bindings1 = {}
-    bindings2 = {}
 
-    # Init bindings 0: uniforms
-    bindings0[0] = Binding("u_stdinfo", "buffer/uniform", render_info.stdinfo_uniform)
-    bindings0[1] = Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer)
-    bindings0[2] = Binding("u_material", "buffer/uniform", material.uniform_buffer)
+    # Init bindings
+    bindings = [
+        Binding("u_stdinfo", "buffer/uniform", render_info.stdinfo_uniform),
+        Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer),
+        Binding("u_material", "buffer/uniform", material.uniform_buffer),
+        Binding("s_indices", "buffer/read_only_storage", geometry.indices, "VERTEX"),
+        Binding(
+            "s_positions", "buffer/read_only_storage", geometry.positions, "VERTEX"
+        ),
+        Binding("s_normals", "buffer/read_only_storage", normal_buffer, "VERTEX"),
+    ]
 
-    # Init bindings 1: storage buffers, textures, and samplers
-    bindings1[0] = Binding(
-        "s_indices", "buffer/read_only_storage", geometry.indices, "VERTEX"
-    )
-    bindings1[1] = Binding(
-        "s_positions", "buffer/read_only_storage", geometry.positions, "VERTEX"
-    )
-    bindings1[2] = Binding(
-        "s_normals", "buffer/read_only_storage", normal_buffer, "VERTEX"
-    )
-    if getattr(geometry, "texcoords", None) is not None:
-        bindings1[3] = Binding(
-            "s_texcoords", "buffer/read_only_storage", geometry.texcoords, "VERTEX"
+    # Per-vertex color, colormap, or a plane color?
+    shader["color_mode"] = "uniform"
+    if material.vertex_colors:
+        shader["color_mode"] = "vertex"
+        shader["vertex_color_channels"] = nchannels = geometry.colors.data.shape[1]
+        if nchannels not in (1, 2, 3, 4):
+            raise ValueError(f"Geometry.colors needs 1-4 columns, not {nchannels}")
+        bindings.append(
+            Binding("s_colors", "buffer/read_only_storage", geometry.colors, "VERTEX")
         )
+    elif material.map is not None:
+        shader["color_mode"] = "map"
+        bindings.extend(handle_colormap(geometry, material, shader))
 
-    # If a colormap (aka texture map) is applied ...
-    if material.map is not None:
-        if isinstance(material.map, Texture):
-            raise TypeError("material.map is a Texture, but must be a TextureView")
-        elif not isinstance(material.map, TextureView):
-            raise TypeError("material.map must be a TextureView")
-        elif getattr(geometry, "texcoords", None) is None:
-            raise ValueError("material.map is present, but geometry has no texcoords")
-        bindings1[4] = Binding(
-            "s_colormap", "sampler/filtering", material.map, "FRAGMENT"
-        )
-        bindings1[5] = Binding("t_colormap", "texture/auto", material.map, "FRAGMENT")
-        # Dimensionality
-        shader["colormap_dim"] = view_dim = material.map.view_dim
-        if view_dim not in ("1d", "2d", "3d"):
-            raise ValueError("Unexpected texture dimension")
-        # Texture dim matches texcoords
-        vert_fmt = to_vertex_format(geometry.texcoords.format)
-        if view_dim == "1d" and "x" not in vert_fmt:
-            pass
-        elif not vert_fmt.endswith("x" + view_dim[0]):
-            raise ValueError(
-                f"geometry.texcoords {geometry.texcoords.format} does not match material.map {view_dim}"
-            )
-        # Sampling type
-        fmt = to_texture_format(material.map.format)
-        if "norm" in fmt or "float" in fmt:
-            shader["colormap_format"] = "f32"
-        elif "uint" in fmt:
-            shader["colormap_format"] = "u32"
-        else:
-            shader["colormap_format"] = "i32"
-        # Channels
-        shader["colormap_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
-
-    # Collect texture and sampler
+    # Triage based on material
     if isinstance(material, MeshNormalMaterial):
         # Special simple fragment shader
+        shader["color_mode"] = "normal"
         shader["colormap_dim"] = ""  # disable texture if there happens to be one
-        shader["normal_color"] = True
     elif isinstance(material, MeshNormalLinesMaterial):
         # Special simple vertex shader with plain fragment shader
         topology = wgpu.PrimitiveTopology.line_list
         shader.vertex_shader = shader.vertex_shader_normal_lines
         index_buffer = None
         n = geometry.positions.nitems * 2
-        shader["colormap_dim"] = ""  # disable texture if there happens to be one
+        shader["color_mode"] = "uniform"
         shader["lighting"] = ""
         shader["wireframe"] = False
     elif isinstance(material, MeshFlatMaterial):
@@ -134,11 +102,13 @@ def mesh_renderer(render_info):
     n_instances = 1
     if isinstance(wobject, InstancedMesh):
         shader["instanced"] = True
-        bindings2[0] = Binding(
-            "s_instance_infos",
-            "buffer/read_only_storage",
-            wobject.instance_infos,
-            "VERTEX",
+        bindings.append(
+            Binding(
+                "s_instance_infos",
+                "buffer/read_only_storage",
+                wobject.instance_infos,
+                "VERTEX",
+            )
         )
         n_instances = wobject.instance_infos.nitems
 
@@ -151,19 +121,25 @@ def mesh_renderer(render_info):
         cull_mode = wgpu.CullMode.none
 
     # Let the shader generate code for our bindings
-    for i, binding in bindings0.items():
+    for i, binding in enumerate(bindings):
         shader.define_binding(0, i, binding)
-    for i, binding in bindings1.items():
-        shader.define_binding(1, i, binding)
 
     # Determine in what render passes this objects must be rendered
     suggested_render_mask = 3
-    if material.map is not None:
+    if material.opacity < 1:
+        suggested_render_mask = 2
+    elif shader["color_mode"] == "vertex":
+        if shader["vertex_color_channels"] in (1, 3):
+            suggested_render_mask = 1
+    elif shader["color_mode"] == "map":
         if shader["colormap_nchannels"] in (1, 3):
             suggested_render_mask = 1
+    elif shader["color_mode"] == "normal":
+        suggested_render_mask = 1
+    elif shader["color_mode"] == "uniform":
+        suggested_render_mask = 1 if material.color[3] >= 1 else 2
     else:
-        is_opaque = material.opacity >= 1 and material.color[3] >= 1
-        suggested_render_mask = 1 if is_opaque else 2
+        raise RuntimeError(f"Unexpected color mode {shader['color_mode']}")
 
     # Put it together!
     return [
@@ -175,9 +151,7 @@ def mesh_renderer(render_info):
             "indices": (range(n), range(n_instances)),
             "index_buffer": index_buffer,
             "vertex_buffers": vertex_buffers,
-            "bindings0": bindings0,
-            "bindings1": bindings1,
-            "bindings2": bindings2,
+            "bindings0": bindings,
         }
     ]
 
@@ -261,6 +235,19 @@ class MeshShader(WorldObjectShader):
             // Set position
             varyings.world_pos = vec3<f32>(world_pos.xyz / world_pos.w);
             varyings.position = vec4<f32>(ndc_pos.xyz, ndc_pos.w);
+
+            // Per-vertex colors
+            $$ if vertex_color_channels == 1
+            let cvalue = load_s_colors(i0);
+            varyings.color = vec4<f32>(cvalue, cvalue, cvalue, 1.0);
+            $$ elif vertex_color_channels == 2
+            let cvalue = load_s_colors(i0);
+            varyings.color = vec4<f32>(cvalue.r, cvalue.r, cvalue.r, cvalue.g);
+            $$ elif vertex_color_channels == 3
+            varyings.color = vec4<f32>(load_s_colors(i0), 1.0);
+            $$ elif vertex_color_channels == 4
+            varyings.color = vec4<f32>(load_s_colors(i0));
+            $$ endif
 
             // Set texture coords
             $$ if colormap_dim == '1d'
@@ -361,14 +348,16 @@ class MeshShader(WorldObjectShader):
         [[stage(fragment)]]
         fn fs_main(varyings: Varyings, [[builtin(front_facing)]] is_front: bool) -> FragmentOutput {
 
-            $$ if colormap_dim
+            $$ if color_mode == 'vertex'
+                let color_value = varyings.color;
+                let albeido = color_value.rgb;
+            $$ elif color_mode == 'map'
                 let color_value = sample_colormap(varyings.texcoord);
                 let albeido = color_value.rgb;  // no more colormap
-            $$ elif normal_color
+            $$ elif color_mode == 'normal'
                 let albeido = normalize(varyings.normal.xyz) * 0.5 + 0.5;
                 let color_value = vec4<f32>(albeido, 1.0);
             $$ else
-                // Just a simple color
                 let color_value = u_material.color;
                 let albeido = color_value.rgb;
             $$ endif

--- a/pygfx/renderers/wgpu/meshrender.py
+++ b/pygfx/renderers/wgpu/meshrender.py
@@ -30,7 +30,6 @@ def mesh_renderer(render_info):
         lighting="",
         colormap_format="f32",
         instanced=False,
-        climcorrection=None,
         wireframe=material.wireframe,
         normal_color=False,
     )
@@ -100,14 +99,9 @@ def mesh_renderer(render_info):
                 f"geometry.texcoords {geometry.texcoords.format} does not match material.map {view_dim}"
             )
         # Sampling type
-        # todo: remove clim stuff
         fmt = to_texture_format(material.map.format)
         if "norm" in fmt or "float" in fmt:
             shader["colormap_format"] = "f32"
-            if "unorm" in fmt:
-                shader["climcorrection"] = " * 255.0"
-            elif "snorm" in fmt:
-                shader["climcorrection"] = " * 255.0 - 128.0"
         elif "uint" in fmt:
             shader["colormap_format"] = "u32"
         else:
@@ -496,6 +490,12 @@ class MeshShader(WorldObjectShader):
 @register_wgpu_render_function(Mesh, MeshSliceMaterial)
 def meshslice_renderer(render_info):
     """Render function capable of rendering mesh slices."""
+
+    # It would technically be possible to implement colormapping or
+    # per-vertex colors, but its a tricky dance to get the per-vertex
+    # data (e.g. texcoords) into a varying. And because the visual
+    # result is a line, its likely that in most use-cases a uniform
+    # color is preferred anyway. So for now we don't implement that.
 
     wobject = render_info.wobject
     geometry = wobject.geometry

--- a/pygfx/renderers/wgpu/volumerender.py
+++ b/pygfx/renderers/wgpu/volumerender.py
@@ -2,18 +2,138 @@ import wgpu  # only for flags/enums
 
 from . import register_wgpu_render_function
 from ._shadercomposer import Binding, WorldObjectShader
+from .imagerender import sampled_value_to_color
 from ._utils import to_texture_format
 from ...objects import Volume
-from ...materials import VolumeSliceMaterial, VolumeRayMaterial
+from ...materials import VolumeBasicMaterial, VolumeSliceMaterial, VolumeRayMaterial
 from ...resources import Texture, TextureView
 
 
 vertex_and_fragment = wgpu.ShaderStage.VERTEX | wgpu.ShaderStage.FRAGMENT
 
 
+@register_wgpu_render_function(Volume, VolumeBasicMaterial)
+def volume_renderer(render_info):
+    """Render function capable of rendering volumes."""
+
+    wobject = render_info.wobject
+    geometry = wobject.geometry
+    material = wobject.material  # noqa
+
+    # The shaders for the volume slice and ray are very different, but their
+    # setup is very similar. This triage captures all diferences.
+    if isinstance(material, VolumeSliceMaterial):
+        shader = VolumeSliceShader(render_info, climcorrection="")
+        topology = wgpu.PrimitiveTopology.triangle_list
+        n = 12
+        cull_mode = wgpu.CullMode.none
+    elif isinstance(material, VolumeRayMaterial):
+        shader = VolumeRayShader(
+            render_info,
+            climcorrection="",
+            mode=material.render_mode,
+        )
+        topology = wgpu.PrimitiveTopology.triangle_list
+        n = 36
+        cull_mode = wgpu.CullMode.front  # the back planes are the ref
+    else:
+        raise RuntimeError(f"Unexpected volume material: {material}")
+
+    bindings = {}
+    bindings[0] = Binding("u_stdinfo", "buffer/uniform", render_info.stdinfo_uniform)
+    bindings[1] = Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer)
+    bindings[2] = Binding("u_material", "buffer/uniform", material.uniform_buffer)
+
+    # Collect texture and sampler
+    if geometry.grid is None:
+        raise ValueError("Volume.geometry must have a grid (texture).")
+    else:
+        if isinstance(geometry.grid, TextureView):
+            view = geometry.grid
+        elif isinstance(geometry.grid, Texture):
+            view = geometry.grid.get_view(filter="linear")
+        else:
+            raise TypeError("Volume.geometry.grid must be a Texture or TextureView")
+        if view.view_dim.lower() != "3d":
+            raise TypeError("Volume.geometry.grid must a 3D texture (view)")
+        # Sampling type
+        fmt = to_texture_format(geometry.grid.format)
+        if "norm" in fmt or "float" in fmt:
+            shader["img_format"] = "f32"
+            if "unorm" in fmt:
+                shader["climcorrection"] = " * 255.0"
+            elif "snorm" in fmt:
+                shader["climcorrection"] = " * 255.0 - 128.0"
+        elif "uint" in fmt:
+            shader["img_format"] = "u32"
+        else:
+            shader["img_format"] = "i32"
+        # Channels
+        shader["img_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
+
+    bindings[3] = Binding("s_img", "sampler/filtering", view, "FRAGMENT")
+    bindings[4] = Binding("t_img", "texture/auto", view, vertex_and_fragment)
+
+    # If a colormap is applied ...
+    if material.map is not None:
+        if isinstance(material.map, Texture):
+            raise TypeError("material.map is a Texture, but must be a TextureView")
+        elif not isinstance(material.map, TextureView):
+            raise TypeError("material.map must be a TextureView")
+        bindings[5] = Binding(
+            "s_colormap", "sampler/filtering", material.map, "FRAGMENT"
+        )
+        bindings[6] = Binding("t_colormap", "texture/auto", material.map, "FRAGMENT")
+        # Dimensionality
+        shader["colormap_dim"] = view_dim = material.map.view_dim
+        if material.map.view_dim not in ("1d", "2d", "3d"):
+            raise ValueError("Unexpected colormap texture dimension")
+        # Texture dim matches image channels
+        if int(view_dim[0]) != shader["img_nchannels"]:
+            raise ValueError(
+                f"Volume channels {shader['img_nchannels']} does not match material.map {view_dim}"
+            )
+        # Sampling type
+        fmt = to_texture_format(material.map.format)
+        if "norm" in fmt or "float" in fmt:
+            shader["colormap_format"] = "f32"
+        elif "uint" in fmt:
+            shader["colormap_format"] = "u32"
+        else:
+            shader["colormap_format"] = "i32"
+        # Channels
+        shader["colormap_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
+
+    # Let the shader generate code for our bindings
+    for i, binding in bindings.items():
+        shader.define_binding(0, i, binding)
+
+    # Get in what passes this needs rendering
+    suggested_render_mask = 3
+    if material.opacity >= 1 and shader["img_nchannels"] in (1, 3):
+        suggested_render_mask = 1
+    elif material.opacity < 1:
+        suggested_render_mask = 2
+
+    # Put it together!
+    return [
+        {
+            "suggested_render_mask": suggested_render_mask,
+            "render_shader": shader,
+            "primitive_topology": topology,
+            "cull_mode": cull_mode,
+            "indices": (range(n), range(1)),
+            "vertex_buffers": {},
+            "bindings0": bindings,
+        }
+    ]
+
+
 class BaseVolumeShader(WorldObjectShader):
     def volume_helpers(self):
-        return """
+        return (
+            sampled_value_to_color
+            + """
         struct VolGeometry {
             indices: array<i32,36>;
             positions: array<vec3<f32>,8>;
@@ -21,7 +141,7 @@ class BaseVolumeShader(WorldObjectShader):
         };
 
         fn get_vol_geometry() -> VolGeometry {
-            let size = textureDimensions(r_tex);
+            let size = textureDimensions(t_img);
             var geo: VolGeometry;
 
             geo.indices = array<i32,36>(
@@ -56,100 +176,17 @@ class BaseVolumeShader(WorldObjectShader):
             return geo;
         }
 
-        fn sample(texcoord: vec3<f32>, sizef: vec3<f32>) -> vec4<f32> {
-            var color_value: vec4<f32>;
-
-            $$ if texture_format == 'f32'
-                color_value = textureSample(r_tex, r_sampler, texcoord.xyz);
+        fn sample_vol(texcoord: vec3<f32>, sizef: vec3<f32>) -> vec4<f32> {
+            $$ if img_format == 'f32'
+                return textureSample(t_img, s_img, texcoord.xyz);
             $$ else
                 let texcoords_u = vec3<i32>(texcoord.xyz * sizef);
-                color_value = vec4<f32>(textureLoad(r_tex, texcoords_u, 0));
+                return vec4<f32>(textureLoad(t_img, texcoords_u, 0));
             $$ endif
-
-            $$ if climcorrection
-                color_value = vec4<f32>(color_value.rgb {{ climcorrection }}, color_value.a);
-            $$ endif
-            $$ if texture_nchannels == 1
-                color_value = vec4<f32>(color_value.rrr, 1.0);
-            $$ elif texture_nchannels == 2
-                color_value = vec4<f32>(color_value.rrr, color_value.g);
-            $$ endif
-            return color_value;
         }
 
     """
-
-
-@register_wgpu_render_function(Volume, VolumeSliceMaterial)
-def volume_slice_renderer(render_info):
-    """Render function capable of rendering volumes."""
-
-    wobject = render_info.wobject
-    geometry = wobject.geometry
-    material = wobject.material  # noqa
-    shader = VolumeSliceShader(render_info, climcorrection=False)
-
-    bindings = {}
-
-    bindings[0] = Binding("u_stdinfo", "buffer/uniform", render_info.stdinfo_uniform)
-    bindings[1] = Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer)
-    bindings[2] = Binding("u_material", "buffer/uniform", material.uniform_buffer)
-
-    topology = wgpu.PrimitiveTopology.triangle_list
-    n = 12
-
-    # Collect texture and sampler
-    if geometry.grid is None:
-        raise ValueError("Volume.geometry must have a grid (texture).")
-    else:
-        if isinstance(geometry.grid, TextureView):
-            view = geometry.grid
-        elif isinstance(geometry.grid, Texture):
-            view = geometry.grid.get_view(filter="linear")
-        else:
-            raise TypeError("Volume.geometry.grid must be a Texture or TextureView")
-        if view.view_dim.lower() != "3d":
-            raise TypeError("Volume.geometry.grid must a 3D texture (view)")
-        # Sampling type
-        fmt = to_texture_format(geometry.grid.format)
-        if "norm" in fmt or "float" in fmt:
-            shader["texture_format"] = "f32"
-            if "unorm" in fmt:
-                shader["climcorrection"] = " * 255.0"
-            elif "snorm" in fmt:
-                shader["climcorrection"] = " * 255.0 - 128.0"
-        elif "uint" in fmt:
-            shader["texture_format"] = "u32"
-        else:
-            shader["texture_format"] = "i32"
-        # Channels
-        shader["texture_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
-
-    bindings[3] = Binding("r_sampler", "sampler/filtering", view, "FRAGMENT")
-    bindings[4] = Binding("r_tex", "texture/auto", view, vertex_and_fragment)
-
-    # Let the shader generate code for our bindings
-    for i, binding in bindings.items():
-        shader.define_binding(0, i, binding)
-
-    # Get in what passes this needs rendering
-    suggested_render_mask = 3
-    if material.opacity >= 1 and shader["texture_nchannels"] in (1, 3):
-        suggested_render_mask = 1
-    elif material.opacity < 1:
-        suggested_render_mask = 2
-
-    # Put it together!
-    return [
-        {
-            "suggested_render_mask": suggested_render_mask,
-            "render_shader": shader,
-            "primitive_topology": topology,
-            "indices": (range(n), range(1)),
-            "vertex_buffers": {},
-            "bindings0": bindings,
-        }
-    ]
+        )
 
 
 class VolumeSliceShader(BaseVolumeShader):
@@ -324,11 +361,11 @@ class VolumeSliceShader(BaseVolumeShader):
 
         [[stage(fragment)]]
         fn fs_main(varyings: Varyings) -> FragmentOutput {
-            let sizef = vec3<f32>(textureDimensions(r_tex));
-            let color_value = sample(varyings.texcoord.xyz, sizef);
-            let albeido = (color_value.rgb - u_material.clim[0]) / (u_material.clim[1] - u_material.clim[0]);
-
-            let final_color = vec4<f32>(albeido, color_value.a * u_material.opacity);
+            let sizef = vec3<f32>(textureDimensions(t_img));
+            let value = sample_vol(varyings.texcoord.xyz, sizef);
+            let color = sampled_value_to_color(value);
+            let albeido = color.rgb;
+            let final_color = vec4<f32>(albeido, color.a * u_material.opacity);
 
             // Wrap up
             apply_clipping_planes(varyings.world_pos);
@@ -348,78 +385,6 @@ class VolumeSliceShader(BaseVolumeShader):
         }
 
         """
-
-
-@register_wgpu_render_function(Volume, VolumeRayMaterial)
-def volume_ray_renderer(render_info):
-    """Render function capable of rendering volumes."""
-
-    wobject = render_info.wobject
-    geometry = wobject.geometry
-    material = wobject.material  # noqa
-    shader = VolumeRayShader(
-        render_info, mode=material.render_mode, climcorrection=False
-    )
-
-    bindings = {}
-
-    bindings[0] = Binding("u_stdinfo", "buffer/uniform", render_info.stdinfo_uniform)
-    bindings[1] = Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer)
-    bindings[2] = Binding("u_material", "buffer/uniform", material.uniform_buffer)
-
-    # Collect texture and sampler
-    if geometry.grid is None:
-        raise ValueError("Volume.geometry must have a grid (texture).")
-    else:
-        if isinstance(geometry.grid, TextureView):
-            view = geometry.grid
-        elif isinstance(geometry.grid, Texture):
-            view = geometry.grid.get_view(filter="linear")
-        else:
-            raise TypeError("Volume.geometry.grid must be a Texture or TextureView")
-        if view.view_dim.lower() != "3d":
-            raise TypeError("Volume.geometry.grid must a 3D texture (view)")
-        # Sampling type
-        fmt = to_texture_format(geometry.grid.format)
-        if "norm" in fmt or "float" in fmt:
-            shader["texture_format"] = "f32"
-            if "unorm" in fmt:
-                shader["climcorrection"] = " * 255.0"
-            elif "snorm" in fmt:
-                shader["climcorrection"] = " * 255.0 - 128.0"
-        elif "uint" in fmt:
-            shader["texture_format"] = "u32"
-        else:
-            shader["texture_format"] = "i32"
-        # Channels
-        shader["texture_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
-
-    bindings[3] = Binding("r_sampler", "sampler/filtering", view, "FRAGMENT")
-    bindings[4] = Binding("r_tex", "texture/auto", view, vertex_and_fragment)
-
-    # Let the shader generate code for our bindings
-    for i, binding in bindings.items():
-        shader.define_binding(0, i, binding)
-
-    # Get in what passes this needs rendering
-    suggested_render_mask = 3
-    if material.opacity >= 1 and shader["texture_nchannels"] in (1, 3):
-        suggested_render_mask = 1
-    elif material.opacity < 1:
-        suggested_render_mask = 2
-
-    # Put it together!
-    return [
-        {
-            "suggested_render_mask": suggested_render_mask,
-            "render_shader": shader,
-            "primitive_topology": wgpu.PrimitiveTopology.triangle_list,
-            "cull_mode": wgpu.CullMode.front,  # the back planes are the ref
-            "indices": (range(36), range(1)),
-            "vertex_buffers": {},
-            "bindings0": bindings,
-        }
-    ]
 
 
 class VolumeRayShader(BaseVolumeShader):
@@ -493,7 +458,7 @@ class VolumeRayShader(BaseVolumeShader):
         fn fs_main(varyings: Varyings) -> FragmentOutput {
 
             // Get size of the volume
-            let sizef = vec3<f32>(textureDimensions(r_tex));
+            let sizef = vec3<f32>(textureDimensions(t_img));
 
             // Determine the stepsize as a float in pixels.
             // This value should be between ~ 0.1 and 1. Smaller values yield better
@@ -592,17 +557,17 @@ class VolumeRayShader(BaseVolumeShader):
 
             // Primary loop. The purpose is to find the approximate location where
             // the maximum is.
-            var the_val = -999999.0;
+            var the_ref = -999999.0;
             var the_coord = start_coord;
-            var the_color : vec4<f32>;
+            var the_value : vec4<f32>;
             for (var iter=0.0; iter<nstepsf; iter=iter+1.0) {
                 let coord = start_coord + iter * step_coord;
-                let color = sample(coord, sizef);
-                let val = color.r;
-                if (val > the_val) {
-                    the_val = val;
+                let value = sample_vol(coord, sizef);
+                let ref = value.r;
+                if (ref > the_ref) {
+                    the_ref = ref;
                     the_coord = coord;
-                    the_color = color;
+                    the_value = value;
                 }
             }
 
@@ -613,24 +578,25 @@ class VolumeRayShader(BaseVolumeShader):
                 substep_coord = substep_coord * 0.5;
                 let coord1 = the_coord - substep_coord;
                 let coord2 = the_coord + substep_coord;
-                let color1 = sample(coord1, sizef);
-                let color2 = sample(coord2, sizef);
-                let val1 = color1.r;
-                let val2 = color2.r;
-                if (val1 >= the_val) {  // deliberate larger-equal
-                    the_val = val1;
+                let value1 = sample_vol(coord1, sizef);
+                let value2 = sample_vol(coord2, sizef);
+                let ref1 = value1.r;
+                let ref2 = value2.r;
+                if (ref1 >= the_ref) {  // deliberate larger-equal
+                    the_ref = ref1;
                     the_coord = coord1;
-                    the_color = color1;
-                } elseif (val2 > the_val) {
-                    the_val = val2;
+                    the_value = value1;
+                } elseif (ref2 > the_ref) {
+                    the_ref = ref2;
                     the_coord = coord2;
-                    the_color = color2;
+                    the_value = value2;
                 }
             }
 
             // Colormapping
-            let albeido = (the_color.rgb - u_material.clim[0]) / (u_material.clim[1] - u_material.clim[0]);
-            let color = vec4<f32>(albeido, the_color.a * u_material.opacity);
+            let color = sampled_value_to_color(the_value);
+            let albeido = color.rgb;
+            let color = vec4<f32>(albeido, color.a * u_material.opacity);
 
             // Produce result
             var out: RenderOutput;

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -135,7 +135,7 @@ class Buffer(Resource):
         assert offset + nbytes <= self.nbytes
         self._vertex_byte_range = offset, nbytes
 
-    def update_range(self, offset=0, size=2 ** 50):
+    def update_range(self, offset=0, size=2**50):
         """Mark a certain range of the data for upload to the GPU. The
         offset and size are expressed in integer number of elements.
         """

--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -73,7 +73,7 @@ def unpack_bitfield(packed, **bit_counts):
     """Unpack values from an uint64 bitfield."""
     values = {}
     for key, bits in bit_counts.items():
-        mask = 2 ** bits - 1
+        mask = 2**bits - 1
         values[key] = packed & mask
         packed = packed >> bits
     return values


### PR DESCRIPTION
Closes #104.

* [x] Proper support for colormaps that are gray, gray+alpha, rgb, rgba.
* [x] Per-vertex colors can be gray, gray+alpha, rgb, rgba.
* For Image:
  * [x] proper support for gray, gray+alpha, rgb, rgba.
  * [x] Colormaps.
* For Volume and VolumeSlice:
  * [x] proper support for gray, gray+alpha, rgb, rgba.
  * [x] Colormaps
* For Mesh:
  * [x] Refactor colormaps.
  * [x] Remove clim property. 
  * [x] Per-vertex colors.
* For MeshSlice:
   * [x] Added note about not implementing colormapping or per-vertex colors for now.
* For Line (and ThinLine):
  * [x] Colormaps.
  * [x] Per-vertex colors (was already implemented).
* For points:
  * [x] Colormaps.
  * [x] Per-vertex colors (was already implemented).
* Do I forget objects, maybe background?
* [ ] A few standard colormaps.
* [ ] A complete lib of builtin colormaps.
* [x] Docs.
* [x] Self review / check todos.
* [x] Rebase and update validation example to be tested on CI.

I'm building this list up for completeness, not everything will go in this PR.

----
<img width="872" alt="image" src="https://user-images.githubusercontent.com/3015475/151766054-fe3bb90e-e804-426a-881b-16347a276f86.png">

<img width="882" alt="image" src="https://user-images.githubusercontent.com/3015475/151766148-8fd7ff81-b319-42c3-b5bf-31c308938b1c.png">

<img width="865" alt="image" src="https://user-images.githubusercontent.com/3015475/151766195-b0533b0b-6a5f-4a0b-b45e-554de5b6bbf1.png">

<img width="880" alt="image" src="https://user-images.githubusercontent.com/3015475/151766310-8123a917-1420-4d6b-9739-d884e1df0149.png">

