### PR TITLE
Camera fixes

### DIFF
--- a/examples/line_basic.py
+++ b/examples/line_basic.py
@@ -35,8 +35,16 @@ scene.add(line)
 camera = gfx.OrthographicCamera(600, 500)
 camera.position.set(300, 250, 0)
 
+controls = gfx.PanZoomControls(camera.position.clone())
+controls.add_default_event_handlers(canvas, camera)
+
+
+def animate():
+    controls.update_camera(camera)
+    renderer.render(scene, camera)
+
 
 if __name__ == "__main__":
     renderer_svg.render(scene, camera)
-    canvas.request_draw(lambda: renderer.render(scene, camera))
+    canvas.request_draw(animate)
     run()

--- a/pygfx/controls/_panzoom.py
+++ b/pygfx/controls/_panzoom.py
@@ -17,9 +17,9 @@ class PanZoomControls:
     ) -> None:
         self.rotation = Quaternion()
         if eye is None:
-            eye = Vector3(50.0, 50.0, 50.0)
+            eye = Vector3(0, 0, 0)
         if target is None:
-            target = Vector3()
+            target = Vector3(eye.x, eye.y, eye.z - 100)
         if up is None:
             up = Vector3(0.0, 1.0, 0.0)
         self.zoom_value = zoom

--- a/pygfx/renderers/wgpu/pointsrender.py
+++ b/pygfx/renderers/wgpu/pointsrender.py
@@ -183,7 +183,7 @@ class PointsShader(WorldObjectShader):
             let delta_ndc = delta_logical * (1.0 / u_stdinfo.logical_size);
 
             var varyings: Varyings;
-            varyings.position = vec4<f32>(ndc_pos.xy + delta_ndc, ndc_pos.zw);
+            varyings.position = vec4<f32>(ndc_pos.xy + delta_ndc * ndc_pos.w, ndc_pos.zw);
             varyings.world_pos = vec3<f32>(world_pos.xyz / world_pos.w);
             varyings.pointcoord = vec2<f32>(delta_logical);
             varyings.size = f32(size);


### PR DESCRIPTION
I was playing with a very simple 2D points visualization, and I ran into some issues. This fixes these.

* [x] The panzoom contro's default initialization is odd for 2D data. I think these numbers were taken from the orbit controls. Let's assume the data is 2D.
* [x] With a perspective camera, points further away from the camera are smaller. We may add an option for this later, but for now this should not be. 