### PR TITLE
Fix box geometry

### DIFF
--- a/examples/validate_box.py
+++ b/examples/validate_box.py
@@ -1,0 +1,31 @@
+"""
+Example showing the box geometry.
+"""
+# test_example = true
+
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+
+canvas = WgpuCanvas()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+
+scene = gfx.Scene()
+
+material = gfx.MeshBasicMaterial(color=(1, 0, 0), wireframe=True)
+geometry = gfx.box_geometry(1, 2, 3)
+box = gfx.Mesh(geometry, material)
+scene.add(box)
+
+material2 = gfx.MeshNormalLinesMaterial(color=(0, 1, 0))
+box2 = gfx.Mesh(geometry, material2)
+scene.add(box2)
+
+camera = gfx.OrthographicCamera(5, 5)
+camera.position.set(5, 5, 5)
+camera.look_at(gfx.linalg.Vector3())
+
+canvas.request_draw(lambda: renderer.render(scene, camera))
+
+if __name__ == "__main__":
+    print(__doc__)
+    run()


### PR DESCRIPTION
Closes #246 

The left/right/top/bottom planes needed to be rotated 90 degrees about their normal to account for the manner in which they are generated here. This PR fixes that and improves variable names a little.

Added a (tested!) validate example for a box with anisotropic dimensions.

![image](https://user-images.githubusercontent.com/1882046/153768554-8eaf95c2-3af1-40e7-b295-ea4fe626f8a1.png)
