### PR TITLE
Better lines and improved helpers

### DIFF
--- a/examples/multi_slice1.py
+++ b/examples/multi_slice1.py
@@ -19,7 +19,7 @@ scene = gfx.Scene()
 background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
 scene.add(background)
 
-scene.add(gfx.AxesHelper(length=50))
+scene.add(gfx.AxesHelper(size=50))
 
 vol = imageio.volread("imageio:stent.npz").astype("float32") / 2000
 tex = gfx.Texture(vol, dim=3)

--- a/examples/multi_slice2.py
+++ b/examples/multi_slice2.py
@@ -21,7 +21,7 @@ scene = gfx.Scene()
 background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
 scene.add(background)
 
-scene.add(gfx.AxesHelper(length=50))
+scene.add(gfx.AxesHelper(size=50))
 
 vol = imageio.volread("imageio:stent.npz").astype("float32")
 tex = gfx.Texture(vol, dim=3)

--- a/examples/object_bounding_box.py
+++ b/examples/object_bounding_box.py
@@ -23,7 +23,7 @@ box_world = gfx.BoxHelper()
 box_world.set_transform_by_object(mesh)
 scene.add(box_world)
 
-box_local = gfx.BoxHelper()
+box_local = gfx.BoxHelper(thickness=2)
 box_local.set_transform_by_object(mesh, space="local")
 mesh.add(box_local)  # note that the parent is `mesh` here, not `scene`
 

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -11,7 +11,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-scene.add(gfx.AxesHelper(length=250))
+scene.add(gfx.AxesHelper(size=250))
 
 im = imageio.imread("imageio:chelsea.png")
 tex = gfx.Texture(im, dim=2).get_view(filter="linear")

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -11,7 +11,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-axes = gfx.AxesHelper(length=250)
+axes = gfx.AxesHelper(size=250)
 scene.add(axes)
 
 background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))

--- a/examples/validate_helpers1.py
+++ b/examples/validate_helpers1.py
@@ -16,7 +16,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
-scene.add(gfx.AxesHelper(length=40))
+scene.add(gfx.AxesHelper(size=40, thickness=5))
 camera = gfx.OrthographicCamera(100, 100)
 
 canvas.request_draw(lambda: renderer.render(scene, camera))

--- a/examples/validate_helpers2.py
+++ b/examples/validate_helpers2.py
@@ -15,18 +15,13 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-background = gfx.Background(
-    None, gfx.BackgroundMaterial((0, 0.1, 0, 1), (0, 0.1, 0.1, 1))
-)
-scene.add(background)
-
-axes = gfx.AxesHelper(length=40)
+axes = gfx.AxesHelper(size=40, thickness=8)
 scene.add(axes)
 
-grid = gfx.GridHelper(size=100)
+grid = gfx.GridHelper(size=100, thickness=4)
 scene.add(grid)
 
-box = gfx.BoxHelper(size=100)
+box = gfx.BoxHelper(size=100, thickness=4)
 scene.add(box)
 
 camera = gfx.PerspectiveCamera(70, 16 / 9)

--- a/pygfx/helpers/_axes.py
+++ b/pygfx/helpers/_axes.py
@@ -1,13 +1,18 @@
 import numpy as np
 
-from .. import Geometry, Line, LineThinSegmentMaterial
+from .. import Geometry, Line, LineSegmentMaterial
 from ..utils import Color
 
 
 class AxesHelper(Line):
-    """An object indicating the axes directions."""
+    """An object indicating the axes directions.
 
-    def __init__(self, length=1.0):
+    Parameters:
+        size (float): The length of the lines (default 1).
+        thickness (float): the thickness of the lines (default 2 px).
+    """
+
+    def __init__(self, size=1.0, thickness=2):
         positions = np.array(
             [
                 [0, 0, 0],
@@ -19,7 +24,7 @@ class AxesHelper(Line):
             ],
             dtype="f4",
         )
-        positions *= length
+        positions *= size
 
         colors = np.array(
             [
@@ -34,7 +39,7 @@ class AxesHelper(Line):
         )
 
         geometry = Geometry(positions=positions, colors=colors)
-        material = LineThinSegmentMaterial(vertex_colors=True)
+        material = LineSegmentMaterial(vertex_colors=True, thickness=thickness, aa=True)
 
         super().__init__(geometry, material)
 

--- a/pygfx/helpers/_box.py
+++ b/pygfx/helpers/_box.py
@@ -1,17 +1,18 @@
 import numpy as np
 
-from .. import Geometry, Line, LineThinSegmentMaterial
+from .. import Geometry, Line, LineSegmentMaterial
 
 
 class BoxHelper(Line):
-    """A line box object. Commonly used to visualize bounding boxes."""
+    """A line box object. Commonly used to visualize bounding boxes.
 
-    def __init__(self, size=1.0):
-        """Construct a box line visual centered around the origin.
+    Parameters:
+        size (float): The length of the box' edges (default 1).
+        thickness (float): the thickness of the lines (default 1 px).
+    """
 
-        Parameters:
-            size (float): The length of the box' edges.
-        """
+    def __init__(self, size=1.0, thickness=1):
+
         self._size = size
 
         positions = np.array(
@@ -47,7 +48,7 @@ class BoxHelper(Line):
         positions *= self._size
 
         geometry = Geometry(positions=positions)
-        material = LineThinSegmentMaterial(color=(1, 0, 0))
+        material = LineSegmentMaterial(color=(1, 0, 0), thickness=thickness, aa=True)
 
         super().__init__(geometry, material)
 

--- a/pygfx/helpers/_grid.py
+++ b/pygfx/helpers/_grid.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .. import Geometry, Line, LineThinSegmentMaterial
+from .. import Geometry, Line, LineSegmentMaterial
 from ..utils import Color
 
 DTYPE = "f4"
@@ -15,6 +15,7 @@ class GridHelper(Line):
         divisions=10,
         color1=(0.35, 0.35, 0.35, 1),
         color2=(0.1, 0.1, 0.1, 1),
+        thickness=1,
     ):
         assert isinstance(divisions, int)
         assert size > 0.0
@@ -39,6 +40,6 @@ class GridHelper(Line):
         geometry = Geometry(
             positions=positions.reshape((-1, 3)), colors=colors.reshape((-1, 4))
         )
-        material = LineThinSegmentMaterial(vertex_colors=True)
+        material = LineSegmentMaterial(vertex_colors=True, thickness=thickness, aa=True)
 
         super().__init__(geometry, material)

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -12,11 +12,18 @@ class LineMaterial(Material):
     )
 
     def __init__(
-        self, color=(1, 1, 1, 1), thickness=2.0, vertex_colors=False, map=None, **kwargs
+        self,
+        color=(1, 1, 1, 1),
+        thickness=2.0,
+        vertex_colors=False,
+        map=None,
+        aa=True,
+        **kwargs
     ):
         super().__init__(**kwargs)
 
         self.color = color
+        self.aa = aa
         self.map = map
         self.thickness = thickness
         self._vertex_colors = bool(vertex_colors)
@@ -31,6 +38,7 @@ class LineMaterial(Material):
 
     @property
     def color(self):
+        """The uniform color of the line."""
         return Color(self.uniform_buffer.data["color"])
 
     @color.setter
@@ -40,6 +48,18 @@ class LineMaterial(Material):
             self._bump_rev()  # rebuild pipeline if this becomes opaque/transparent
         self.uniform_buffer.data["color"] = color
         self.uniform_buffer.update_range(0, 1)
+
+    @property
+    def aa(self):
+        """Whether or not the line should be anti-aliased. Aliasing
+        gives prettier results, but may affect performance for very large
+        datasets. Default True.
+        """
+        return self._aa
+
+    @aa.setter
+    def aa(self, aa):
+        self._aa = bool(aa)
 
     @property
     def vertex_colors(self):

--- a/pygfx/renderers/wgpu/linerender.py
+++ b/pygfx/renderers/wgpu/linerender.py
@@ -117,14 +117,30 @@ def line_renderer(render_info):
         shader.define_binding(0, i, binding)
 
     # Determine in what render passes this objects must be rendered
-    # Note: the renderer use alpha for aa, so we are never opaque only.
     suggested_render_mask = 3
     if material.opacity < 1:
         suggested_render_mask = 2
     elif shader["color_mode"] == "uniform":
-        suggested_render_mask = 3 if material.color[3] >= 1 else 2
-    else:
-        suggested_render_mask = 3
+        if material.color[3] < 1:
+            suggested_render_mask = 2
+        elif material.aa:
+            suggested_render_mask = 3
+        else:
+            suggested_render_mask = 1
+    elif shader["color_mode"] == "vertex":
+        if shader["vertex_color_channels"] in (2, 4):
+            suggested_render_mask = 3
+        elif material.aa:
+            suggested_render_mask = 3
+        else:
+            suggested_render_mask = 1
+    elif shader["color_mode"] == "map":
+        if shader["colormap_nchannels"] in (2, 4):
+            suggested_render_mask = 3
+        elif material.aa:
+            suggested_render_mask = 3
+        else:
+            suggested_render_mask = 1
 
     # Done
     return [


### PR DESCRIPTION

Lines:
* [x] Lines compensate for thickness-loss due to aa (our lines were too thin).
* [x] Add an `aa` prop to the line material, so the additional anti-aliasing can be disabled.
* [x] Adjust `render_mask` accordingly (non-antialised lines don't need to render in the transparency pass).

Helpers:
* [x] All helpers use the normal lines instead of the thin ones. Closes #235.
* [x] The helpers have a `thickness` arg.
* [x] Renamed Axes' `length` arg to `size` for consistency with the other helpers.

Examples:
* [x] Adjusted examples where needed.
* [x] Made validation examples use extra thick lines, so we can be more forgiving at pixel mismatches at the edges.
* [x] Remove background in validation examples to avoid pixel mismatches.

<img width="616" alt="image" src="https://user-images.githubusercontent.com/3015475/154240589-8e89bdc7-19a5-42bc-aea9-518a20c8ab6b.png">
