### PR TITLE
Add 'before' argument to `WorldObject.add` method

### DIFF
--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -273,19 +273,28 @@ class WorldObject(ResourceContainer):
         """
         return tuple(self._children)
 
-    def add(self, *objects):
+    def add(self, *objects, before=None):
         """Adds object as child of this object. Any number of
         objects may be added. Any current parent on an object passed
         in here will be removed, since an object can have at most one
         parent.
+        If ``before`` argument is given (and present in children), then
+        the items are inserted before the given element.
         """
+        idx = len(self._children)
+        if before:
+            try:
+                idx = self._children.index(before)
+            except ValueError:
+                pass
         for obj in objects:
             # orphan if needed
             if obj._parent_ref is not None:
                 obj._parent_ref().remove(obj)
             # attach to scene graph
             obj._parent_ref = weakref.ref(self)
-            self._children.append(obj)
+            self._children.insert(idx, obj)
+            idx += 1
             # flag world matrix as dirty
             obj._matrix_world_dirty = True
         return self

--- a/tests/objects/test_world_object.py
+++ b/tests/objects/test_world_object.py
@@ -149,3 +149,34 @@ def test_no_cyclic_references():
     del child
 
     assert not grandchild_ref()
+
+
+def test_adjust_children_order():
+    root = WorldObject()
+    child1 = WorldObject()
+    child2 = WorldObject()
+
+    root.add(child1, child2)
+
+    assert root.children == (child1, child2)
+
+    root.add(child2, before=child1)
+
+    assert root.children == (child2, child1)
+
+    child3 = WorldObject()
+    root.add(child3, child1, before=child2)
+
+    assert root.children == (child3, child1, child2)
+
+    # Assert that nothing happens when adding the same element
+    # before itself
+    root.add(child1, before=child1)
+    assert root.children == (child3, child1, child2)
+
+    non_child = WorldObject()
+
+    # Append item at end when the `before` parameter
+    # is not in children
+    root.add(child1, before=non_child)
+    assert root.children == (child3, child2, child1)


### PR DESCRIPTION
This allows for inserting objects at specific positions in the children array. This can be useful in cases where the scene tree is dynamically rendered with a reactive library/framework (such as [pygui](https://github.com/fork-tongue/pygui) 😉).