### PR TITLE
WIP: fix subplots  v1

### DIFF
--- a/examples/helpers_gizmo.py
+++ b/examples/helpers_gizmo.py
@@ -31,9 +31,10 @@ gizmo.add_default_event_handlers(renderer, camera)
 def animate():
     # We render the scene, and then the gizmo on top,
     # as an overlay, so that it's always on top.
+    w, h = canvas.get_logical_size()
     controls.update_camera(camera)
-    renderer.render(scene, camera, flush=False)
-    renderer.render(gizmo, camera, clear_color=False)
+    renderer.render(scene, camera, flush=False, viewport=(w / 2, 0, w / 2, h))
+    renderer.render(gizmo, camera, clear_color=False, viewport=(w / 2, 0, w / 2, h))
 
 
 if __name__ == "__main__":

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -1,5 +1,5 @@
 """
-Example showing orbit camera controls.
+Example showing pan-zoom camera controls.
 """
 
 import imageio

--- a/pygfx/renderers/wgpu/_flusher.py
+++ b/pygfx/renderers/wgpu/_flusher.py
@@ -95,7 +95,9 @@ class RenderFlusher:
             usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST,
         )
 
-    def render(self, src_color_tex, src_depth_tex, dst_color_tex, dst_format):
+    def render(
+        self, physical_viewport, src_color_tex, src_depth_tex, dst_color_tex, dst_format
+    ):
         """Render the (internal) result of the renderer into a texture."""
         # NOTE: cannot actually use src_depth_tex as a sample texture (BindingCollision)
         assert src_depth_tex is None
@@ -112,7 +114,7 @@ class RenderFlusher:
             self._pipelines[dst_format] = hash, bind_group, render_pipeline
 
         self._update_uniforms(src_color_tex, dst_color_tex)
-        return self._render(dst_color_tex, dst_format)
+        return self._render(physical_viewport, dst_color_tex, dst_format)
 
     def _update_uniforms(self, src_color_tex, dst_color_tex):
         # Get factor between texture sizes
@@ -134,7 +136,7 @@ class RenderFlusher:
         self._uniform_data["sigma"] = sigma
         self._uniform_data["support"] = support
 
-    def _render(self, dst_color_tex, dst_format):
+    def _render(self, physical_viewport, dst_color_tex, dst_format):
         device = self._device
         _, bind_group, render_pipeline = self._pipelines[dst_format]
 
@@ -159,6 +161,7 @@ class RenderFlusher:
             ],
             depth_stencil_attachment=None,
         )
+        render_pass.set_viewport(*physical_viewport)
         render_pass.set_pipeline(render_pipeline)
         render_pass.set_bind_group(0, bind_group, [], 0, 99)
         render_pass.draw(4, 1)


### PR DESCRIPTION
This is an attempt to fix #266, but I'm not entirely happy with it (yet?). Notes to self:

* The whole color clearing must be changed. Clearing is applied to the total area, so the flusher would need to be adjusted to the fact that the renderer represents a sub-rectangle of the canvas.
* The required memory can be larger because for each viewport you need a new renderer + stack of render textures. 
* The viewport is now a property. To make it flexible, e.g. take up a percentage of space, and include margins, you'd need a DSL to express that.