### PR TITLE
WIP: fix subplots  v2

### DIFF
--- a/examples/helpers_gizmo.py
+++ b/examples/helpers_gizmo.py
@@ -32,8 +32,10 @@ def animate():
     # We render the scene, and then the gizmo on top,
     # as an overlay, so that it's always on top.
     controls.update_camera(camera)
-    renderer.render(scene, camera, flush=False)
-    renderer.render(gizmo, camera, clear_color=False)
+    w, h = canvas.get_logical_size()
+    viewport = w / 2, 0, w / 2, h
+    renderer.render(scene, camera, flush=False, viewport=viewport)
+    renderer.render(gizmo, camera, clear_color=False, viewport=viewport)
 
 
 if __name__ == "__main__":

--- a/pygfx/cameras/_base.py
+++ b/pygfx/cameras/_base.py
@@ -23,13 +23,13 @@ class Camera(WorldObject):
     def __init__(self):
         super().__init__()
 
+        self._viewport = 0, 0, 0, 0
         self.matrix_world_inverse = Matrix4()
         self.projection_matrix = Matrix4()
         self.projection_matrix_inverse = Matrix4()
 
-    def set_view_size(self, width, height):
-        # In logical pixels
-        pass
+    def set_view_size(self, viewport):
+        self._viewport = viewport  # Set by renderer, in logical pixels
 
     def update_matrix_world(self, *args, **kwargs):
         super().update_matrix_world(*args, **kwargs)
@@ -100,17 +100,9 @@ class ScreenCoordsCamera(Camera):
     as in NDC (0 to 1).
     """
 
-    def __init__(self):
-        super().__init__()
-        self._width = 1
-        self._height = 1
-
-    def set_view_size(self, width, height):
-        self._width = width
-        self._height = height
-
     def update_projection_matrix(self):
-        sx, sy, sz = 2 / self._width, 2 / self._height, 1
+        width, height = self._viewport[2], self._viewport[3]
+        sx, sy, sz = 2 / width, 2 / height, 1
         dx, dy, dz = -1, -1, 0
         m = sx, 0, 0, dx, 0, sy, 0, dy, 0, 0, sz, dz, 0, 0, 0, 1
         self.projection_matrix.set(*m)

--- a/pygfx/cameras/_orthographic.py
+++ b/pygfx/cameras/_orthographic.py
@@ -26,7 +26,7 @@ class OrthographicCamera(Camera):
         assert self.near < self.far
         self.zoom = 1
         self.maintain_aspect = True
-        self.set_view_size(1, 1)
+        self.set_view_size((0, 0, 1, 1))
         self.update_projection_matrix()
 
     def __repr__(self) -> str:
@@ -40,7 +40,9 @@ class OrthographicCamera(Camera):
         flips = int(self.scale.x < 0) + int(self.scale.y < 0) + int(self.scale.z < 0)
         return bool(flips % 2)
 
-    def set_view_size(self, width, height):
+    def set_view_size(self, viewport):
+        super().set_view_size(viewport)
+        width, height = viewport[2], viewport[3]
         self._view_aspect = width / height
         # The reference view plane is scaled with the zoom factor
         width = self.width / self.zoom

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -37,7 +37,9 @@ class PerspectiveCamera(Camera):
         flips = int(self.scale.x < 0) + int(self.scale.y < 0) + int(self.scale.z < 0)
         return bool(flips % 2)
 
-    def set_view_size(self, width, height):
+    def set_view_size(self, viewport):
+        super().set_view_size(viewport)
+        width, height = viewport[2], viewport[3]
         self._view_aspect = width / height
 
     def update_projection_matrix(self):

--- a/pygfx/helpers/_gizmo.py
+++ b/pygfx/helpers/_gizmo.py
@@ -323,7 +323,10 @@ class TransformGizmo(WorldObject):
         """
 
         camera = self._camera
-        canvas_size = self._canvas.get_logical_size()
+        canvas_size = (
+            camera._viewport[2],
+            camera._viewport[3],
+        )  # self._canvas.get_logical_size()
         world_pos = self._object_to_control.position
         ndc_pos = world_pos.clone().project(camera)
 
@@ -397,7 +400,10 @@ class TransformGizmo(WorldObject):
             return
 
         camera = self._camera
-        canvas_size = self._canvas.get_logical_size()
+        canvas_size = (
+            camera._viewport[2],
+            camera._viewport[3],
+        )  # self._canvas.get_logical_size()
         world_pos = self._object_to_control.position
         ndc_pos = world_pos.clone().project(camera)
 
@@ -603,7 +609,10 @@ class TransformGizmo(WorldObject):
             event.y - self._ref["event_pos"][1],
             0,
         )
-        canvas_size = self._canvas.get_logical_size()
+        canvas_size = (
+            self._camera._viewport[2],
+            self._camera._viewport[3],
+        )  # self._canvas.get_logical_size()
         ndc_moved = screen_moved.clone().multiply(
             Vector3(2 / canvas_size[0], -2 / canvas_size[1], 0)
         )


### PR DESCRIPTION
This is another attempt to fix #266. This time, the renderer sets the viewport on the camera, and other components can use that. Note that the renderer already set the viewport size for the camera (so the camera could adjust to the aspect ratio). Now it can also adjust for the offset.

Todo:
* [ ] Also update orbit controls.
* [ ] Revert examples that I changed for testing.
* [ ] Give camera a simple API so that controller et al. don't have to use the private `_viewport` prop.
* [ ] Give renderer a `request_draw` method.
* [ ] Remove `canvas` from the args of the methods that register default events (controllers and gizmo).