### PR TITLE
Fix examples that were still using render(viewport=..)

### DIFF
--- a/examples/clipping_planes.py
+++ b/examples/clipping_planes.py
@@ -47,8 +47,8 @@ def animate():
     controls.update_camera(camera)
 
     w, h = canvas.get_logical_size()
-    renderer.render(scene1, camera, flush=False, viewport=(0, 0, w / 2, h))
-    renderer.render(scene2, camera, flush=False, viewport=(w / 2, 0, w / 2, h))
+    renderer.render(scene1, camera, flush=False, rect=(0, 0, w / 2, h))
+    renderer.render(scene2, camera, flush=False, rect=(w / 2, 0, w / 2, h))
     renderer.flush()
 
     canvas.request_draw()

--- a/examples/validate_culling.py
+++ b/examples/validate_culling.py
@@ -43,13 +43,13 @@ camera = gfx.OrthographicCamera(6, 4)
 def animate():
     # Render top row
     camera.scale.z = 1
-    renderer.render(scene, camera, viewport=(0, 0, 600, 300), flush=False)
+    renderer.render(scene, camera, rect=(0, 0, 600, 300), flush=False)
     # Render same scene in bottom row. The camera's z scale is negative.
     # This means it looks backwards, but more importantly, it means that the
     # winding is affected. The result should still look correct because we
     # take this effect into account in the mesh shader.
     camera.scale.z = -1
-    renderer.render(scene, camera, viewport=(0, 300, 600, 300))
+    renderer.render(scene, camera, rect=(0, 300, 600, 300))
 
 
 canvas.request_draw(animate)

--- a/examples/validate_volume.py
+++ b/examples/validate_volume.py
@@ -60,10 +60,10 @@ camera.position.x = 3
 def animate():
     w, h = canvas.get_logical_size()
     renderer.render(
-        scene1, camera, viewport=(0.0 * w, -0.4 * h, 0.7 * w, 1.4 * h), flush=False
+        scene1, camera, rect=(0.0 * w, -0.4 * h, 0.7 * w, 1.4 * h), flush=False
     )
     renderer.render(
-        scene2, camera, viewport=(0.5 * w, -0.4 * h, 0.7 * w, 1.4 * h), flush=False
+        scene2, camera, rect=(0.5 * w, -0.4 * h, 0.7 * w, 1.4 * h), flush=False
     )
     renderer.flush()
 


### PR DESCRIPTION
The `viewport` arg still works for now, but produces a deprecation warning.