### PR TITLE
example with video or image updates in subplots with pan and zoom

### DIFF
--- a/examples/scene_subplots_video.py
+++ b/examples/scene_subplots_video.py
@@ -1,5 +1,6 @@
 """
-An example combining `synced_video.py` with subplots
+An example combining `synced_video.py` with subplots.
+Double click to re-center the images.
 """
 
 from wgpu.gui.auto import WgpuCanvas, run
@@ -72,35 +73,15 @@ def layout(event=None):
     viewports[3].rect = w / 2 + 5, h / 2 + 5, w2, h2
 
 
-reset_cameras = False
-
-
 def animate():
     for img in images:
         # create new image data
         img.geometry.grid.data[:] = np.random.rand(*dims).astype(np.float32) * 255
         img.geometry.grid.update_range((0, 0, 0), img.geometry.grid.size)
 
-    global reset_cameras
-
-    # reset the cameras if `reset_camera` is set to True
-    if reset_cameras:
-        # this should work in the future
-        # for camera, image in zip(cameras, images):
-        #     camera.show_object(image)
-
-        # until a way to center the controller in the scene is implemented
-        for camera, controller, cntrl_default in zip(
-            cameras, controllers, cntl_defaults
-        ):
-            controller.load_state(cntrl_default)
-            controller.update_camera(camera)
-
-        reset_cameras = False
-    else:
-        for camera, controller in zip(cameras, controllers):
-            # if not reset, update with the pan & zoom params
-            controller.update_camera(camera)
+    for camera, controller in zip(cameras, controllers):
+        # update with the pan & zoom params
+        controller.update_camera(camera)
 
     # render the viewports
     for viewport, s, c in zip(viewports, scenes, cameras):
@@ -108,6 +89,15 @@ def animate():
 
     renderer.flush()
     canvas.request_draw()
+
+
+def center_objects(ev):
+    for con, cam, img in zip(controllers, cameras, images):
+        con.show_object(cam, img)
+        con.zoom(1.3)
+
+
+renderer.add_event_handler(center_objects, "double_click")
 
 
 layout()

--- a/examples/scene_subplots_video.py
+++ b/examples/scene_subplots_video.py
@@ -62,18 +62,18 @@ for i in range(4):
     cntl_default["target"] = controller.target.clone()
     cntl_defaults.append(cntl_default)
 
-w_div = 2
-h_div = 2
 
-
-# 2x2 arrangement for the viewports
-def produce_rect(w, h):
-    return [
-        (0, 0, w / w_div, h / h_div),
-        (w / w_div, 0, w / w_div, h / h_div),
-        (0, h / h_div, w / w_div, h / h_div),
-        (w / w_div, h / h_div, w / w_div, h / h_div),
-    ]
+@renderer.add_event_handler("resize")
+def layout(event=None):
+    """
+    Update the viewports when the canvas is resized
+    """
+    w, h = renderer.logical_size
+    w2, h2 = w / 2, h / 2
+    viewports[0].rect = 10, 10, w2, h2
+    viewports[1].rect = w / 2 + 5, 10, w2, h2
+    viewports[2].rect = 10, h / 2 + 5, w2, h2
+    viewports[3].rect = w / 2 + 5, h / 2 + 5, w2, h2
 
 
 reset_cameras = False
@@ -86,45 +86,45 @@ def animate():
         img.geometry.grid.update_range((0, 0, 0), img.geometry.grid.size)
         # img.geometry.grid = gfx.Texture(np.random.rand(*dims).astype(np.float32) * 255, dim=2)
 
-    w, h = canvas.get_logical_size()
-
-    rects = produce_rect(w, h)
-
     global reset_cameras
 
     # reset the cameras if `reset_camera` is set to True
     if reset_cameras:
-        for camera, controller, cntrl_default in zip(
-            cameras, controllers, cntl_defaults
-        ):
-            pan_delta = (
-                cntl_default["target"].clone().sub(camera.position)
-            )  # find the dx, dy
-            controller.pan(pan_delta)  # pan to initial state
+        for camera, image in zip(cameras, images):
+            camera.show_object(image)
 
-            # set zoom and distance to initial state
-            controller.zoom_value = cntl_default["zoom_value"]
-            controller.distance = cntl_default["distance"]
-
-            # update camera with the new params
-            controller.update_camera(camera)
+        # for camera, controller, cntrl_default in zip(
+        #     cameras, controllers, cntl_defaults
+        # ):
+        #     pan_delta = (
+        #         cntl_default["target"].clone().sub(camera.position)
+        #     )  # find the dx, dy
+        #     controller.pan(pan_delta)  # pan to initial state
+        #
+        #     # set zoom and distance to initial state
+        #     controller.zoom_value = cntl_default["zoom_value"]
+        #     controller.distance = cntl_default["distance"]
+        #
+        #     # update camera with the new params
+        #     controller.update_camera(camera)
 
         reset_cameras = False
     else:
-        for camera, controller, cntrl_default in zip(
-            cameras, controllers, cntl_defaults
+        for camera, controller in zip(
+            cameras, controllers
         ):
             # if not reset, update with the pan & zoom params
             controller.update_camera(camera)
 
     # render the viewports
-    for viewport, s, c, r in zip(viewports, scenes, cameras, rects):
-        viewport.rect = r
+    for viewport, s, c in zip(viewports, scenes, cameras):
         viewport.render(s, c)
 
     renderer.flush()
     canvas.request_draw()
 
+
+layout()
 
 if __name__ == "__main__":
     canvas.request_draw(animate)

--- a/examples/scene_subplots_video.py
+++ b/examples/scene_subplots_video.py
@@ -1,0 +1,144 @@
+"""
+An example combining `synced_video.py` with subplots
+"""
+
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+import numpy as np
+
+canvas = WgpuCanvas()
+renderer = gfx.renderers.WgpuRenderer(canvas)
+
+dims = (512, 512)  # image dimensions
+# default cam position
+center_cam_pos = (256, 256, 0)
+
+# colormaps for each of the 4 images
+cmaps = \
+    [
+        gfx.cm.inferno,
+        gfx.cm.plasma,
+        gfx.cm.magma,
+        gfx.cm.viridis
+    ]
+
+# lists of everything necessary to make this plot
+scenes = list()
+cameras = list()
+images = list()
+controllers = list()
+cntl_defaults = list()
+viewports = list()
+
+for i in range(4):
+    # create scene for this subplot
+    scene = gfx.Scene()
+    scenes.append(scene)
+
+    # create Image WorldObject
+    img = gfx.Image(
+        gfx.Geometry(grid=gfx.Texture(np.random.rand(*dims).astype(np.float32) * 255, dim=2)),
+        gfx.ImageBasicMaterial(clim=(0, 255), map=cmaps[i])
+    )
+
+    # add image to list
+    images.append(img)
+    scene.add(img)
+
+    # create camera, set default position, add to list
+    camera = gfx.OrthographicCamera(*dims)
+    camera.position.set(*center_cam_pos)
+    cameras.append(camera)
+
+    # create viewport for this image
+    viewport = gfx.Viewport(renderer)
+    viewports.append(viewport)
+
+    # controller for pan & zoom
+    controller = gfx.PanZoomController(camera.position.clone())
+    controller.add_default_event_handlers(viewport, camera)
+    controllers.append(controller)
+
+    # get the initial controller params so the camera can be reset later
+    cntl_default = dict()
+    cntl_default['distance'] = controller.distance
+    cntl_default['zoom_value'] = controller.zoom_value
+    cntl_default['target'] = controller.target.clone()
+    cntl_defaults.append(cntl_default)
+
+w_div = 2
+h_div = 2
+
+
+# 2x2 arrangement for the viewports
+def produce_rect(w, h):
+    return [
+        (0, 0, w / w_div, h / h_div),
+        (w / w_div, 0, w / w_div, h / h_div),
+        (0, h / h_div, w / w_div, h / h_div),
+        (w / w_div, h / h_div, w / w_div, h / h_div)
+    ]
+
+
+reset_cameras = False
+
+
+def animate():
+    for img in images:
+        # create new image data
+        img.geometry.grid.data[:] = np.random.rand(*dims).astype(np.float32) * 255
+        img.geometry.grid.update_range((0, 0, 0), img.geometry.grid.size)
+        # img.geometry.grid = gfx.Texture(np.random.rand(*dims).astype(np.float32) * 255, dim=2)
+
+    w, h = canvas.get_logical_size()
+
+    rects = produce_rect(w, h)
+
+    global reset_cameras
+
+    # reset the cameras if `reset_camera` is set to True
+    if reset_cameras:
+        for camera, controller, cntrl_default in zip(cameras, controllers, cntl_defaults):
+            pan_delta = cntl_default['target'].clone().sub(camera.position)  # find the dx, dy
+            controller.pan(pan_delta)  # pan to initial state
+
+            # set zoom and distance to initial state
+            controller.zoom_value = cntl_default['zoom_value']
+            controller.distance = cntl_default['distance']
+
+            # update camera with the new params
+            controller.update_camera(camera)
+
+        reset_cameras = False
+    else:
+        for camera, controller, cntrl_default in zip(cameras, controllers, cntl_defaults):
+            # if not reset, update with the pan & zoom params
+            controller.update_camera(camera)
+
+    # render the viewports
+    for viewport, s, c, r in zip(viewports, scenes, cameras, rects):
+        viewport.rect = r
+        viewport.render(s, c)
+
+    renderer.flush()
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    run()
+
+# Use with a Qt app or `jupyter_rfb` to utilize the `reset_camera`:
+# from ipywidgets import Button
+#
+# reset_button = Button(description="Reset View")
+#
+# def on_button_clicked(b):
+#     global reset_cameras
+#     reset_cameras = True
+#
+# reset_button.on_click(on_button_clicked)
+#
+# reset_button
+
+

--- a/examples/scene_subplots_video.py
+++ b/examples/scene_subplots_video.py
@@ -56,7 +56,7 @@ for i in range(4):
     controller.add_default_event_handlers(viewport, camera)
     controllers.append(controller)
 
-    # # get the initial controller params so the camera can be reset later
+    # get the initial controller params so the camera can be reset later
     cntl_defaults.append(controller.save_state())
 
 
@@ -91,7 +91,7 @@ def animate():
     canvas.request_draw()
 
 
-def center_objects(ev):
+def center_objects(ev):  # center objects upon double-click event
     for con, cam, img in zip(controllers, cameras, images):
         con.show_object(cam, img)
         con.zoom(1.3)
@@ -106,16 +106,3 @@ layout()
 if __name__ == "__main__":
     canvas.request_draw(animate)
     run()
-
-# Use with a Qt app or `jupyter_rfb` to utilize the `reset_camera`:
-# from ipywidgets import Button
-#
-# reset_button = Button(description="Reset View")
-#
-# def on_button_clicked(b):
-#     global reset_cameras
-#     reset_cameras = True
-#
-# reset_button.on_click(on_button_clicked)
-#
-# reset_button

--- a/examples/scene_subplots_video.py
+++ b/examples/scene_subplots_video.py
@@ -14,13 +14,7 @@ dims = (512, 512)  # image dimensions
 center_cam_pos = (256, 256, 0)
 
 # colormaps for each of the 4 images
-cmaps = \
-    [
-        gfx.cm.inferno,
-        gfx.cm.plasma,
-        gfx.cm.magma,
-        gfx.cm.viridis
-    ]
+cmaps = [gfx.cm.inferno, gfx.cm.plasma, gfx.cm.magma, gfx.cm.viridis]
 
 # lists of everything necessary to make this plot
 scenes = list()
@@ -37,8 +31,10 @@ for i in range(4):
 
     # create Image WorldObject
     img = gfx.Image(
-        gfx.Geometry(grid=gfx.Texture(np.random.rand(*dims).astype(np.float32) * 255, dim=2)),
-        gfx.ImageBasicMaterial(clim=(0, 255), map=cmaps[i])
+        gfx.Geometry(
+            grid=gfx.Texture(np.random.rand(*dims).astype(np.float32) * 255, dim=2)
+        ),
+        gfx.ImageBasicMaterial(clim=(0, 255), map=cmaps[i]),
     )
 
     # add image to list
@@ -61,9 +57,9 @@ for i in range(4):
 
     # get the initial controller params so the camera can be reset later
     cntl_default = dict()
-    cntl_default['distance'] = controller.distance
-    cntl_default['zoom_value'] = controller.zoom_value
-    cntl_default['target'] = controller.target.clone()
+    cntl_default["distance"] = controller.distance
+    cntl_default["zoom_value"] = controller.zoom_value
+    cntl_default["target"] = controller.target.clone()
     cntl_defaults.append(cntl_default)
 
 w_div = 2
@@ -76,7 +72,7 @@ def produce_rect(w, h):
         (0, 0, w / w_div, h / h_div),
         (w / w_div, 0, w / w_div, h / h_div),
         (0, h / h_div, w / w_div, h / h_div),
-        (w / w_div, h / h_div, w / w_div, h / h_div)
+        (w / w_div, h / h_div, w / w_div, h / h_div),
     ]
 
 
@@ -98,20 +94,26 @@ def animate():
 
     # reset the cameras if `reset_camera` is set to True
     if reset_cameras:
-        for camera, controller, cntrl_default in zip(cameras, controllers, cntl_defaults):
-            pan_delta = cntl_default['target'].clone().sub(camera.position)  # find the dx, dy
+        for camera, controller, cntrl_default in zip(
+            cameras, controllers, cntl_defaults
+        ):
+            pan_delta = (
+                cntl_default["target"].clone().sub(camera.position)
+            )  # find the dx, dy
             controller.pan(pan_delta)  # pan to initial state
 
             # set zoom and distance to initial state
-            controller.zoom_value = cntl_default['zoom_value']
-            controller.distance = cntl_default['distance']
+            controller.zoom_value = cntl_default["zoom_value"]
+            controller.distance = cntl_default["distance"]
 
             # update camera with the new params
             controller.update_camera(camera)
 
         reset_cameras = False
     else:
-        for camera, controller, cntrl_default in zip(cameras, controllers, cntl_defaults):
+        for camera, controller, cntrl_default in zip(
+            cameras, controllers, cntl_defaults
+        ):
             # if not reset, update with the pan & zoom params
             controller.update_camera(camera)
 
@@ -140,5 +142,3 @@ if __name__ == "__main__":
 # reset_button.on_click(on_button_clicked)
 #
 # reset_button
-
-

--- a/examples/scene_subplots_video.py
+++ b/examples/scene_subplots_video.py
@@ -55,12 +55,8 @@ for i in range(4):
     controller.add_default_event_handlers(viewport, camera)
     controllers.append(controller)
 
-    # get the initial controller params so the camera can be reset later
-    cntl_default = dict()
-    cntl_default["distance"] = controller.distance
-    cntl_default["zoom_value"] = controller.zoom_value
-    cntl_default["target"] = controller.target.clone()
-    cntl_defaults.append(cntl_default)
+    # # get the initial controller params so the camera can be reset later
+    cntl_defaults.append(controller.save_state())
 
 
 @renderer.add_event_handler("resize")
@@ -84,35 +80,25 @@ def animate():
         # create new image data
         img.geometry.grid.data[:] = np.random.rand(*dims).astype(np.float32) * 255
         img.geometry.grid.update_range((0, 0, 0), img.geometry.grid.size)
-        # img.geometry.grid = gfx.Texture(np.random.rand(*dims).astype(np.float32) * 255, dim=2)
 
     global reset_cameras
 
     # reset the cameras if `reset_camera` is set to True
     if reset_cameras:
-        for camera, image in zip(cameras, images):
-            camera.show_object(image)
+        # this should work in the future
+        # for camera, image in zip(cameras, images):
+        #     camera.show_object(image)
 
-        # for camera, controller, cntrl_default in zip(
-        #     cameras, controllers, cntl_defaults
-        # ):
-        #     pan_delta = (
-        #         cntl_default["target"].clone().sub(camera.position)
-        #     )  # find the dx, dy
-        #     controller.pan(pan_delta)  # pan to initial state
-        #
-        #     # set zoom and distance to initial state
-        #     controller.zoom_value = cntl_default["zoom_value"]
-        #     controller.distance = cntl_default["distance"]
-        #
-        #     # update camera with the new params
-        #     controller.update_camera(camera)
+        # until a way to center the controller in the scene is implemented
+        for camera, controller, cntrl_default in zip(
+            cameras, controllers, cntl_defaults
+        ):
+            controller.load_state(cntrl_default)
+            controller.update_camera(camera)
 
         reset_cameras = False
     else:
-        for camera, controller in zip(
-            cameras, controllers
-        ):
+        for camera, controller in zip(cameras, controllers):
             # if not reset, update with the pan & zoom params
             controller.update_camera(camera)
 
@@ -125,6 +111,7 @@ def animate():
 
 
 layout()
+
 
 if __name__ == "__main__":
     canvas.request_draw(animate)


### PR DESCRIPTION
This is a more complex example that kind of combines `synced_video.py` with subplots. Each view can be panned and zoom independently. The pan & zoom can be reset.

If there's not a method to reset `PanZoomController` I think I can easily add one? It would make this example much easier.

Demo in a notebook with `jupyter_rfb`:

https://user-images.githubusercontent.com/9403332/163316431-92b95380-47b6-4fae-8390-d16444579da3.mp4
