### PR TITLE
Pin imageio-ffmpeg to avoid bug in new version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,6 +12,6 @@ imageio
 # examples
 PySide6
 imageio
-imageio-ffmpeg
+imageio-ffmpeg==0.4.5
 scikit-image
 trimesh


### PR DESCRIPTION
This bug is causing CI to fail on the geometry_plane example, and therefore it's blocking all PRs.

See https://github.com/imageio/imageio-ffmpeg/issues/69