### PR TITLE
Pointer_enter and pointer_leave events v1

### DIFF
--- a/examples/events.py
+++ b/examples/events.py
@@ -7,6 +7,7 @@ the items from that group (because the group has a double-click
 event handler).
 """
 
+from functools import partial
 from random import randint, random
 
 from wgpu.gui.auto import WgpuCanvas, run
@@ -27,47 +28,53 @@ scene = gfx.Scene()
 geometry = gfx.box_geometry(40, 40, 40)
 default_material = gfx.MeshPhongMaterial()
 selected_material = gfx.MeshPhongMaterial(color="#FF0000")
-hovered_material = gfx.MeshPhongMaterial(color="#FFAA00")
+hover_material = gfx.MeshPhongMaterial(color="#FFAA00")
 
 selected_obj = None
 
 
-def select(obj):
+def set_material(material, obj):
+    if isinstance(obj, gfx.Mesh):
+        obj.material = material
+
+
+def select(event):
+    # when this event handler is invoked on non-leaf nodes of the
+    # scene graph, event.target will still point to the leaf node that
+    # originally triggered the event, so we use event.current_target
+    # to get a reference to the node that is currently handling
+    # the event, which can be a Mesh, a Group or None (the event root)
+    obj = event.current_target
+
+    # prevent propagation so we handle this event only at one
+    # level in the hierarchy
+    event.stop_propagation()
+
+    # clear selection
     global selected_obj
     if selected_obj:
-
-        def apply_default_mat(obj):
-            if isinstance(obj, gfx.Mesh):
-                obj.material = default_material
-
-        selected_obj.traverse(apply_default_mat)
+        selected_obj.traverse(partial(set_material, default_material))
         selected_obj = None
 
+    # if the background was clicked, we're done
+    if isinstance(obj, gfx.Renderer):
+        return
+
+    # set selection (group or mesh)
     selected_obj = obj
-    if selected_obj:
-
-        def apply_selected_mat(obj):
-            if isinstance(obj, gfx.Mesh):
-                obj.material = selected_material
-
-        selected_obj.traverse(apply_selected_mat)
+    selected_obj.traverse(partial(set_material, selected_material))
 
 
 def hover(event):
-    if (
-        event.type == gfx.EventType.POINTER_LEAVE
-        and event.target.material is not selected_material
-    ):
-        event.target.material = default_material
-    elif (
-        event.type == gfx.EventType.POINTER_ENTER
-        and event.target.material is not selected_material
-    ):
-        event.target.material = hovered_material
+    obj = event.target
 
+    if obj.material is selected_material:
+        return
 
-def select_obj(event):
-    select(event.target)
+    obj.material = {
+        "pointer_leave": default_material,
+        "pointer_enter": hover_material,
+    }[event.type]
 
 
 def random_rotation():
@@ -90,13 +97,13 @@ def animate():
 
 
 if __name__ == "__main__":
+    renderer.add_event_handler(select, "click")
+
     # Build up scene
     for _ in range(4):
         group = gfx.Group()
         group.random_rotation = random_rotation()
-        group.add_event_handler(
-            lambda event: select(event.current_target), "double_click"
-        )
+        group.add_event_handler(select, "double_click")
         scene.add(group)
 
         for _ in range(10):
@@ -105,7 +112,7 @@ if __name__ == "__main__":
             cube.position.y = randint(-200, 200)
             cube.position.z = randint(-200, 200)
             cube.random_rotation = random_rotation()
-            cube.add_event_handler(select_obj, "click")
+            cube.add_event_handler(select, "click")
             cube.add_event_handler(hover, "pointer_enter", "pointer_leave")
             group.add(cube)
 

--- a/examples/events.py
+++ b/examples/events.py
@@ -54,9 +54,15 @@ def select(obj):
 
 
 def hover(event):
-    if event.type == gfx.EventType.POINTER_LEAVE and event.target is not selected_obj:
+    if (
+        event.type == gfx.EventType.POINTER_LEAVE
+        and event.target.material is not selected_material
+    ):
         event.target.material = default_material
-    elif event.type == gfx.EventType.POINTER_ENTER and event.target is not selected_obj:
+    elif (
+        event.type == gfx.EventType.POINTER_ENTER
+        and event.target.material is not selected_material
+    ):
         event.target.material = hovered_material
 
 

--- a/examples/events.py
+++ b/examples/events.py
@@ -30,7 +30,6 @@ selected_material = gfx.MeshPhongMaterial(color="#FF0000")
 hovered_material = gfx.MeshPhongMaterial(color="#FFAA00")
 
 selected_obj = None
-hovered_obj = None
 
 
 def select(obj):
@@ -54,15 +53,11 @@ def select(obj):
         selected_obj.traverse(apply_selected_mat)
 
 
-def hover(obj):
-    global hovered_obj
-    if hovered_obj:
-        if hovered_obj.material is not selected_material:
-            hovered_obj.material = default_material
-            hovered_obj = None
-    hovered_obj = obj
-    if hovered_obj and hovered_obj.material is not selected_material:
-        hovered_obj.material = hovered_material
+def hover(event):
+    if event.type == gfx.EventType.POINTER_LEAVE and event.target is not selected_obj:
+        event.target.material = default_material
+    elif event.type == gfx.EventType.POINTER_ENTER and event.target is not selected_obj:
+        event.target.material = hovered_material
 
 
 def select_obj(event):
@@ -105,7 +100,7 @@ if __name__ == "__main__":
             cube.position.z = randint(-200, 200)
             cube.random_rotation = random_rotation()
             cube.add_event_handler(select_obj, "click")
-            cube.add_event_handler(lambda event: hover(event.target), "pointer_move")
+            cube.add_event_handler(hover, "pointer_enter", "pointer_leave")
             group.add(cube)
 
     canvas.request_draw(animate)

--- a/pygfx/objects/_events.py
+++ b/pygfx/objects/_events.py
@@ -347,12 +347,12 @@ class RootEventHandler(EventTarget):
             previous_target = (previous_target_ref and previous_target_ref()) or None
             # Get the current target for this pointer (if any)
             new_target = event.target
-            # Update the current target for this pointer
-            RootEventHandler.target_tracker[pointer_id] = (
-                new_target and ref(new_target)
-            ) or None
             # Check if the target has changed since the previous move event
             if previous_target is not new_target or first_move:
+                # Update the current target for this pointer
+                RootEventHandler.target_tracker[pointer_id] = (
+                    new_target and ref(new_target)
+                ) or None
                 if not first_move:
                     # Dispatch a `pointer_leave` event for the previous target
                     ev = event.copy(type="pointer_leave")

--- a/pygfx/objects/_events.py
+++ b/pygfx/objects/_events.py
@@ -18,6 +18,8 @@ class EventType(str, Enum):
     POINTER_DOWN = "pointer_down"
     POINTER_MOVE = "pointer_move"
     POINTER_UP = "pointer_up"
+    POINTER_ENTER = "pointer_enter"
+    POINTER_LEAVE = "pointer_leave"
     CLICK = "click"
     DOUBLE_CLICK = "double_click"
     # Wheel

--- a/pygfx/objects/_events.py
+++ b/pygfx/objects/_events.py
@@ -355,9 +355,7 @@ class RootEventHandler(EventTarget):
                 ) or None
                 if not first_move:
                     # Dispatch a `pointer_leave` event for the previous target
-                    ev = event.copy(type="pointer_leave")
-                    # Retarget to the previous target
-                    ev._retarget(previous_target)
+                    ev = event.copy(type="pointer_leave", target=previous_target)
                     self.dispatch_event(ev)
                 # Dispatch a `pointer_enter` event for the new target
                 ev = event.copy(type="pointer_enter")

--- a/tests/objects/test_events.py
+++ b/tests/objects/test_events.py
@@ -227,7 +227,7 @@ def test_pointer_event_copy():
         cancelled=True,
     )
 
-    other = event.copy("click", 5)
+    other = event.copy(type="click", clicks=5)
 
     for attr in [
         attr


### PR DESCRIPTION
Closes #262

* Make event.copy more generic 
* Add support for pointer_enter and pointer_leave events by tracking event targets
* Refactor events example
  * Leverage pointer_enter and pointer_leave events for global-less hover materials
  * Add option to click background to deselect
  * Showcase the power of the event system a little more, and add some code comments to explain

<img width=250 src='https://user-images.githubusercontent.com/1882046/163675785-8f5dc710-284e-4604-9e54-8fcd85574f7c.gif' />