### PR TITLE
clear a scene by removing all children

### DIFF
--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -312,6 +312,12 @@ class WorldObject(EventTarget, ResourceContainer):
                 pass
         return self
 
+    def clear(self):
+        """Removes all children."""
+        for child in self._children:
+            child._parent_ref = None
+        self._children.clear()
+
     def traverse(self, callback, skip_invisible=False):
         """Executes the callback on this object and all descendants.
 


### PR DESCRIPTION
It's convenient to have a method that clears a scene, not sure if it's best to have this in `Scene` or the `WorldObject` base class?