### PR TITLE
Allow vertex and index buffers

### DIFF
--- a/pygfx/renderers/wgpu/_pipelinebuilder.py
+++ b/pygfx/renderers/wgpu/_pipelinebuilder.py
@@ -128,10 +128,10 @@ def collect_pipeline_resources(shared, wobject, pipeline_infos):
         assert isinstance(pipeline_info, dict)
         buffer = pipeline_info.get("index_buffer", None)
         if buffer is not None:
-            buffer._wgpu_usage |= wgpu.BufferUsage.INDEX
+            buffer._wgpu_usage |= wgpu.BufferUsage.INDEX | wgpu.BufferUsage.STORAGE
             pipeline_resources.append(("buffer", buffer))
         for buffer in pipeline_info.get("vertex_buffers", {}).values():
-            buffer._wgpu_usage |= wgpu.BufferUsage.VERTEX
+            buffer._wgpu_usage |= wgpu.BufferUsage.VERTEX | wgpu.BufferUsage.STORAGE
             pipeline_resources.append(("buffer", buffer))
         for key in pipeline_info.keys():
             if key.startswith("bindings"):
@@ -147,6 +147,10 @@ def collect_pipeline_resources(shared, wobject, pipeline_infos):
                             resource._wgpu_usage |= wgpu.BufferUsage.UNIFORM
                         elif "storage" in binding.type:
                             resource._wgpu_usage |= wgpu.BufferUsage.STORAGE
+                            if "indices" in binding.name:
+                                resource._wgpu_usage |= wgpu.BufferUsage.INDEX
+                            else:
+                                resource._wgpu_usage |= wgpu.BufferUsage.VERTEX
                     elif binding.type.startswith("sampler/"):
                         assert isinstance(resource, TextureView)
                         pipeline_resources.append(("sampler", resource))


### PR DESCRIPTION
Different render functions may need to either use a buffer as an index or vertex buffer, while others use storage buffers. This PR makes that both such objects can use the same buffer objects (and thus use the same geometry). 

This *should* fix an issue in #309, but I have not tested it :D