### PR TITLE
Remove unneeded request_draw calls

### DIFF
--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -45,12 +45,13 @@ def on_key_down(event):
 renderer.add_event_handler(on_key_down, "key_down")
 
 
-def animate():
+def render_scene():
     controller.update_camera(camera)
     renderer.render(scene, camera)
-    canvas.request_draw()
+    # NOTE: The controller requests new draws automatically
+    # so there is no need for an animation loop
 
 
 if __name__ == "__main__":
-    canvas.request_draw(animate)
+    canvas.request_draw(render_scene)
     run()

--- a/pygfx/controllers/_orbit.py
+++ b/pygfx/controllers/_orbit.py
@@ -216,14 +216,14 @@ class OrbitController(Controller):
                 self.rotate_stop()
             elif event.button == 2:
                 self.pan_stop()
-            viewport.renderer.request_draw()
         elif type == "pointer_move":
             xy = event.x, event.y
             if 1 in event.buttons:
                 self.rotate_move(xy),
+                viewport.renderer.request_draw()
             if 2 in event.buttons:
                 self.pan_move(xy),
-            viewport.renderer.request_draw()
+                viewport.renderer.request_draw()
         elif type == "wheel" and viewport.is_inside(event.x, event.y):
             xy = event.x, event.y
             d = event.dy or event.dx

--- a/pygfx/controllers/_orbit.py
+++ b/pygfx/controllers/_orbit.py
@@ -19,6 +19,7 @@ class OrbitController(Controller):
         *,
         zoom_changes_distance=True,
         min_zoom: float = 0.0001,
+        auto_update: bool = True,
     ) -> None:
         super().__init__()
         self.rotation = Quaternion()
@@ -33,6 +34,7 @@ class OrbitController(Controller):
         self.zoom_changes_distance = bool(zoom_changes_distance)
         self.zoom_value = 1
         self.min_zoom = min_zoom
+        self.auto_update = auto_update
 
         # State info used during a pan or rotate operation
         self._pan_info = None
@@ -220,16 +222,19 @@ class OrbitController(Controller):
             xy = event.x, event.y
             if 1 in event.buttons:
                 self.rotate_move(xy),
-                viewport.renderer.request_draw()
+                if self.auto_update:
+                    viewport.renderer.request_draw()
             if 2 in event.buttons:
                 self.pan_move(xy),
-                viewport.renderer.request_draw()
+                if self.auto_update:
+                    viewport.renderer.request_draw()
         elif type == "wheel" and viewport.is_inside(event.x, event.y):
             xy = event.x, event.y
             d = event.dy or event.dx
             f = 2 ** (-d * 0.0015)
             self.zoom(f)
-            viewport.renderer.request_draw()
+            if self.auto_update:
+                viewport.renderer.request_draw()
 
     def show_object(self, camera, target):
         target_pos = camera.show_object(target, self.target.clone().sub(self._v), 1.2)

--- a/pygfx/controllers/_orbit.py
+++ b/pygfx/controllers/_orbit.py
@@ -258,7 +258,13 @@ class OrbitOrthoController(OrbitController):
         up: Vector3 = None,
         *,
         min_zoom: float = 0.0001,
+        auto_update: bool = True,
     ):
         super().__init__(
-            eye, target, up, zoom_changes_distance=False, min_zoom=min_zoom
+            eye,
+            target,
+            up,
+            zoom_changes_distance=False,
+            min_zoom=min_zoom,
+            auto_update=auto_update,
         )

--- a/pygfx/controllers/_panzoom.py
+++ b/pygfx/controllers/_panzoom.py
@@ -154,7 +154,6 @@ class PanZoomController(Controller):
         elif type == "pointer_up":
             if event.button == 1:
                 self.pan_stop()
-                viewport.renderer.request_draw()
         elif type == "pointer_move":
             if 1 in event.buttons:
                 xy = event.x, event.y

--- a/pygfx/controllers/_panzoom.py
+++ b/pygfx/controllers/_panzoom.py
@@ -16,6 +16,7 @@ class PanZoomController(Controller):
         up: Vector3 = None,
         zoom: float = 1.0,
         min_zoom: float = 0.0001,
+        auto_update: bool = True,
     ) -> None:
         super().__init__()
         self.rotation = Quaternion()
@@ -29,6 +30,7 @@ class PanZoomController(Controller):
             up = Vector3(0.0, 1.0, 0.0)
         self.zoom_value = zoom
         self.min_zoom = min_zoom
+        self.auto_update = True
 
         # State info used during a pan or rotate operation
         self._pan_info = None
@@ -158,12 +160,14 @@ class PanZoomController(Controller):
             if 1 in event.buttons:
                 xy = event.x, event.y
                 self.pan_move(xy)
-                viewport.renderer.request_draw()
+                if self.auto_update:
+                    viewport.renderer.request_draw()
         elif type == "wheel" and viewport.is_inside(event.x, event.y):
             xy = event.x, event.y
             f = 2 ** (-event.dy * 0.0015)
             self.zoom_to_point(f, xy, viewport, camera)
-            viewport.renderer.request_draw()
+            if self.auto_update:
+                viewport.renderer.request_draw()
 
     def show_object(self, camera, target):
         # TODO: implement for perspective camera


### PR DESCRIPTION
I noticed some unnecessary draws on mouse movement (without any buttons pressed), so I updated the `handle_event` code to only request new draws when there was an actual change.

I also would like to propose to add an `auto_update` argument to the controller classes to configure this behaviour. That would make it possible for the user to have more fine-grained control over exactly when to draw or not.