### PR TITLE
Colorspace and gamma correction

### DIFF
--- a/examples/validate_color.py
+++ b/examples/validate_color.py
@@ -1,0 +1,55 @@
+"""
+This example draws squares of reference colors. These can be compared to
+similar output from e.g. Matplotlib.
+"""
+# test_example = true
+
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+
+colors1 = ["#ff0000", "#770000", "#00ff00", "#007700", "#0000ff", "#000077"]
+colors2 = ["#000000", "#333333", "#666666", "#999999", "#cccccc", "#ffffff"]
+
+canvas = WgpuCanvas()
+renderer = gfx.WgpuRenderer(canvas)
+camera = gfx.OrthographicCamera(6, 2)
+camera.position.set(2.5, 1, 0)
+scene = gfx.Scene()
+
+plane = gfx.plane_geometry()
+for i, color in enumerate(colors1):
+    m = gfx.Mesh(plane, gfx.MeshBasicMaterial(color=color))
+    m.position.x = i
+    m.position.y = 0
+    scene.add(m)
+for i, color in enumerate(colors2):
+    m = gfx.Mesh(plane, gfx.MeshBasicMaterial(color=color))
+    m.position.x = i
+    m.position.y = 1
+    scene.add(m)
+
+canvas.request_draw(lambda: renderer.render(scene, camera))
+
+
+def show_mpl():
+
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Rectangle
+
+    fig, ax = plt.subplots()
+    ax.set_facecolor("k")
+    plt.xlim([0, 6])
+    plt.ylim([-1, 3])
+
+    for i, color in enumerate(colors1):
+        ax.add_patch(Rectangle((i, 0), 1, 1, facecolor=color))
+    for i, color in enumerate(colors2):
+        ax.add_patch(Rectangle((i, 1), 1, 1, facecolor=color))
+
+    fig.show()
+
+
+if __name__ == "__main__":
+    print(__doc__)
+    show_mpl()
+    run()


### PR DESCRIPTION
Closes #329.

It was observed in #329 that the colors are washed out compared to e.g. Matplotlib and Vispy. After some research it appears that this is due to the srgb colorspace texture of the final step. Most examples in wgpu upstream use srgb, but I guess this convention does not hold for our ecosystem? I'm not sure what's right here, but I agree that the colors look "washed out", and that without srgb things look more vibrant.

It was observed that the colors still don't match that of Matplotlib. In fact, Matplotlib applies *some* conversion, as e.g. an input "#33333" does not appear as such on screen. The color transform applied by Matplotlib is close to a gamma correction with `gamma=0.82`. Close but not exactly.

This PR turns off srgb by default, but keeps an option to enable it. It also adds a `gamma_correction`  property to the renderer. This way, things look more similar by default, and can be made pretty close to MPL if you want.

I will also have a look to see if colors can become the exact same value on screen. There appears to be a small offset or rounding or something.

Side note: the wgpu funtion `get_preferred_format` was implemented just recently in wgpu-native, and wgpu-py returns a hardcoded value at the moment. We'd need to review this pygfx code when we do the next wgpu-py update.



 