### PR TITLE
Skybox can be oriented

### DIFF
--- a/examples/skybox.py
+++ b/examples/skybox.py
@@ -26,7 +26,7 @@ tex = gfx.Texture(im, dim=2, size=tex_size)
 view = tex.get_view(view_dim="cube", layer_range=range(6))
 
 # And the background image with the cube texture
-background = gfx.Background(None, gfx.BackgroundImageMaterial(map=view))
+background = gfx.Background(None, gfx.BackgroundSkyboxMaterial(map=view))
 scene.add(background)
 
 # Let's add some cubes to make the scene less boring
@@ -40,8 +40,6 @@ for pos in (-600, 0, -600), (-600, 0, +600), (+600, 0, -600), (+600, 0, +600):
 
 
 camera = gfx.PerspectiveCamera(70)
-camera.scale.y = -1
-camera.position.z = 0
 
 
 def animate():

--- a/pygfx/materials/__init__.py
+++ b/pygfx/materials/__init__.py
@@ -24,7 +24,11 @@ from ._volume import (
     VolumeRayMaterial,
     VolumeMipMaterial,
 )
-from ._background import BackgroundMaterial, BackgroundImageMaterial
+from ._background import (
+    BackgroundMaterial,
+    BackgroundImageMaterial,
+    BackgroundSkyboxMaterial,
+)
 
 
 # Define __all__ for e.g. Sphinx

--- a/pygfx/renderers/wgpu/backgroundshader.py
+++ b/pygfx/renderers/wgpu/backgroundshader.py
@@ -83,7 +83,6 @@ class BackgroundShader(WorldObjectShader):
             @builtin(vertex_index) index : u32,
         };
 
-
         @stage(vertex)
         fn vs_main(in: VertexInput) -> Varyings {
             var varyings: Varyings;
@@ -104,7 +103,9 @@ class BackgroundShader(WorldObjectShader):
                 // Store positions and the view direction in the world
                 varyings.position = vec4<f32>(ndc_pos1);
                 varyings.world_pos = vec3<f32>(wpos1);
-                varyings.texcoord = vec3<f32>(wpos2.xyz - wpos1.xyz);
+                let d = wpos2.xyz - wpos1.xyz;
+                let index = u_material.tex_index.xyz;
+                varyings.texcoord = vec3<f32>(d[index.x], -u_material.yscale * d[index.y], d[index.z]);
             $$ else
                 // Store positions and the view direction in the world
                 varyings.position = vec4<f32>(pos, 0.9999999, 1.0);


### PR DESCRIPTION
This will help some examples in #324 simpler. Also the default up is now `(0, 1, 0)` instead of `(0, -1, 0)`.