### PR TITLE
Fix wrong mipmap sampling level in IBL

### DIFF
--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -317,7 +317,7 @@ class TextureView(Resource):
             assert mip_range.step == 1
             self._mip_range = mip_range
         else:
-            self._mip_range = range(texture._mip_level_count)
+            self._mip_range = None  # None means all mip levels in the texture are used
         if layer_range:
             assert isinstance(layer_range, range)
             assert layer_range.step == 1
@@ -359,7 +359,9 @@ class TextureView(Resource):
         """The range of mip levels to view, as a range object.
         The step is always 1.
         """
-        return self._mip_range
+        return self._mip_range or range(
+            self.texture._mip_level_count
+        )  # "texture._mip_level_count" may be updated in auto mipmap generation
 
     @property
     def layer_range(self):


### PR DESCRIPTION
I found that IBL on the current main branch does not work correctly.

As shown below:

![image](https://user-images.githubusercontent.com/8044566/195508228-8e4ecfcf-2b85-4ba9-835a-c544bd10b242.png)

The back of the helmet is not smooth and should not project the surrounding environment obviously.

That is irradiance is not sampled correctly from the corresponding blur level according to the roughness.


This PR fixed this.

![image](https://user-images.githubusercontent.com/8044566/195509732-0b3fddeb-d17e-445b-8bc8-ad093905386e.png)

