### PR TITLE
More readable code defining Bindings

### DIFF
--- a/pygfx/renderers/wgpu/lineshader.py
+++ b/pygfx/renderers/wgpu/lineshader.py
@@ -77,12 +77,13 @@ class LineShader(WorldObjectShader):
         uniform_buffer = Buffer(array_from_shadertype(renderer_uniform_type))
         uniform_buffer.data["last_i"] = positions1.nitems - 1
 
+        rbuffer = "buffer/read_only_storage"
         bindings = [
             Binding("u_stdinfo", "buffer/uniform", shared.uniform_buffer),
             Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer),
             Binding("u_material", "buffer/uniform", material.uniform_buffer),
             Binding("u_renderer", "buffer/uniform", uniform_buffer),
-            Binding("s_positions", "buffer/read_only_storage", positions1, "VERTEX"),
+            Binding("s_positions", rbuffer, positions1, "VERTEX"),
         ]
 
         # Per-vertex color, colormap, or a plane color?
@@ -92,11 +93,7 @@ class LineShader(WorldObjectShader):
             self["vertex_color_channels"] = nchannels = geometry.colors.data.shape[1]
             if nchannels not in (1, 2, 3, 4):
                 raise ValueError(f"Geometry.colors needs 1-4 columns, not {nchannels}")
-            bindings.append(
-                Binding(
-                    "s_colors", "buffer/read_only_storage", geometry.colors, "VERTEX"
-                )
-            )
+            bindings.append(Binding("s_colors", rbuffer, geometry.colors, "VERTEX"))
         elif material.map is not None:
             self["color_mode"] = "map"
             bindings.extend(self.define_vertex_colormap(material.map))
@@ -582,13 +579,12 @@ class ThinLineShader(WorldObjectShader):
         material = wobject.material
         geometry = wobject.geometry
 
+        rbuffer = "buffer/read_only_storage"
         bindings = [
             Binding("u_stdinfo", "buffer/uniform", shared.uniform_buffer),
             Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer),
             Binding("u_material", "buffer/uniform", material.uniform_buffer),
-            Binding(
-                "s_positions", "buffer/read_only_storage", geometry.positions, "VERTEX"
-            ),
+            Binding("s_positions", rbuffer, geometry.positions, "VERTEX"),
         ]
 
         # Per-vertex color, colormap, or a plane color?
@@ -599,11 +595,7 @@ class ThinLineShader(WorldObjectShader):
             self["vertex_color_channels"] = nchannels = geometry.colors.data.shape[1]
             if nchannels not in (1, 2, 3, 4):
                 raise ValueError(f"Geometry.colors needs 1-4 columns, not {nchannels}")
-            bindings.append(
-                Binding(
-                    "s_colors", "buffer/read_only_storage", geometry.colors, "VERTEX"
-                )
-            )
+            bindings.append(Binding("s_colors", rbuffer, geometry.colors, "VERTEX"))
         elif material.map is not None:
             self["color_mode"] = "map"
             bindings.extend(self.define_vertex_colormap(material.map))

--- a/pygfx/renderers/wgpu/meshshader.py
+++ b/pygfx/renderers/wgpu/meshshader.py
@@ -76,25 +76,18 @@ class MeshShader(WorldObjectShader):
             normal_buffer = Buffer(normal_data)
 
         # Init bindings
+        rbuffer = "buffer/read_only_storage"
         bindings = [
             Binding("u_stdinfo", "buffer/uniform", shared.uniform_buffer),
             Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer),
             Binding("u_material", "buffer/uniform", material.uniform_buffer),
-            Binding(
-                "s_indices", "buffer/read_only_storage", geometry.indices, "VERTEX"
-            ),
-            Binding(
-                "s_positions", "buffer/read_only_storage", geometry.positions, "VERTEX"
-            ),
-            Binding("s_normals", "buffer/read_only_storage", normal_buffer, "VERTEX"),
+            Binding("s_indices", rbuffer, geometry.indices, "VERTEX"),
+            Binding("s_positions", rbuffer, geometry.positions, "VERTEX"),
+            Binding("s_normals", rbuffer, normal_buffer, "VERTEX"),
         ]
 
         if self["color_mode"] == "vertex":
-            bindings.append(
-                Binding(
-                    "s_colors", "buffer/read_only_storage", geometry.colors, "VERTEX"
-                )
-            )
+            bindings.append(Binding("s_colors", rbuffer, geometry.colors, "VERTEX"))
         if self["color_mode"] == "map":
             bindings.extend(
                 self.define_vertex_colormap(material.map, geometry.texcoords)
@@ -108,10 +101,7 @@ class MeshShader(WorldObjectShader):
         bindings1 = {}  # non-auto-generated bindings
         if self["instanced"]:
             bindings1[0] = Binding(
-                "s_instance_infos",
-                "buffer/read_only_storage",
-                wobject.instance_buffer,
-                "VERTEX",
+                "s_instance_infos", rbuffer, wobject.instance_buffer, "VERTEX"
             )
 
         return {
@@ -605,12 +595,9 @@ class MeshSliceShader(WorldObjectShader):
         assert getattr(geometry, "indices", None)
 
         # Init storage buffer bindings
-        bindings[3] = Binding(
-            "s_indices", "buffer/read_only_storage", geometry.indices, "VERTEX"
-        )
-        bindings[4] = Binding(
-            "s_positions", "buffer/read_only_storage", geometry.positions, "VERTEX"
-        )
+        rbuffer = "buffer/read_only_storage"
+        bindings[3] = Binding("s_indices", rbuffer, geometry.indices, "VERTEX")
+        bindings[4] = Binding("s_positions", rbuffer, geometry.positions, "VERTEX")
 
         # Let the shader generate code for our bindings
         self.define_bindings(0, bindings)

--- a/pygfx/renderers/wgpu/pointsshader.py
+++ b/pygfx/renderers/wgpu/pointsshader.py
@@ -21,21 +21,18 @@ class PointsShader(WorldObjectShader):
         geometry = wobject.geometry
         material = wobject.material
 
+        rbuffer = "buffer/read_only_storage"
         bindings = [
             Binding("u_stdinfo", "buffer/uniform", shared.uniform_buffer),
             Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer),
             Binding("u_material", "buffer/uniform", material.uniform_buffer),
-            Binding(
-                "s_positions", "buffer/read_only_storage", geometry.positions, "VERTEX"
-            ),
+            Binding("s_positions", rbuffer, geometry.positions, "VERTEX"),
         ]
 
         self["per_vertex_sizes"] = False
         if material.vertex_sizes:
             self["per_vertex_sizes"] = True
-            bindings.append(
-                Binding("s_sizes", "buffer/read_only_storage", geometry.sizes, "VERTEX")
-            )
+            bindings.append(Binding("s_sizes", rbuffer, geometry.sizes, "VERTEX"))
 
         # Per-vertex color, colormap, or a plane color?
         self["color_mode"] = "uniform"
@@ -45,11 +42,7 @@ class PointsShader(WorldObjectShader):
             self["vertex_color_channels"] = nchannels = geometry.colors.data.shape[1]
             if nchannels not in (1, 2, 3, 4):
                 raise ValueError(f"Geometry.colors needs 1-4 columns, not {nchannels}")
-            bindings.append(
-                Binding(
-                    "s_colors", "buffer/read_only_storage", geometry.colors, "VERTEX"
-                )
-            )
+            bindings.append(Binding("s_colors", rbuffer, geometry.colors, "VERTEX"))
         elif material.map is not None:
             self["color_mode"] = "map"
             bindings.extend(


### PR DESCRIPTION
Related to #337. I thought of changing `Binding` a bit to make its definition shorted, because it tends to be long and spread over multiple lines. But this fix is easier and keeps things simple.