### PR TITLE
Fix shadows in MeshStandardMaterial

### DIFF
--- a/pygfx/renderers/wgpu/_shaderlib.py
+++ b/pygfx/renderers/wgpu/_shaderlib.py
@@ -608,8 +608,10 @@ class Shaderlib:
                     var light = getPointLightInfo(point_light, geometry);
                     if (! light.visible) { continue; }
                     $$ if receive_shadow
-                    let shadow = get_cube_shadow(u_shadow_map_point_light, u_shadow_sampler, i, u_shadow_point_light[i].light_view_proj_matrix, geometry.position, light.direction, u_shadow_point_light[i].bias);
-                    light.color *= shadow;
+                    if (point_light.cast_shadow != 0){
+                        let shadow = get_cube_shadow(u_shadow_map_point_light, u_shadow_sampler, i, point_light.light_view_proj_matrix, geometry.position, light.direction, point_light.shadow_bias);
+                        light.color *= shadow;
+                    }
                     $$ endif
                     reflected_light = RE_Direct_Physical( light, geometry, material, reflected_light );
                     continuing {
@@ -625,9 +627,11 @@ class Shaderlib:
                     var light = getSpotLightInfo(spot_light, geometry);
                     if (! light.visible) { continue; }
                     $$ if receive_shadow
-                    let coords = u_shadow_spot_light[i].light_view_proj_matrix * vec4<f32>(geometry.position,1.0);
-                    let shadow = get_shadow(u_shadow_map_spot_light, u_shadow_sampler, i, coords, u_shadow_spot_light[i].bias);
-                    light.color *= shadow;
+                    if (spot_light.cast_shadow != 0){
+                        let coords = spot_light.light_view_proj_matrix * vec4<f32>(geometry.position,1.0);
+                        let shadow = get_shadow(u_shadow_map_spot_light, u_shadow_sampler, i, coords, spot_light.shadow_bias);
+                        light.color *= shadow;
+                    }
                     $$ endif
                     reflected_light = RE_Direct_Physical( light, geometry, material, reflected_light );
                     continuing {
@@ -643,9 +647,11 @@ class Shaderlib:
                     var light = getDirectionalLightInfo(dir_light, geometry);
                     if (! light.visible) { continue; }
                     $$ if receive_shadow
-                    let coords = u_shadow_dir_light[i].light_view_proj_matrix * vec4<f32>(geometry.position,1.0);
-                    let shadow = get_shadow(u_shadow_map_dir_light, u_shadow_sampler, i, coords, u_shadow_dir_light[i].bias);
-                    light.color *= shadow;
+                    if (dir_light.cast_shadow != 0) {
+                        let coords = dir_light.light_view_proj_matrix * vec4<f32>(geometry.position,1.0);
+                        let shadow = get_shadow(u_shadow_map_dir_light, u_shadow_sampler, i, coords, dir_light.shadow_bias);
+                        light.color *= shadow;
+                    }
                     $$ endif
                     reflected_light = RE_Direct_Physical( light, geometry, material, reflected_light );
                     continuing {


### PR DESCRIPTION
In my previous code, I redefined the structure of shadows in the shader, but only modified the rendering logic of MeshPhongMaterial, and forgot to modify MeshStandardMaterial. 😅 

This should solves the problem of shadows in #349.