### PR TITLE
Use a hash for the key of a shader source

### DIFF
--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -59,11 +59,11 @@ class LineMaterial(Material):
         gives prettier results, but may affect performance for very large
         datasets. Default True.
         """
-        return self._aa
+        return self._store.aa
 
     @aa.setter
     def aa(self, aa):
-        self._aa = bool(aa)
+        self._store.aa = bool(aa)
 
     @property
     def vertex_colors(self):

--- a/pygfx/renderers/wgpu/_pipeline.py
+++ b/pygfx/renderers/wgpu/_pipeline.py
@@ -5,6 +5,7 @@ actual dispatching / drawing.
 """
 
 import wgpu
+import hashlib
 
 from ...resources import Buffer, TextureView
 from ...utils import logger
@@ -740,7 +741,7 @@ class Cache:
         # todo: cache more objects, like pipelines once we figure out how to clean things up
 
         assert isinstance(source, str)
-        key = source  # or hash(code)
+        key = hashlib.sha1(source.encode()).hexdigest()
 
         m = self.get(key)
         if m is None:

--- a/pygfx/renderers/wgpu/_pipeline.py
+++ b/pygfx/renderers/wgpu/_pipeline.py
@@ -383,12 +383,12 @@ class PipelineContainer:
         """Update the actual wgpu objects."""
 
         if self.wgpu_shaders.get(env_hash, None) is None:
-
             environment.register_pipeline_container(self)  # allows us to clean up
             changed.add("compile_shader")
             self.wgpu_shaders[env_hash] = self._compile_shaders(
                 shared.device, environment
             )
+            self.wgpu_pipelines = {}  # Invalidate pipelines so new shaders get used
 
         if self.wgpu_pipelines.get(env_hash, None) is None:
             changed.add("compose_pipeline")

--- a/pygfx/renderers/wgpu/lineshader.py
+++ b/pygfx/renderers/wgpu/lineshader.py
@@ -48,13 +48,13 @@ class LineShader(WorldObjectShader):
     def __init__(self, wobject):
         super().__init__(wobject)
         self["line_type"] = "line"
+        self["aa"] = wobject.material.aa
 
     def get_bindings(self, wobject, shared):
         material = wobject.material
         geometry = wobject.geometry
 
         self["vertex_color_channels"] = 0
-        self["aa"] = material.aa
 
         positions1 = geometry.positions
 


### PR DESCRIPTION
I observed that when changing material properties that should trigger the shader source to be recompiled, that this does not happen in all cases. ~After some digging it turned out that the hash lookup is the problem.~ It turned out that when the shaders are compiled, a new pipeline build is not enforced. Not sure whether this bug has been always there, or fell victim in a refactoring. 

* [x] Fix the bug that a new pipeline build was not enforced after a shader rebuild.
* [x] Fixed that `LimeMaterial.aa` was not tracked.
* [x] Use a proper hash as a key for cached shader modules.