### PR TITLE
fix image_click_events.py example, previous points now reset to blue

### DIFF
--- a/examples/image_click_events.py
+++ b/examples/image_click_events.py
@@ -38,6 +38,9 @@ points.position.z = 1  # move points in front of the image
 scene.add(points)
 
 
+previous_selection = None
+
+
 def event_handler(event):
     print(
         f"Canvas click coordinates: {event.x, event.y}\n"
@@ -45,10 +48,15 @@ def event_handler(event):
         f"Other `pick_info`: {event.pick_info}"
     )
 
-    # reset colors to blue
-    points.geometry.colors.data[:] = np.vstack([[0.0, 0.0, 1.0, 1.0]] * len(xx)).astype(
-        np.float32
-    )
+    global previous_selection
+
+    if previous_selection is not None:
+        # reset colors to blue
+        blues = np.vstack([[0.0, 0.0, 1.0, 1.0]] * 3).astype(np.float32)
+        points.geometry.colors.data[previous_selection] = blues
+
+        for idx in previous_selection.tolist():
+            points.geometry.colors.update_range(idx, size=1)
 
     # set the color of the 3 closest points to red
     positions = points.geometry.positions.data
@@ -58,6 +66,9 @@ def event_handler(event):
     for idx in closest[:3].tolist():
         # only mark the changed points for synchronization to the GPU
         points.geometry.colors.update_range(idx, size=1)
+
+    previous_selection = closest[:3]
+
     renderer.request_draw()
 
 


### PR DESCRIPTION
in the current version the points do not go back to blue after a new click event occurs, this one resets the previous points to blue and sets the current selection to red