### PR TITLE
Tweak flusher smoothing

### DIFF
--- a/pygfx/renderers/wgpu/_flusher.py
+++ b/pygfx/renderers/wgpu/_flusher.py
@@ -135,7 +135,7 @@ class RenderFlusher:
             # A bit less crisp, but also less flicker.
             sigma = 0.5
             support = 2
-        elif factor >= 1:
+        elif factor > 1:
             # With src a higher res, we will do ssaa.
             # Kernel scales with input res.
             sigma = 0.5 * factor

--- a/pygfx/renderers/wgpu/_flusher.py
+++ b/pygfx/renderers/wgpu/_flusher.py
@@ -130,14 +130,20 @@ class RenderFlusher:
         factor_y = src_color_tex.size[1] / dst_color_tex.size[1]
         factor = (factor_x + factor_y) / 2
 
-        if factor > 1:
-            # The src has higher res, we can do ssaa.
+        if factor == 1:
+            # With equal res, we smooth a tiny bit.
+            # A bit less crisp, but also less flicker.
+            sigma = 0.5
+            support = 2
+        elif factor >= 1:
+            # With src a higher res, we will do ssaa.
+            # Kernel scales with input res.
             sigma = 0.5 * factor
             support = min(5, int(sigma * 3))
         else:
-            # The src has lower res, interpolate + smooth.
-            # Smoothing a bit more helps reduce the blockiness.
-            sigma = 1
+            # With src a lower res, the output is interpolated.
+            # But we also smooth to reduce the blockiness.
+            sigma = 0.5
             support = 2
 
         self._uniform_data["size"] = src_color_tex.size[:2]

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -251,11 +251,12 @@ class WgpuRenderer(RootEventHandler, Renderer):
         else:
             raise TypeError(f"Unexpected render target {target.__class__.__name__}")
 
+        target_lsize = self.logical_size
+
         # Determine the pixel ratio of the render texture
         if self._pixel_ratio:
             pixel_ratio = self._pixel_ratio
         else:
-            target_lsize = self.logical_size
             pixel_ratio = target_psize[0] / target_lsize[0]
             if pixel_ratio <= 1:
                 pixel_ratio = 2.0  # use 2 on non-hidpi displays


### PR DESCRIPTION
When working with text I observed that on a hirez display the output is smoothed quite a bit. This tunes this down a bit.

I know that the triage can be written in 3 lines or so, but each `if`  represents a different situation, for which we may later want a different approach, so I prefer to keep it explicit.

Also fixed that you could not set `renderer.pixel_ratio`.