### PR TITLE
Modify image shader to set image position

### DIFF
--- a/pygfx/renderers/wgpu/imageshader.py
+++ b/pygfx/renderers/wgpu/imageshader.py
@@ -69,10 +69,10 @@ class BaseImageShader(WorldObjectShader):
 
             let pos1 = vec2<f32>(-0.5);
             let pos2 = vec2<f32>(size.xy) + pos1;
-            
+
             // get the offset from the top left corner
             let pos_offset = load_s_positions(0);
-            
+
             geo.positions = array<vec3<f32>,4>(
                 vec3<f32>(pos2.x + pos_offset.x, pos1.y + pos_offset.x, 0.0),
                 vec3<f32>(pos2.x + pos_offset.x, pos2.y + pos_offset.x, 0.0),


### PR DESCRIPTION
followup from #367 

without `positions` specified:

```python
image = gfx.Image(
    gfx.Geometry(grid=gfx.Texture(im, dim=2)),
    gfx.ImageBasicMaterial(clim=(0, 255)),
)
```
![image](https://user-images.githubusercontent.com/9403332/199606258-cdcbfb40-9440-461e-8824-62d5fc02d942.png)

with `positions`, uses the positions to apply an offset:

```python
positions = [
    [100, 100, 0],
]

image = gfx.Image(
    gfx.Geometry(grid=gfx.Texture(im, dim=2), positions=positions),
    gfx.ImageBasicMaterial(clim=(0, 255)),
)
```

![image](https://user-images.githubusercontent.com/9403332/199606188-736643ac-b619-4f58-8d84-bf80a4bbe5e1.png)
