### PR TITLE
Update examples to IIO v3

### DIFF
--- a/examples/colormap_image.py
+++ b/examples/colormap_image.py
@@ -3,7 +3,7 @@ Example demonstrating different colormap dimensions on an image.
 """
 
 import numpy as np
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -23,7 +23,7 @@ camera.position.x = 1736 / 2
 # the colormap data we use a colormap that goes from red to green to
 # blue (1D). A classic image colormap use-case.
 
-img_data1 = imageio.imread("imageio:astronaut.png")[:, :, 1]
+img_data1 = iio.imread("imageio:astronaut.png")[:, :, 1]
 
 colormap1 = gfx.cm.magma
 image1 = gfx.Image(
@@ -69,8 +69,7 @@ rr, zz = np.meshgrid(np.linspace(0, 2 * np.pi, 512), np.linspace(0, 1, 512))
 xx = np.sin(rr) * 0.4 + 0.5
 yy = np.cos(rr) * 0.4 + 0.5
 img_data3 = np.stack([xx, yy, zz], 2).astype(np.float32)
-# img_data3 = np.stack([xx, yy, zz], 2).astype(np.float32)
-colormap_data3 = imageio.volread("imageio:stent.npz").astype(np.float32) / 1500
+colormap_data3 = iio.imread("imageio:stent.npz").astype(np.float32) / 1500
 
 colormap3 = gfx.Texture(colormap_data3, dim=3).get_view(filter="linear")
 image3 = gfx.Image(

--- a/examples/colormap_mesh.py
+++ b/examples/colormap_mesh.py
@@ -7,7 +7,7 @@ this can also be applied for points and lines.
 """
 
 import numpy as np
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -69,7 +69,7 @@ ob1.position.x = -6
 
 texcoords2 = geometry.texcoords.data.copy()
 
-cmap2 = imageio.imread("imageio:chelsea.png").astype(np.float32) / 255
+cmap2 = iio.imread("imageio:chelsea.png").astype(np.float32) / 255
 tex2 = gfx.Texture(cmap2, dim=2).get_view(address_mode="repeat")
 
 ob2 = WobjectClass(
@@ -90,7 +90,7 @@ ob2.position.x = -2
 
 texcoords3 = geometry.positions.data * 0.4 + 0.5
 
-cmap3 = imageio.volread("imageio:stent.npz").astype(np.float32) / 1000
+cmap3 = iio.imread("imageio:stent.npz").astype(np.float32) / 1000
 tex3 = gfx.Texture(cmap3, dim=3).get_view()
 
 ob3 = WobjectClass(

--- a/examples/geometry_cubes.py
+++ b/examples/geometry_cubes.py
@@ -2,7 +2,7 @@
 Example showing multiple rotating cubes. This also tests the depth buffer.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -11,7 +11,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:chelsea.png")
+im = iio.imread("imageio:chelsea.png")
 tex = gfx.Texture(im, dim=2).get_view(filter="linear")
 
 material = gfx.MeshBasicMaterial(map=tex)

--- a/examples/geometry_image.py
+++ b/examples/geometry_image.py
@@ -2,7 +2,7 @@
 Show an image.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -11,7 +11,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:astronaut.png")[:, :, 1]
+im = iio.imread("imageio:astronaut.png")[:, :, 1]
 
 image = gfx.Image(
     gfx.Geometry(grid=gfx.Texture(im, dim=2)),

--- a/examples/geometry_torus_knot.py
+++ b/examples/geometry_torus_knot.py
@@ -2,7 +2,7 @@
 Example showing a Torus knot, with a texture and lighting.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -11,7 +11,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:bricks.jpg")
+im = iio.imread("imageio:bricks.jpg")
 tex = gfx.Texture(im, dim=2).get_view(filter="linear", address_mode="repeat")
 
 geometry = gfx.torus_knot_geometry(1, 0.3, 128, 32)

--- a/examples/image_click_events.py
+++ b/examples/image_click_events.py
@@ -2,7 +2,7 @@
 Show an image and print the x, y image data coordinates for click events.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 import numpy as np
@@ -13,7 +13,7 @@ scene = gfx.Scene()
 
 # %% add image
 
-im = imageio.imread("imageio:astronaut.png")
+im = iio.imread("imageio:astronaut.png")
 
 image = gfx.Image(
     gfx.Geometry(grid=gfx.Texture(im, dim=2)),

--- a/examples/image_plus_points.py
+++ b/examples/image_plus_points.py
@@ -2,7 +2,7 @@
 Show an image with points overlaid.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -12,7 +12,7 @@ scene = gfx.Scene()
 
 # %% add image
 
-im = imageio.imread("imageio:astronaut.png")
+im = iio.imread("imageio:astronaut.png")
 
 image = gfx.Image(
     gfx.Geometry(grid=gfx.Texture(im, dim=2)),

--- a/examples/instancing_mesh.py
+++ b/examples/instancing_mesh.py
@@ -3,7 +3,7 @@ Example rendering the same mesh object multiple times, using instancing.
 """
 
 import numpy as np
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -12,7 +12,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:bricks.jpg").astype(np.float32) / 255
+im = iio.imread("imageio:bricks.jpg").astype(np.float32) / 255
 tex = gfx.Texture(im, dim=2).get_view(filter="linear", address_mode="repeat")
 
 geometry = gfx.torus_knot_geometry(1, 0.3, 128, 32)

--- a/examples/manual_matrix_update.py
+++ b/examples/manual_matrix_update.py
@@ -2,7 +2,7 @@
 Example showing transform control flow without matrix auto updating.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -11,7 +11,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:chelsea.png")
+im = iio.imread("imageio:chelsea.png")
 tex = gfx.Texture(im, dim=2).get_view(filter="linear")
 
 material = gfx.MeshBasicMaterial(map=tex)

--- a/examples/multi_slice1.py
+++ b/examples/multi_slice1.py
@@ -6,7 +6,7 @@ is a generic approach. See multi_slice2.py for a simpler way.
 
 from time import time
 
-import imageio
+import imageio.v3 as iio
 import numpy as np
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
@@ -21,7 +21,7 @@ scene.add(background)
 
 scene.add(gfx.AxesHelper(size=50))
 
-vol = imageio.volread("imageio:stent.npz").astype("float32") / 2000
+vol = iio.imread("imageio:stent.npz").astype("float32") / 2000
 tex = gfx.Texture(vol, dim=3)
 view = tex.get_view(filter="linear")
 material = gfx.MeshBasicMaterial(map=view)

--- a/examples/multi_slice2.py
+++ b/examples/multi_slice2.py
@@ -7,7 +7,7 @@ See multi_slice1.py for a more generic approach.
 
 from time import time
 
-import imageio
+import imageio.v3 as iio
 import numpy as np
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
@@ -23,7 +23,7 @@ scene.add(background)
 
 scene.add(gfx.AxesHelper(size=50))
 
-vol = imageio.volread("imageio:stent.npz").astype("float32")
+vol = iio.imread("imageio:stent.npz").astype("float32")
 tex = gfx.Texture(vol, dim=3)
 
 surface = marching_cubes(vol[0:], 200)

--- a/examples/offscreen.py
+++ b/examples/offscreen.py
@@ -6,7 +6,7 @@ Note that one can also render to a ``pygfx.Texture`` and use that texture to
 decorate an object in another scene.
 """
 
-import imageio
+import imageio.v3 as iio
 import pygfx as gfx
 from wgpu.gui.offscreen import WgpuCanvas
 
@@ -16,7 +16,7 @@ canvas = WgpuCanvas(640, 480, 1)
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:astronaut.png").astype("float32") / 255
+im = iio.imread("imageio:astronaut.png").astype("float32") / 255
 tex = gfx.Texture(im, dim=2).get_view(filter="linear", address_mode="repeat")
 
 geometry = gfx.box_geometry(200, 200, 200)
@@ -47,4 +47,4 @@ if __name__ == "__main__":
     im2 = renderer.snapshot()
     print("Image from renderer.snapshot():", im2.shape)  # (960, 1280, 4)
 
-    imageio.imsave("offscreen.png", im1)
+    iio.imwrite("offscreen.png", im1)

--- a/examples/orbit_camera.py
+++ b/examples/orbit_camera.py
@@ -5,7 +5,7 @@ Press 's' to save the state, and
 press 'l' to load the last saved state.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -16,7 +16,7 @@ scene = gfx.Scene()
 
 scene.add(gfx.AxesHelper(size=250))
 
-im = imageio.imread("imageio:chelsea.png")
+im = iio.imread("imageio:chelsea.png")
 tex = gfx.Texture(im, dim=2).get_view(filter="linear")
 
 material = gfx.MeshBasicMaterial(map=tex, side="front")

--- a/examples/panzoom_camera.py
+++ b/examples/panzoom_camera.py
@@ -5,7 +5,7 @@ Press 's' to save the state, and
 press 'l' to load the last saved state.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -20,7 +20,7 @@ scene.add(axes)
 background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
 scene.add(background)
 
-im = imageio.imread("imageio:astronaut.png")
+im = iio.imread("imageio:astronaut.png")
 tex = gfx.Texture(im, dim=2)
 geometry = gfx.plane_geometry(512, 512)
 material = gfx.MeshBasicMaterial(map=tex.get_view(filter="linear"))

--- a/examples/pbr.py
+++ b/examples/pbr.py
@@ -5,7 +5,7 @@ The cubemap of skybox is also the environment cubemap of the helmet.
 
 from pathlib import Path
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -22,7 +22,7 @@ controller = gfx.OrbitController(camera.position.clone())
 controller.add_default_event_handlers(renderer, camera)
 
 # Read cube image and turn it into a 3D image (a 4d array)
-env_img = imageio.imread("imageio:meadow_cube.jpg")
+env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
 env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
 

--- a/examples/pbr2.py
+++ b/examples/pbr2.py
@@ -8,7 +8,7 @@ import time
 import math
 from colorsys import hls_to_rgb
 
-import imageio
+import imageio.v3 as iio
 import pygfx as gfx
 from wgpu.gui.auto import WgpuCanvas, run
 
@@ -34,7 +34,7 @@ scene.add(point_light)
 point_light.add(gfx.PointLightHelper(4))
 
 # Read cube image and turn it into a 3D image (a 4d array)
-env_img = imageio.imread("imageio:meadow_cube.jpg")
+env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
 env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
 

--- a/examples/physical_color.py
+++ b/examples/physical_color.py
@@ -7,7 +7,7 @@ This example shows how you can also provide colors in physical colorspace
 * An image in physical colorspace, rendered correctly.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 import numpy as np
@@ -18,7 +18,7 @@ scene = gfx.Scene()
 
 
 def read_srgb_color_image():
-    return imageio.imread("imageio:astronaut.png").astype(np.float32) / 255
+    return iio.imread("imageio:astronaut.png").astype(np.float32) / 255
 
 
 def read_physical_color_image():

--- a/examples/picking_color.py
+++ b/examples/picking_color.py
@@ -4,7 +4,7 @@ object being clicked, more detailed picking info is available.
 """
 
 import numpy as np
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -16,7 +16,7 @@ scene = gfx.Scene()
 background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 0, 1, 1)))
 scene.add(background)
 
-im = imageio.imread("imageio:astronaut.png").astype(np.float32) / 255
+im = iio.imread("imageio:astronaut.png").astype(np.float32) / 255
 tex = gfx.Texture(im, dim=2).get_view(filter="linear", address_mode="repeat")
 
 geometry = gfx.box_geometry(200, 200, 200)

--- a/examples/picking_mesh.py
+++ b/examples/picking_mesh.py
@@ -6,7 +6,7 @@ on. Upon clicking, the vertex closest to the pick location is moved.
 # todo: if we have per-vertex coloring, we can paint on the mesh instead :D
 
 import numpy as np
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -15,7 +15,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:astronaut.png").astype(np.float32) / 255
+im = iio.imread("imageio:astronaut.png").astype(np.float32) / 255
 tex = gfx.Texture(im, dim=2).get_view(filter="linear", address_mode="repeat")
 
 geometry = gfx.box_geometry(200, 200, 200)

--- a/examples/post_processing1.py
+++ b/examples/post_processing1.py
@@ -15,7 +15,7 @@ Note that we may get a more streamlined way to implement post-processing effects
 import time
 
 import numpy as np
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 from pygfx.renderers.wgpu import Binding
@@ -142,7 +142,7 @@ texture = gfx.Texture(dim=2, size=(640, 480, 1), format="rgba8unorm")
 renderer1 = gfx.renderers.WgpuRenderer(texture)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:astronaut.png").astype(np.float32) / 255
+im = iio.imread("imageio:astronaut.png").astype(np.float32) / 255
 tex = gfx.Texture(im, dim=2).get_view(filter="linear", address_mode="repeat")
 
 geometry = gfx.box_geometry(200, 200, 200)

--- a/examples/post_processing2.py
+++ b/examples/post_processing2.py
@@ -12,7 +12,7 @@ future.
 """
 
 import numpy as np
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -23,7 +23,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:bricks.jpg").astype(np.float32) / 255
+im = iio.imread("imageio:bricks.jpg").astype(np.float32) / 255
 tex = gfx.Texture(im, dim=2).get_view(filter="linear", address_mode="repeat")
 
 geometry = gfx.box_geometry(200, 200, 200)

--- a/examples/scene_in_a_scene.py
+++ b/examples/scene_in_a_scene.py
@@ -10,7 +10,7 @@ surface of the cube in the outer scene.
 """
 
 import numpy as np
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -25,7 +25,7 @@ scene1 = gfx.Scene()
 background1 = gfx.Background(None, gfx.BackgroundMaterial((0, 0.5, 0, 1)))
 scene1.add(background1)
 
-im = imageio.imread("imageio:bricks.jpg").astype(np.float32) / 255
+im = iio.imread("imageio:bricks.jpg").astype(np.float32) / 255
 tex = gfx.Texture(im, dim=2).get_view(filter="linear", address_mode="repeat")
 geometry1 = gfx.box_geometry(200, 200, 200)
 material1 = gfx.MeshPhongMaterial(map=tex, color=(1, 1, 0, 1.0))

--- a/examples/show_image.py
+++ b/examples/show_image.py
@@ -2,7 +2,7 @@
 Use camera.show_object to ensure the Image is in view.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -11,7 +11,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:astronaut.png")
+im = iio.imread("imageio:astronaut.png")
 
 image = gfx.Image(
     gfx.Geometry(grid=gfx.Texture(im, dim=2)),

--- a/examples/show_scene.py
+++ b/examples/show_scene.py
@@ -2,12 +2,12 @@
 Demonstrates show utility for a scene
 """
 
-import imageio
+import imageio.v3 as iio
 import pygfx as gfx
 
 scene = gfx.Scene()
 
-im = imageio.imread("imageio:chelsea.png")
+im = iio.imread("imageio:chelsea.png")
 tex = gfx.Texture(im, dim=2).get_view(filter="linear")
 
 material = gfx.MeshBasicMaterial(map=tex)

--- a/examples/skybox.py
+++ b/examples/skybox.py
@@ -4,13 +4,13 @@ Example with a skybox background.
 Inspired by https://github.com/gfx-rs/wgpu-rs/blob/master/examples/skybox/main.rs
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
 # Read the image
 # The order of the images is already correct for GPU cubemap texture sampling
-im = imageio.imread("imageio:meadow_cube.jpg")
+im = iio.imread("imageio:meadow_cube.jpg")
 
 # Turn it into a 3D image (a 4d nd array)
 width = height = im.shape[1]

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 import subprocess
 import sys
 
-import imageio.v2 as imageio
+import imageio.v3 as iio
 import numpy as np
 import pytest
 
@@ -98,13 +98,13 @@ def test_examples_screenshots(module, pytestconfig, force_offscreen, mock_time):
     # regenerate screenshot if requested
     screenshot_path = screenshots_dir / f"{module}.png"
     if pytestconfig.getoption("regenerate_screenshots"):
-        imageio.imwrite(screenshot_path, img)
+        iio.imwrite(screenshot_path, img)
 
     # if a reference screenshot exists, assert it is equal
     assert (
         screenshot_path.exists()
     ), "found # test_example = true but no reference screenshot available"
-    stored_img = imageio.imread(screenshot_path)
+    stored_img = iio.imread(screenshot_path)
     # assert similarity
     is_similar = np.allclose(img, stored_img, atol=1)
     update_diffs(module, is_similar, img, stored_img)
@@ -143,7 +143,7 @@ def update_diffs(module, is_similar, img, stored_img):
     for path, slicer in diffs.items():
         if not is_similar:
             diff = get_diffs_rgba(slicer)
-            imageio.imwrite(path, diff)
+            iio.imwrite(path, diff)
         elif path.exists():
             path.unlink()
 

--- a/examples/volume_render1.py
+++ b/examples/volume_render1.py
@@ -2,7 +2,7 @@
 Render a volume. Shift-click to draw white blobs inside the volume.
 """
 
-import imageio
+import imageio.v3 as iio
 import numpy as np
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
@@ -12,7 +12,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-voldata = imageio.volread("imageio:stent.npz").astype(np.float32)
+voldata = iio.imread("imageio:stent.npz").astype(np.float32)
 
 
 tex = gfx.Texture(voldata, dim=3)

--- a/examples/volume_render2.py
+++ b/examples/volume_render2.py
@@ -2,7 +2,7 @@
 Render three volumes using different world transforms.
 """
 
-import imageio
+import imageio.v3 as iio
 import numpy as np
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
@@ -12,7 +12,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-voldata = imageio.volread("imageio:stent.npz").astype(np.float32)
+voldata = iio.imread("imageio:stent.npz").astype(np.float32)
 
 geometry = gfx.Geometry(grid=voldata)
 material = gfx.VolumeRayMaterial(clim=(0, 2000))

--- a/examples/volume_slice1.py
+++ b/examples/volume_slice1.py
@@ -3,7 +3,7 @@ Render slices through a volume, by uploading to a 2D texture.
 Simple and ... slow.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -12,7 +12,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-vol = imageio.volread("imageio:stent.npz").astype("float32") / 2000
+vol = iio.imread("imageio:stent.npz").astype("float32") / 2000
 nslices = vol.shape[0]
 index = nslices // 2
 im = vol[index].copy()

--- a/examples/volume_slice2.py
+++ b/examples/volume_slice2.py
@@ -3,7 +3,7 @@ Render slices through a volume, by creating a 3D texture, with 2D views.
 Simple and relatively fast, but no subslices.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -12,7 +12,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-vol = imageio.volread("imageio:stent.npz").astype("float32") / 2000
+vol = iio.imread("imageio:stent.npz").astype("float32") / 2000
 nslices = vol.shape[0]
 index = nslices // 2
 

--- a/examples/volume_slice3.py
+++ b/examples/volume_slice3.py
@@ -3,7 +3,7 @@ Render slices through a volume, by creating a 3D texture, and sampling onto
 a plane geometry. Simple, fast and subpixel!
 """
 
-import imageio
+import imageio.v3 as iio
 import numpy as np
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
@@ -13,7 +13,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-vol = imageio.volread("imageio:stent.npz").astype("float32") / 2000
+vol = iio.imread("imageio:stent.npz").astype("float32") / 2000
 nslices = vol.shape[0]
 index = nslices // 2
 

--- a/examples/volume_slice4.py
+++ b/examples/volume_slice4.py
@@ -3,7 +3,7 @@ Render slices through a volume, by creating a 3D texture, and viewing
 it with a VolumeSliceMaterial. Easy because we can just define the view plane.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
@@ -12,7 +12,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-voldata = imageio.volread("imageio:stent.npz").astype("float32")
+voldata = iio.imread("imageio:stent.npz").astype("float32")
 nslices = voldata.shape[0]
 index = nslices // 2
 

--- a/examples/world_bounding_box.py
+++ b/examples/world_bounding_box.py
@@ -4,7 +4,7 @@ Prints the world bounding box of the scene which used
 to trigger an Exception.
 """
 
-import imageio
+import imageio.v3 as iio
 import numpy as np
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
@@ -14,7 +14,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-voldata = imageio.volread("imageio:stent.npz").astype(np.float32)
+voldata = iio.imread("imageio:stent.npz").astype(np.float32)
 
 geometry = gfx.Geometry(grid=voldata)
 geometry_with_texture = gfx.Geometry(grid=gfx.Texture(data=voldata, dim=3))


### PR DESCRIPTION
This PR updates the examples to the ImageIO v3 API. For the most part, this is a simple renaming, except for `volread` calls, which are now `imread` calls, too. So those have changed.