### PR TITLE
make gfx.show customizable

### DIFF
--- a/examples/cube.py
+++ b/examples/cube.py
@@ -4,26 +4,18 @@ Example showing a single geometric cube.
 
 import pygfx as gfx
 
-
-scene = gfx.Scene()
-
 cube = gfx.Mesh(
     gfx.box_geometry(200, 200, 200),
     gfx.MeshPhongMaterial(color="#336699"),
 )
-scene.add(cube)
-
-camera = gfx.PerspectiveCamera(70, 16 / 9)
-camera.position.z = 400
-
-scene.add(gfx.AmbientLight())
-scene.add(gfx.DirectionalLight())
 
 
+@gfx.Display.before_render
 def animate():
     rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.005, 0.01))
     cube.rotation.multiply(rot)
 
 
 if __name__ == "__main__":
-    gfx.show(scene, camera=camera, before_render=animate)
+    disp = gfx.Display()
+    disp.show(cube)

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -2,11 +2,9 @@
 Example showing a single geometric cube.
 """
 
-from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
 scene = gfx.Scene()
 
 cube = gfx.Mesh(
@@ -26,10 +24,6 @@ def animate():
     rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.005, 0.01))
     cube.rotation.multiply(rot)
 
-    renderer.render(scene, camera)
-    renderer.request_draw()
-
 
 if __name__ == "__main__":
-    renderer.request_draw(animate)
-    run()
+    gfx.show(scene, camera=camera, before_render=animate)

--- a/examples/cube.py
+++ b/examples/cube.py
@@ -10,7 +10,6 @@ cube = gfx.Mesh(
 )
 
 
-@gfx.Display.before_render
 def animate():
     rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.005, 0.01))
     cube.rotation.multiply(rot)
@@ -18,4 +17,5 @@ def animate():
 
 if __name__ == "__main__":
     disp = gfx.Display()
+    disp.before_render = animate
     disp.show(cube)

--- a/examples/geometry_plane.py
+++ b/examples/geometry_plane.py
@@ -2,19 +2,23 @@
 Use a plane geometry to show a texture, which is continuously updated to show video.
 """
 
-import imageio
+import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
+
+
+def loop_video(video):
+    while True:
+        for frame in iio.imiter(video):
+            yield frame[:, :, 0]
 
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-reader = imageio.get_reader("imageio:cockatoo.mp4")
-im = reader.get_next_data()[:, :, 1]
-
-tex = gfx.Texture(im, dim=2)
+frame_generator = loop_video("imageio:cockatoo.mp4")
+tex = gfx.Texture(next(frame_generator), dim=2)
 
 geometry = gfx.plane_geometry(200, 200, 12, 12)
 material = gfx.MeshBasicMaterial(map=tex.get_view(filter="linear"))
@@ -24,20 +28,18 @@ scene.add(plane)
 camera = gfx.PerspectiveCamera(70)
 camera.position.z = 200
 
+scene.add(gfx.AmbientLight(), gfx.DirectionalLight())
+
 
 def animate():
     # Read next frame, rewind if we reach the end
-    try:
-        tex.data[:] = reader.get_next_data()[:, :, 1]
-    except IndexError:
-        reader.set_image_index(0)
-    else:
-        tex.update_range((0, 0, 0), tex.size)
+    tex.data[:] = next(frame_generator)
+    tex.update_range((0, 0, 0), tex.size)
 
     renderer.render(scene, camera)
     canvas.request_draw()
 
 
 if __name__ == "__main__":
-    canvas.draw_frame = animate
+    renderer.request_draw(animate)
     run()

--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -14,7 +14,7 @@ from .renderers import *
 
 from .utils.color import Color
 from .utils.load import load_scene
-from .utils.show import show
+from .utils.show import show, Display
 from .utils.viewport import Viewport
 from .utils import cm, logger
 

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -3,6 +3,8 @@ Quickly visualize world objects with as
 little boilerplate as possible.
 """
 
+import sys
+
 from .. import (
     Background,
     BackgroundMaterial,
@@ -21,7 +23,6 @@ def show(
     up=None,
     *,
     canvas=None,
-    event_loop=None,
     renderer=None,
     controller=None,
     camera=None,
@@ -29,11 +30,36 @@ def show(
     after_render=None,
     draw_function=None
 ):
-    """Visualize a given WorldObject in a new window with an interactive camera.
+    """Display a WorldObject
 
-    Parameters:
-        object (WorldObject): The object to show.
-        up (Vector3): Optional. Configure the up vector for the camera controller.
+    This function provides you with the basic scaffolding to visualize a given
+    WorldObject in a new window. While it does add scaffolding, it aims to be
+    fully customizable so that you can replace each piece as needed.
+
+    Parameters
+    ----------
+        object : gfx.WorldObject
+            The object to show.
+        up : gfx.Vector3
+            If set, set the default camera controller's up vector to this value.
+        canvas : WgpuCanvas
+            The canvas to use to display the object.
+        renderer : gfx.Renderer
+            The renderer to use while drawing the scene.
+        controller : gfx.Controller
+            The camera controller to use.
+        camera : gfx.Camera
+            The camera to use.
+        before_render : Callable
+            A callback that will be executed during each draw call before a new
+            render is made.
+        after_render : Callable
+            A callback that will be executed during each draw call after a new
+            render is made.
+        draw_function : Callable
+            Replaces the draw callback with a custom one. If set both
+            `before_render` and `after_render` will have no effect.
+        
     """
 
     if isinstance(object, Scene):
@@ -56,11 +82,8 @@ def show(
 
         canvas = WgpuCanvas()
         event_loop = run
-    elif event_loop is None:
-        # TODO: find the matching run function
-        raise ValueError(
-            "When providing a canvas you also need to provide the event loop."
-        )
+    else:
+        event_loop = sys.modules[renderer.target.__module__].run
 
     if renderer is None:
         renderer = WgpuRenderer(canvas)

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -27,10 +27,10 @@ class Display:
 
     This class provides the basic scaffolding needed to visualize a given
     WorldObject. To do so the class chooses a sensible default for each part of
-    the full setup (@almarklein: what is the technical term for the full setup?)
-    unless the value is explicitly set by the user or exists as a child of the
-    ``object`` passed to ``show()``. For example, it will create a camera unless you explicitly set a
-    value for camera or if there is (at least) one camera in the scene.
+    the full setup unless the value is explicitly set by the user or exists as a
+    child of ``object``. For example, it will create a camera unless you
+    explicitly set a value for camera or if there is (at least) one camera in
+    the scene.
 
     Parameters
     ----------
@@ -205,12 +205,15 @@ def show(
     Parameters
     ----------
     object : gfx.WorldObject
-            The object to show. If it is not a :class:`gfx.Scene <pygfx.Scene>`
-            then Display will wrap it into a new scene containing lights and a
-            background.
+        The object to show. If it is not a :class:`gfx.Scene <pygfx.Scene>`
+        then Display will wrap it into a new scene containing lights and a
+        background.
     up : gfx.Vector3
         If set, and ``object`` does not contain a controller, set the camera
         controller's up vector to this value.
+        canvas : WgpuCanvas
+        The canvas used to display the object. If both ``renderer`` and
+        ``canvas`` are set, then the renderer needs to use the set canvas.
     canvas : WgpuCanvas
         The canvas used to display the object. If both ``renderer`` and
         ``canvas`` are set, then the renderer needs to use the set canvas.
@@ -218,12 +221,10 @@ def show(
         The renderer to use while drawing the scene. If both ``renderer``
         and ``canvas`` are set, then the renderer needs to use the set canvas.
     controller : gfx.Controller
-        The camera controller to use. If not set, Display will use the first
-        controller defined on ``object``. If there is none, Display will
-        create one.
+        The camera controller to use. 
     camera : gfx.Camera
         The camera to use. If not set, Display will use the first camera
-        defined on ``object``. If there is none, Display will create one.
+        in the scene graph. If there is none, Display will create one.
     before_render : Callable
         A callback that will be executed during each draw call before a new
         render is made.
@@ -231,8 +232,14 @@ def show(
         A callback that will be executed during each draw call after a new
         render is made.
     draw_function : Callable
-        Replaces the draw callback with a custom one. If set both
+        Replaces the draw callback with a custom one. If set, both
         `before_render` and `after_render` will have no effect.
+
+    Notes
+    -----
+    If you want to display multiple objects, use :class:`gfx.Group
+    <pygfx.Group>` instead of :class:`gfx.Scene <pygfx.Scene>` if you
+    want lights and background to be added.
 
     """
 

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -60,7 +60,7 @@ def show(
         draw_function : Callable
             Replaces the draw callback with a custom one. If set both
             `before_render` and `after_render` will have no effect.
-        
+
     """
 
     if isinstance(object, Scene):
@@ -81,13 +81,13 @@ def show(
     if renderer is not None:
         canvas = renderer.target
     elif canvas is None:
-        from wgpu.gui.auto import WgpuCanvas, run
+        from wgpu.gui.auto import WgpuCanvas
 
         canvas = WgpuCanvas()
         renderer = WgpuRenderer(canvas)
     else:
         renderer = WgpuRenderer(canvas)
-    
+
     if controller is None:
         look_at = camera.show_object(object)
         controller = OrbitController(camera.position.clone(), look_at, up=up)

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -28,8 +28,8 @@ class Display:
     This class provides the basic scaffolding needed to visualize a given
     WorldObject. To do so the class chooses a sensible default for each part of
     the full setup (@almarklein: what is the technical term for the full setup?)
-    unless the value is explicitly set by the user or exists as a child of
-    ``object``. For example, it will create a camera unless you explicitly set a
+    unless the value is explicitly set by the user or exists as a child of the
+    ``object`` passed to ``show()``. For example, it will create a camera unless you explicitly set a
     value for camera or if there is (at least) one camera in the scene.
 
     Parameters
@@ -41,12 +41,10 @@ class Display:
         The renderer to use while drawing the scene. If both ``renderer``
         and ``canvas`` are set, then the renderer needs to use the set canvas.
     controller : gfx.Controller
-        The camera controller to use. If not set, Display will use the first
-        controller defined on ``object``. If there is none, Display will
-        create one.
+        The camera controller to use. 
     camera : gfx.Camera
         The camera to use. If not set, Display will use the first camera
-        defined on ``object``. If there is none, Display will create one.
+        in the scene graph. If there is none, Display will create one.
     before_render : Callable
         A callback that will be executed during each draw call before a new
         render is made.
@@ -54,7 +52,7 @@ class Display:
         A callback that will be executed during each draw call after a new
         render is made.
     draw_function : Callable
-        Replaces the draw callback with a custom one. If set both
+        Replaces the draw callback with a custom one. If set, both
         `before_render` and `after_render` will have no effect.
 
     """
@@ -113,9 +111,9 @@ class Display:
 
         Notes
         -----
-        If you want to display multiple objects prefer :class:`gfx.Group
-        <pygfx.Group>` over :class:`gfx.Scene <pygfx.Scene>` to avoid the pitfall of
-        forgetting to add lights to the scene.
+        If you want to display multiple objects, use :class:`gfx.Group
+        <pygfx.Group>` instead of :class:`gfx.Scene <pygfx.Scene>` if you
+        want lights and background to be added.
 
         """
 

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -19,7 +19,6 @@ from .. import (
     DirectionalLight,
     Light,
     Camera,
-    Controller,
 )
 
 

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -60,13 +60,15 @@ class RenderCallback:
         if instance is None:
             return self
 
-        value = getattr(instance, self.private_name, None)
-        if value is not None:
-            return value
+        try:
+            value = getattr(instance, self.private_name)
+        except AttributeError:
+            # persist the current class-level default on the instance
+            self.__set__(instance, self.default_callback)
 
-        # persist callback to prevent it from changing
-        self.__set__(instance, self.default_callback)
-        return self.default_callback
+            value = self.default_callback
+
+        return value
 
     def __set__(self, instance, value) -> None:
         setattr(instance, self.private_name, value)

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -196,7 +196,7 @@ class Display:
             scene.add(AmbientLight(), DirectionalLight())
         self.scene = scene
 
-        if len(self.find_children(Light)) == 0:
+        if not any(self.find_children(Light)):
             warnings.warn(
                 "Your scene does not contain any lights. Some objects may not be visible"
             )
@@ -204,7 +204,7 @@ class Display:
         existing_cameras = self.find_children(Camera)
         if self.camera:
             pass
-        elif len(existing_cameras) > 0:
+        elif any(existing_cameras):
             self.camera = existing_cameras[0]
         elif not self.camera:
             self.camera = PerspectiveCamera(70, 16 / 9)
@@ -227,12 +227,7 @@ class Display:
         else:
             pass
 
-        controllers = self.find_children(Controller)
-        if self.controller is not None:
-            pass
-        elif len(controllers) > 0:
-            self.controller = controllers[0]
-        else:
+        if self.controller is None:
             look_at = self.camera.show_object(object)
             self.controller = OrbitController(
                 self.camera.position.clone(), look_at, up=up

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -22,60 +22,6 @@ from .. import (
 )
 
 
-class RenderCallback:
-    """A callback used during the draw call
-
-    This class implements a Descriptor that manages the draw call callbacks of
-    Display. It's main purpose is to allow setting the default value of these
-    callbacks using a decorator-style syntax::
-
-        @gfx.Display.before_render
-        def animate():
-            ...
-
-        gfx.show()  # uses animate
-
-    Parameters
-    ----------
-    default : Callable
-        The default callback to use.
-
-    Notes
-    -----
-    Using the decorator feature above sets the class-level default for the
-    callback and affects all instances of Display that use the default value.
-
-    """
-
-    def __init__(self, default=None) -> None:
-        self.default_callback = default
-
-    def __set_name__(self, owner, name):
-        self.private_name = "_" + name
-
-    def __get__(self, instance, type=None):
-        # allow decorator-style setting of default
-        # callback
-        if instance is None:
-            return self
-
-        try:
-            value = getattr(instance, self.private_name)
-        except AttributeError:
-            # persist the current class-level default on the instance
-            self.__set__(instance, self.default_callback)
-
-            value = self.default_callback
-
-        return value
-
-    def __set__(self, instance, value) -> None:
-        setattr(instance, self.private_name, value)
-
-    def __call__(self, callback_fn) -> None:
-        self.default_callback = callback_fn
-
-
 class Display:
     """A Helper to display an object or scene
 
@@ -113,10 +59,6 @@ class Display:
 
     """
 
-    before_render = RenderCallback()
-    after_render = RenderCallback()
-    draw_function = RenderCallback()
-
     def __init__(
         self,
         canvas=None,
@@ -131,14 +73,10 @@ class Display:
         self.renderer = renderer
         self.controller = controller
         self.camera = camera
-        self.draw_function = draw_function or self.default_draw
         self.scene = None
-
-        if before_render is not None:
-            self.before_render = before_render
-
-        if after_render is not None:
-            self.after_render = after_render
+        self.before_render = before_render
+        self.after_render = after_render
+        self.draw_function = draw_function or self.default_draw
 
     def default_draw(self):
         if self.before_render is not None:

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -209,8 +209,6 @@ class Display:
         elif not self.camera:
             self.camera = PerspectiveCamera(70, 16 / 9)
             self.camera.add(DirectionalLight())
-            # do we really want to modify the scene and add
-            # a camera?
             self.scene.add(self.camera)
 
         if self.renderer is None and self.canvas is None:

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -4,6 +4,7 @@ little boilerplate as possible.
 """
 
 import sys
+import numpy as np
 
 from .. import (
     Background,
@@ -69,7 +70,10 @@ def show(
         scene = Scene()
         scene.add(object)
 
-        background = Background(None, BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+        dark_gray = np.array((169, 167, 168, 255)) / 255
+        light_gray = np.array((100, 100, 100, 255)) / 255
+
+        background = Background(None, BackgroundMaterial(light_gray, dark_gray))
         scene.add(background)
         scene.add(AmbientLight(0.2))
 

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -41,7 +41,7 @@ class Display:
         The renderer to use while drawing the scene. If both ``renderer``
         and ``canvas`` are set, then the renderer needs to use the set canvas.
     controller : gfx.Controller
-        The camera controller to use. 
+        The camera controller to use.
     camera : gfx.Camera
         The camera to use. If not set, Display will use the first camera
         in the scene graph. If there is none, Display will create one.
@@ -118,8 +118,10 @@ class Display:
         """
 
         if isinstance(object, Scene):
+            custom_scene = False
             scene = object
         else:
+            custom_scene = True
             scene = Scene()
             scene.add(object)
 
@@ -141,10 +143,12 @@ class Display:
             pass
         elif any(existing_cameras):
             self.camera = existing_cameras[0]
-        elif not self.camera:
+        elif custom_scene:
             self.camera = PerspectiveCamera(70, 16 / 9)
             self.camera.add(DirectionalLight())
             self.scene.add(self.camera)
+        else:
+            self.camera = PerspectiveCamera(70, 16 / 9)
 
         if self.renderer is None and self.canvas is None:
             from wgpu.gui.auto import WgpuCanvas
@@ -221,7 +225,7 @@ def show(
         The renderer to use while drawing the scene. If both ``renderer``
         and ``canvas`` are set, then the renderer needs to use the set canvas.
     controller : gfx.Controller
-        The camera controller to use. 
+        The camera controller to use.
     camera : gfx.Camera
         The camera to use. If not set, Display will use the first camera
         in the scene graph. If there is none, Display will create one.

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -45,7 +45,8 @@ def show(
         canvas : WgpuCanvas
             The canvas to use to display the object.
         renderer : gfx.Renderer
-            The renderer to use while drawing the scene.
+            The renderer to use while drawing the scene. If set, `canvas` is
+            ignored.
         controller : gfx.Controller
             The camera controller to use.
         camera : gfx.Camera
@@ -77,17 +78,16 @@ def show(
         camera.add(DirectionalLight(0.8))
         scene.add(camera)
 
-    if canvas is None:
+    if renderer is not None:
+        canvas = renderer.target
+    elif canvas is None:
         from wgpu.gui.auto import WgpuCanvas, run
 
         canvas = WgpuCanvas()
-        event_loop = run
-    else:
-        event_loop = sys.modules[renderer.target.__module__].run
-
-    if renderer is None:
         renderer = WgpuRenderer(canvas)
-
+    else:
+        renderer = WgpuRenderer(canvas)
+    
     if controller is None:
         look_at = camera.show_object(object)
         controller = OrbitController(camera.position.clone(), look_at, up=up)
@@ -110,4 +110,4 @@ def show(
         draw_function = animate
 
     canvas.request_draw(draw_function)
-    event_loop()
+    sys.modules[renderer.target.__module__].run()

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -5,6 +5,7 @@ little boilerplate as possible.
 
 import sys
 import numpy as np
+import warnings
 
 from .. import (
     Background,
@@ -16,7 +17,219 @@ from .. import (
     OrbitController,
     AmbientLight,
     DirectionalLight,
+    Light,
 )
+
+
+class DecorSet:
+    """Set function attributes using decorators.
+
+    This class implements a Descriptor that allows setting
+    it's
+
+    """
+
+    def __init__(self, default=None) -> None:
+        self.default_callback = default
+
+    def __set_name__(self, owner, name):
+        self.private_name = "_" + name
+
+    def __get__(self, instance, type=None):
+        # allow decorator-style setting of default
+        # callback
+        if instance is None:
+            return self
+
+        value = getattr(instance, self.private_name, None)
+        if value is not None:
+            return value
+
+        # persist callback to prevent it from changing
+        self.__set__(instance, self.default_callback)
+        return self.default_callback
+
+    def __set__(self, instance, value) -> None:
+        setattr(instance, self.private_name, value)
+
+    def __call__(self, callback_fn) -> None:
+        self.default_callback = callback_fn
+
+
+class Display:
+    """A Helper to Display Objects
+
+    This class provides the basic scaffolding needed to visualize a given
+    WorldObject in a new window. While it does add scaffolding, it aims to be
+    fully customizable so that you can replace each piece as needed.
+
+    Parameters
+    ----------
+        object : gfx.WorldObject
+            The object to show.
+        up : gfx.Vector3
+            If set, set the default camera controller's up vector to this value.
+        canvas : WgpuCanvas
+            The canvas to use to display the object.
+        renderer : gfx.Renderer
+            The renderer to use while drawing the scene. If set, `canvas` is
+            ignored.
+        controller : gfx.Controller
+            The camera controller to use.
+        camera : gfx.Camera
+            The camera to use.
+        before_render : Callable
+            A callback that will be executed during each draw call before a new
+            render is made.
+        after_render : Callable
+            A callback that will be executed during each draw call after a new
+            render is made.
+        draw_function : Callable
+            Replaces the draw callback with a custom one. If set both
+            `before_render` and `after_render` will have no effect.
+
+    """
+
+    before_render = DecorSet()
+    after_render = DecorSet()
+    draw_function = DecorSet()
+
+    def __init__(
+        self,
+        canvas=None,
+        renderer=None,
+        controller=None,
+        camera=None,
+        before_render=None,
+        after_render=None,
+        draw_function=None,
+    ) -> None:
+        self.canvas = canvas
+        self.renderer = renderer
+        self.controller = controller
+        self.camera = camera
+        self.draw_function = draw_function or self.default_draw
+        self.scene = None
+
+        if before_render is not None:
+            self.before_render = before_render
+
+        if after_render is not None:
+            self.after_render = after_render
+
+    def default_draw(self):
+        if self.before_render is not None:
+            self.before_render()
+
+        self.controller.update_camera(self.camera)
+        self.renderer.render(self.scene, self.camera)
+
+        if self.after_render is not None:
+            self.after_render()
+
+        self.renderer.request_draw()
+
+    def show(
+        self,
+        object: WorldObject,
+        up=None,
+    ):
+        """Display a WorldObject
+
+        This function provides you with the basic scaffolding to visualize a given
+        WorldObject in a new window. While it does add scaffolding, it aims to be
+        fully customizable so that you can replace each piece as needed.
+
+        Parameters
+        ----------
+            object : gfx.WorldObject
+                The object to show.
+            up : gfx.Vector3
+                If set, set the default camera controller's up vector to this value.
+            canvas : WgpuCanvas
+                The canvas to use to display the object.
+            renderer : gfx.Renderer
+                The renderer to use while drawing the scene. If set, `canvas` is
+                ignored.
+            controller : gfx.Controller
+                The camera controller to use.
+            camera : gfx.Camera
+                The camera to use.
+            before_render : Callable
+                A callback that will be executed during each draw call before a new
+                render is made.
+            after_render : Callable
+                A callback that will be executed during each draw call after a new
+                render is made.
+            draw_function : Callable
+                Replaces the draw callback with a custom one. If set both
+                `before_render` and `after_render` will have no effect.
+
+        """
+
+        if (
+            self.canvas is not None
+            and self.renderer is not None
+            and self.canvas != self.renderer.target
+        ):
+            raise ValueError("Display's render target differs from it's canvas.")
+
+        if isinstance(object, Scene):
+            scene = object
+        else:
+            scene = Scene()
+            scene.add(object)
+
+            dark_gray = np.array((169, 167, 168, 255)) / 255
+            light_gray = np.array((100, 100, 100, 255)) / 255
+
+            background = Background(None, BackgroundMaterial(light_gray, dark_gray))
+            scene.add(background)
+            scene.add(AmbientLight(), DirectionalLight())
+        self.scene = scene
+
+        if len(self.find_children(Light)) == 0:
+            warnings.warn(
+                "Your scene does not contain any lights. Some objects may not be visible"
+            )
+
+        if not self.camera:
+            self.camera = PerspectiveCamera(70, 16 / 9)
+            self.camera.add(DirectionalLight())
+            self.scene.add(self.camera)
+
+        if self.renderer is not None:
+            self.canvas = self.renderer.target
+        elif self.canvas is None:
+            from wgpu.gui.auto import WgpuCanvas
+
+            self.canvas = WgpuCanvas()
+            self.renderer = WgpuRenderer(self.canvas)
+        else:
+            self.renderer = WgpuRenderer(self.canvas)
+
+        if self.controller is None:
+            look_at = self.camera.show_object(object)
+            self.controller = OrbitController(
+                self.camera.position.clone(), look_at, up=up
+            )
+            self.controller.add_default_event_handlers(self.renderer, self.camera)
+
+        self.canvas.request_draw(self.draw_function)
+        sys.modules[self.canvas.__module__].run()
+
+    # this should probably live on WorldObject
+    def find_children(self, clazz):
+        """Return all children of the given type"""
+        objects = list()
+
+        # can we make traverse a generator?
+        # [x for x in self.scene.traverse(filter=lambda x: isinstance(x, clazz))
+        self.scene.traverse(
+            lambda x: objects.append(x) if isinstance(x, clazz) else None
+        )
+
+        return objects
 
 
 def show(
@@ -29,7 +242,7 @@ def show(
     camera=None,
     before_render=None,
     after_render=None,
-    draw_function=None
+    draw_function=None,
 ):
     """Display a WorldObject
 
@@ -64,54 +277,6 @@ def show(
 
     """
 
-    if isinstance(object, Scene):
-        scene = object
-    else:
-        scene = Scene()
-        scene.add(object)
-
-        dark_gray = np.array((169, 167, 168, 255)) / 255
-        light_gray = np.array((100, 100, 100, 255)) / 255
-
-        background = Background(None, BackgroundMaterial(light_gray, dark_gray))
-        scene.add(background)
-        scene.add(AmbientLight(0.2))
-
-    if not camera:
-        camera = PerspectiveCamera(70, 16 / 9)
-        camera.add(DirectionalLight(0.8))
-        scene.add(camera)
-
-    if renderer is not None:
-        canvas = renderer.target
-    elif canvas is None:
-        from wgpu.gui.auto import WgpuCanvas
-
-        canvas = WgpuCanvas()
-        renderer = WgpuRenderer(canvas)
-    else:
-        renderer = WgpuRenderer(canvas)
-
-    if controller is None:
-        look_at = camera.show_object(object)
-        controller = OrbitController(camera.position.clone(), look_at, up=up)
-        controller.add_default_event_handlers(renderer, camera)
-
-    if draw_function is None:
-
-        def animate():
-            if before_render is not None:
-                before_render()
-
-            controller.update_camera(camera)
-            renderer.render(scene, camera)
-
-            if after_render is not None:
-                after_render()
-
-            renderer.request_draw()
-
-        draw_function = animate
-
-    canvas.request_draw(draw_function)
-    sys.modules[renderer.target.__module__].run()
+    Display(
+        canvas, renderer, controller, camera, before_render, after_render, draw_function
+    ).show(object, up)


### PR DESCRIPTION
Closes: https://github.com/pygfx/pygfx/issues/378 and https://github.com/pygfx/pygfx/issues/383

This PR adds more flexibility to `gfx.show` by allowing the replacement of various parts of this default setup. In particular, it allows using a custom: `canvas`, `event_loop`, `renderer`, `controller`, `camera`, and `draw_function`. It also enhances the default draw function by introducing two callbacks: `before_render` and `after_render`, which allow customizing the draw call (eg. to add animations) without having to replace the entire thing.

I also changed the way lighting is treated by `gfx.show` and only add a light source when the user does not provide a `Scene` object. My angle here is that, if the user provides an entire scene, they probably have their reasons and don't want us to mess with it. I'm happy to revert this though if you think it would be better to add light.

I'm also not super happy with always having a controller (what if a person wants none), but I think this is a minor issue.

Finally, a point that we could consider is if we want to change the callbacks from kwargs on `show` to decorators. Ie., if we would like to enable something like:

```python
import pygfx as gfx

@gfx.show.before_render
def animate():
    ...

gfx.show()  # uses animate
```

---

Since this is my first PR that contributes actual code and I didn't find any active coverage tracking, I will ask explicitly: @almarklein  @Korijn What are your expectations towards tests and coverage?