### PR TITLE
Fix pbr metalness

### DIFF
--- a/pygfx/materials/_compat.py
+++ b/pygfx/materials/_compat.py
@@ -47,6 +47,8 @@ def trimesh_material(material):
         ).get_view(address_mode="repeat", filter="linear")
         gfx_material.roughness_map = metallic_roughness_map
         gfx_material.metalness_map = metallic_roughness_map
+        gfx_material.roughness = 1.0
+        gfx_material.metalness = 1.0
 
     if material.roughnessFactor is not None:
         gfx_material.roughness = material.roughnessFactor


### PR DESCRIPTION
To convert materials from trimesh, when "metalic_roughness_map" exists but "roughnessFactor" or "metalicFactor" does not exist, the corresponding default value should be 1.0.

In the current "pbr. py" example, "metalness_map" does not actually work:

![image](https://user-images.githubusercontent.com/8044566/204474152-f44e8c36-83b4-408a-8845-3c559004d8f2.png)

Correct results:

![image](https://user-images.githubusercontent.com/8044566/204474366-f5f393b6-5fb4-48c6-861e-972f273a0a65.png)
