### PR TITLE
Move find_children to WorldObject and call it iter

### DIFF
--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -348,11 +348,21 @@ class WorldObject(EventTarget, RootTrackable):
         skipped. Note that modifying the scene graph inside the callback
         is discouraged.
         """
+
+        for child in self.iter(skip_invisible=skip_invisible):
+            callback(child)
+
+    def iter(self, filter_fn=None, skip_invisible=False):
         if skip_invisible and not self.visible:
             return
-        callback(self)
+
+        if filter_fn is not None and not filter_fn(self):
+            return
+
+        yield self
+
         for child in self._children:
-            child.traverse(callback, skip_invisible)
+            yield from child.iter(filter_fn, skip_invisible)
 
     def update_matrix(self):
         p, r, s = self.position, self.rotation, self.scale

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -133,12 +133,12 @@ class Display:
             scene.add(AmbientLight(), DirectionalLight())
         self.scene = scene
 
-        if not any(self.find_children(Light)):
+        if not any(scene.iter(lambda x: isinstance(x, Light))):
             warnings.warn(
                 "Your scene does not contain any lights. Some objects may not be visible"
             )
 
-        existing_cameras = self.find_children(Camera)
+        existing_cameras = [x for x in scene.iter(lambda x: isinstance(x, Camera))]
         if self.camera:
             pass
         elif any(existing_cameras):
@@ -173,19 +173,6 @@ class Display:
 
         self.canvas.request_draw(self.draw_function)
         sys.modules[self.canvas.__module__].run()
-
-    # this should probably live on WorldObject
-    def find_children(self, clazz):
-        """Return all children of the given type"""
-        objects = list()
-
-        # can we make traverse a generator?
-        # [x for x in self.scene.traverse(filter=lambda x: isinstance(x, clazz))
-        self.scene.traverse(
-            lambda x: objects.append(x) if isinstance(x, clazz) else None
-        )
-
-        return objects
 
 
 def show(


### PR DESCRIPTION
Closes: https://github.com/pygfx/pygfx/issues/385

This PR moves `Display.find_children` to `WorldObject.iter` and reactors both `Display.show` and `WorldObject.traverse` to use the new `iter` method.