### PR TITLE
Fix WorldObject.iter function

### DIFF
--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -356,10 +356,8 @@ class WorldObject(EventTarget, RootTrackable):
         if skip_invisible and not self.visible:
             return
 
-        if filter_fn is not None and not filter_fn(self):
-            return
-
-        yield self
+        if not (filter_fn is not None and not filter_fn(self)):
+            yield self
 
         for child in self._children:
             yield from child.iter(filter_fn, skip_invisible)

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -353,6 +353,10 @@ class WorldObject(EventTarget, RootTrackable):
             callback(child)
 
     def iter(self, filter_fn=None, skip_invisible=False):
+        """Create a generator that iterates over this objects and its children.
+        If ``filter_fn`` is given, only objects for which it returns ``True``
+        are included.
+        """
         if skip_invisible and not self.visible:
             return
 

--- a/tests/objects/test_world_object.py
+++ b/tests/objects/test_world_object.py
@@ -180,3 +180,20 @@ def test_adjust_children_order():
     # is not in children
     root.add(child1, before=non_child)
     assert root.children == (child3, child2, child1)
+
+
+def test_iter():
+    class Foo(WorldObject):
+        pass
+
+    root = WorldObject()
+    root.add(Foo(), Foo())
+    assert len(list(root.iter(lambda x: isinstance(x, Foo)))) == 2
+
+    root = Foo()
+    root.add(Foo(), Foo())
+    assert len(list(root.iter(lambda x: isinstance(x, Foo)))) == 3
+
+    root = WorldObject()
+    root.add(Foo(), WorldObject(), Foo())
+    assert len(list(root.iter(lambda x: isinstance(x, Foo)))) == 2


### PR DESCRIPTION
I got a warning that my scene did not have any lights, when in fact it did have lights 😄  Seems like a small oversight, unless it was intended to work this way, but then we cannot use `iter` the way we do. Also added a test to avoid regressions.