### PR TITLE
Add more extensive envmap supports

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -66,6 +66,7 @@ Currently this includes the following classes, which comprise the public API:
 
     ~pygfx.materials.Material
     ~pygfx.materials.material_from_trimesh
+    ~pygfx.materials.MeshAbstractMaterial
     ~pygfx.materials.MeshBasicMaterial
     ~pygfx.materials.MeshPhongMaterial
     ~pygfx.materials.MeshNormalMaterial

--- a/examples/feature_demo/env_maps.py
+++ b/examples/feature_demo/env_maps.py
@@ -2,8 +2,10 @@
 Environment Map Effects
 =======================
 
-This example demonstrates the environment mapping effects of the CUBE-REFLECTION and CUBE-REFRACTION mapping modes
-in "MeshBasicMaterial", "MeshPhongMaterial", and "MeshStandardMaterial" for a given object.
+This example demonstrates the environment mapping effects
+of the "CUBE-REFLECTION" and "CUBE-REFRACTION" mapping modes
+in "MeshBasicMaterial", "MeshPhongMaterial", and "MeshStandardMaterial"
+for a given object.
 
 """
 

--- a/examples/feature_demo/env_maps.py
+++ b/examples/feature_demo/env_maps.py
@@ -1,0 +1,102 @@
+"""
+Environment Map Effects
+=======================
+
+This example demonstrates the environment mapping effects of the CUBE-REFLECTION and CUBE-REFRACTION mapping modes
+in "MeshBasicMaterial", "MeshPhongMaterial", and "MeshStandardMaterial" for a given object.
+
+"""
+
+# sphinx_gallery_pygfx_render = True
+
+import os
+import math
+
+import imageio
+import trimesh
+from pathlib import Path
+import pylinalg as la
+from wgpu.gui.auto import WgpuCanvas, run
+
+import pygfx as gfx
+
+try:
+    # modify this line if your model is located elsewhere
+    model_dir = Path(__file__).parents[1] / "data"
+except NameError:
+    # compatibility with sphinx-gallery
+    model_dir = Path(os.getcwd()).parent / "data"
+
+TEAPOT = model_dir / "teapot.stl"
+
+renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+scene = gfx.Scene()
+
+dir_light = gfx.DirectionalLight(1, 2)
+dir_light.local.position = (0, 0, 1)
+
+scene.add(gfx.AmbientLight(1, 0.2), dir_light)
+
+# Read cube image and turn it into a 3D image (a 4d array)
+env_img = imageio.imread("imageio:meadow_cube.jpg")
+cube_size = env_img.shape[1]
+env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+
+# Create environment map
+env_tex = gfx.Texture(
+    env_img, dim=2, size=(cube_size, cube_size, 6), generate_mipmaps=True
+)
+
+teapot = trimesh.load(TEAPOT)
+
+rot = la.quat_from_euler(-math.pi / 2, order="X")
+
+
+def add_mesh(material, env_mapping_mode, pos_x, pos_y):
+
+    material.env_map = env_tex
+    material.env_mapping_mode = env_mapping_mode
+
+    mesh = gfx.Mesh(gfx.geometry_from_trimesh(teapot), material)
+
+    mesh.local.position = (pos_x, pos_y, 0)
+    mesh.local.rotation = la.quat_mul(rot, mesh.local.rotation)
+    scene.add(mesh)
+
+
+# BasicMaterial - CUBE-REFRACTION
+material = gfx.MeshBasicMaterial()
+add_mesh(material, "CUBE-REFRACTION", -60, 0)
+
+# BasicMaterial - CUBE-REFLECTION
+material = gfx.MeshBasicMaterial()
+add_mesh(material, "CUBE-REFLECTION", -60, -60)
+
+# PhongMaterial - CUBE-REFRACTION
+material = gfx.MeshPhongMaterial()
+material.env_combine_mode = "MIX"  # can be "MIX", "MULTIPLY" or "ADD"
+add_mesh(material, "CUBE-REFRACTION", 0, 0)
+
+# PhongMaterial - CUBE-REFLECTION
+material = gfx.MeshPhongMaterial()
+material.env_combine_mode = "MIX"  # can be "MIX", "MULTIPLY" or "ADD"
+add_mesh(material, "CUBE-REFLECTION", 0, -60)
+
+# StandardMaterial - CUBE-REFRACTION
+material = gfx.MeshStandardMaterial(roughness=0.1, metalness=1.0)
+add_mesh(material, "CUBE-REFRACTION", 60, 0)
+
+# StandardMaterial - CUBE-REFLECTION
+material = gfx.MeshStandardMaterial(roughness=0.1, metalness=1.0)
+add_mesh(material, "CUBE-REFLECTION", 60, -60)
+
+background = gfx.Background(None, gfx.BackgroundSkyboxMaterial(map=env_tex))
+scene.add(background)
+
+camera = gfx.PerspectiveCamera(45, 16 / 9)
+camera.show_object(scene, view_dir=(0, 0, -300))
+controller = gfx.OrbitController(camera, register_events=renderer)
+
+if __name__ == "__main__":
+    renderer.request_draw(lambda: renderer.render(scene, camera))
+    run()

--- a/examples/feature_demo/env_maps.py
+++ b/examples/feature_demo/env_maps.py
@@ -55,7 +55,6 @@ rot = la.quat_from_euler(-math.pi / 2, order="X")
 
 
 def add_mesh(material, env_mapping_mode, pos_x, pos_y):
-
     material.env_map = env_tex
     material.env_mapping_mode = env_mapping_mode
 

--- a/pygfx/materials/__init__.py
+++ b/pygfx/materials/__init__.py
@@ -16,6 +16,7 @@ colormaps, the strength of specular reflections, etc.
     Material
     material_from_trimesh
 
+    MeshAbstractMaterial
     MeshBasicMaterial
     MeshPhongMaterial
     MeshNormalMaterial
@@ -53,6 +54,7 @@ colormaps, the strength of specular reflections, etc.
 from ._base import Material
 from ._compat import material_from_trimesh
 from ._mesh import (
+    MeshAbstractMaterial,
     MeshBasicMaterial,
     MeshPhongMaterial,
     MeshNormalMaterial,

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -185,7 +185,8 @@ class MeshBasicMaterial(MeshAbstractMaterial):
     env_mapping_mode : str
         The environment mapping mode.
         The default value is "CUBE-REFLECTION" and the valid values are "CUBE-REFLECTION" and "CUBE-REFRACTION".
-
+    kwargs : Any
+        Additional kwargs will be passed to the :class:`base class <pygfx.MeshAbstractMaterial>`.
     """
 
     uniform_type = dict(

--- a/pygfx/renderers/wgpu/_shader.py
+++ b/pygfx/renderers/wgpu/_shader.py
@@ -260,6 +260,15 @@ class WorldObjectShader(BaseShader):
 
         """
 
+        refract = """
+        fn refract( light : vec3<f32>, normal : vec3<f32>, eta : f32 ) -> vec3<f32> {
+            let cosTheta = dot( -light, normal );
+            let rOutPerp = eta * ( light + cosTheta * normal );
+            let rOutParallel = -sqrt( abs( 1.0 - dot( rOutPerp, rOutPerp ) ) ) * normal;
+            return rOutPerp + rOutParallel;
+        }
+        """
+
         return (
             ""
             + math
@@ -267,6 +276,7 @@ class WorldObjectShader(BaseShader):
             + ortho
             + ndc_to_world_pos
             + srgb2physical
+            + refract
             + lighting
             + self._code_colormap()
             + self._code_clipping_planes()

--- a/pygfx/renderers/wgpu/_shaderbase.py
+++ b/pygfx/renderers/wgpu/_shaderbase.py
@@ -458,7 +458,7 @@ class BaseShader:
         self._binding_codes[binding.name] = code
 
     def _define_texture(self, bindgroup, index, binding):
-        texture = binding.resource  # or view
+        texture = binding.resource  # GfxTextureView
         format = to_texture_format(texture.format)
         if "norm" in format or "float" in format:
             format = "f32"

--- a/pygfx/renderers/wgpu/meshshader.py
+++ b/pygfx/renderers/wgpu/meshshader.py
@@ -93,6 +93,30 @@ class MeshShader(WorldObjectShader):
                 )
             )
 
+        sampler = GfxSampler(material.map_interpolation, "repeat")
+        # set envmap configs
+        if getattr(material, "env_map", None):
+            self._check_texture(
+                material.env_map, 6
+            )  # TODO: envmap not only cube, but also equirect (hdr format)
+            view = GfxTextureView(material.env_map, view_dim="cube")
+            bindings.append(
+                Binding("s_env_map", "sampler/filtering", sampler, "FRAGMENT")
+            )
+            bindings.append(Binding("t_env_map", "texture/auto", view, "FRAGMENT"))
+
+            if isinstance(material, MeshStandardMaterial):
+                self["use_IBL"] = True
+            elif isinstance(material, (MeshBasicMaterial, MeshPhongMaterial)):
+                self["use_env_map"] = True
+                self["env_combine_mode"] = getattr(
+                    material, "env_combine_mode", "MULTIPLY"
+                )
+
+            self["env_mapping_mode"] = getattr(
+                material, "env_mapping_mode", "CUBE-REFLECTION"
+            )
+
         # Define shader code for binding
         bindings = {i: binding for i, binding in enumerate(bindings)}
         self.define_bindings(0, bindings)
@@ -358,8 +382,8 @@ class MeshShader(WorldObjectShader):
             $$ endif
             let opacity = color_value.a * u_material.opacity;
 
-            // Lighting
-            $$ if lighting
+            // Get normal used to calculate lighting or reflection
+            $$ if lighting or use_env_map is defined
                 // Get view direction
                 let view = select(
                     normalize(u_stdinfo.cam_transform_inv[3].xyz - varyings.world_pos),
@@ -373,10 +397,34 @@ class MeshShader(WorldObjectShader):
                     let normal_map_scale = vec3<f32>( normal_map.xy * u_material.normal_scale, normal_map.z );
                     normal = perturbNormal2Arb(view, normal, normal_map_scale, varyings.texcoord, is_front);
                 $$ endif
+            $$ endif
+
+            // Lighting
+            $$ if lighting
                 // Do the math
                 let physical_color = lighting_{{ lighting }}(varyings, normal, view, physical_albeido);
             $$ else
                 let physical_color = physical_albeido;
+            $$ endif
+
+            // Environment mapping
+            $$ if use_env_map is defined
+                let reflectivity = u_material.reflectivity;
+                let specular_strength = 1.0; // TODO: support specular_map
+                $$ if env_mapping_mode == "CUBE-REFLECTION"
+                    var reflectVec = reflect( -view, normal );
+                $$ elif env_mapping_mode == "CUBE-REFRACTION"
+                    var reflectVec = refract( -view, normal, u_material.refraction_ratio );
+                $$ endif
+                var env_color_srgb = textureSample( t_env_map, s_env_map, vec3<f32>( -reflectVec.x, reflectVec.yz) );
+                let env_color = srgb2physical(env_color_srgb.rgb); // TODO: maybe already in linear-space
+                $$ if env_combine_mode == 'MULTIPLY'
+                    var physical_color = mix(physical_color, physical_color * env_color.xyz, specular_strength * reflectivity);
+                $$ elif env_combine_mode == 'MIX'
+                    var physical_color = mix(physical_color, env_color.xyz, specular_strength * reflectivity);
+                $$ elif env_combine_mode == 'ADD'
+                    var physical_color = physical_color + env_color.xyz * specular_strength * reflectivity;
+                $$ endif
             $$ endif
 
             $$ if wireframe
@@ -411,6 +459,12 @@ class MeshShader(WorldObjectShader):
 
     def code_lighting(self):
         return ""
+
+    def _check_texture(self, t, size2=1):
+        assert isinstance(t, Texture)
+        assert t.size[2] == size2
+        fmt = to_texture_format(t.format)
+        assert "norm" in fmt or "float" in fmt
 
 
 @register_wgpu_render_function(Mesh, MeshNormalMaterial)
@@ -450,8 +504,13 @@ class MeshStandardShader(MeshShader):
 
         bindings = []
 
+        F = "FRAGMENT"  # noqa: N806
+        sampling = "sampler/filtering"
+        sampler = GfxSampler(material.map_interpolation, "repeat")
+        texturing = "texture/auto"
+
         # We need uv to use the maps, so if uv not exist, ignore all maps
-        if geometry.texcoords is not None:
+        if hasattr(geometry, "texcoords") and geometry.texcoords is not None:
             # Texcoords must always be nx2 since it used for all texture maps.
             if not (
                 geometry.texcoords.data.ndim == 2
@@ -459,55 +518,36 @@ class MeshStandardShader(MeshShader):
             ):
                 raise ValueError("For standard material, the texcoords must be Nx2")
 
-            # Ensure all the maps data are float32 fomat, so we can use textureSampler.
-            def check_texture(t, size2=1):
-                assert isinstance(t, Texture)
-                assert t.size[2] == size2
-                fmt = to_texture_format(t.format)
-                assert "norm" in fmt or "float" in fmt
-
-            F = "FRAGMENT"  # noqa: N806
-            sampling = "sampler/filtering"
-            sampler = GfxSampler(material.map_interpolation, "repeat")
-            texturing = "texture/auto"
-
-            if material.env_map is not None:
-                check_texture(material.env_map, 6)
-                view = GfxTextureView(material.env_map, view_dim="cube")
-                self["use_env_map"] = True
-                bindings.append(Binding("s_env_map", sampling, sampler, F))
-                bindings.append(Binding("t_env_map", texturing, view, F))
-
             if material.normal_map is not None:
-                check_texture(material.normal_map)
+                self._check_texture(material.normal_map)
                 view = GfxTextureView(material.normal_map, view_dim="2d")
                 self["use_normal_map"] = True
                 bindings.append(Binding("s_normal_map", sampling, sampler, F))
                 bindings.append(Binding("t_normal_map", texturing, view, F))
 
             if material.roughness_map is not None:
-                check_texture(material.roughness_map)
+                self._check_texture(material.roughness_map)
                 view = GfxTextureView(material.roughness_map, view_dim="2d")
                 self["use_roughness_map"] = True
                 bindings.append(Binding("s_roughness_map", sampling, sampler, F))
                 bindings.append(Binding("t_roughness_map", texturing, view, F))
 
             if material.metalness_map is not None:
-                check_texture(material.metalness_map)
+                self._check_texture(material.metalness_map)
                 view = GfxTextureView(material.metalness_map, view_dim="2d")
                 self["use_metalness_map"] = True
                 bindings.append(Binding("s_metalness_map", sampling, sampler, F))
                 bindings.append(Binding("t_metalness_map", texturing, view, F))
 
             if material.emissive_map is not None:
-                check_texture(material.emissive_map)
+                self._check_texture(material.emissive_map)
                 view = GfxTextureView(material.emissive_map, view_dim="2d")
                 self["use_emissive_map"] = True
                 bindings.append(Binding("s_emissive_map", sampling, sampler, F))
                 bindings.append(Binding("t_emissive_map", texturing, view, F))
 
             if material.ao_map is not None:
-                check_texture(material.ao_map)
+                self._check_texture(material.ao_map)
                 view = GfxTextureView(material.ao_map, view_dim="2d")
                 self["use_ao_map"] = True
                 bindings.append(Binding("s_ao_map", sampling, sampler, F))

--- a/pygfx/renderers/wgpu/meshshader.py
+++ b/pygfx/renderers/wgpu/meshshader.py
@@ -35,8 +35,8 @@ class MeshShader(WorldObjectShader):
         self["instanced"] = isinstance(wobject, InstancedMesh)
 
         # Is this a wireframe mesh?
-        self["wireframe"] = material.wireframe
-        self["flat_shading"] = material.flat_shading
+        self["wireframe"] = getattr(material, "wireframe", False)
+        self["flat_shading"] = getattr(material, "flat_shading", False)
 
         # Lighting off in the base class
         self["lighting"] = ""

--- a/pygfx/renderers/wgpu/meshshader.py
+++ b/pygfx/renderers/wgpu/meshshader.py
@@ -107,7 +107,7 @@ class MeshShader(WorldObjectShader):
 
             if isinstance(material, MeshStandardMaterial):
                 self["use_IBL"] = True
-            elif isinstance(material, (MeshBasicMaterial, MeshPhongMaterial)):
+            elif isinstance(material, MeshBasicMaterial):
                 self["use_env_map"] = True
                 self["env_combine_mode"] = getattr(
                     material, "env_combine_mode", "MULTIPLY"


### PR DESCRIPTION
Try adding more extensive environment map supports, to make it suitable for MeshBasicMaterial, MeshPhongMaterial, and MeshStandardMaterial.

Add more environment map types and mapping modes.
At present, the "cube-reflection" and "cube-refraction" mapping are supported first.

![image](https://user-images.githubusercontent.com/8044566/207057737-34a3f7b8-a845-47a2-bd15-860492f8dee0.png)

The "env_maps.py" example shows the effect of the "cube-reflection" and "cube-refraction" mapping modes of "MeshBasicMaterial", "MeshPhongMaterial", and "MeshStandardMaterial" respectively.