### PR TITLE
Tame backgrounds

### DIFF
--- a/examples/feature_demo/plot_colormap_channels.py
+++ b/examples/feature_demo/plot_colormap_channels.py
@@ -6,16 +6,13 @@ Example demonstrating colormaps in 4 modes: grayscale, gray+alpha, RGB, RGBA.
 """
 
 # sphinx_gallery_pygfx_render = True
+# sphinx_gallery_pygfx_target_name = "disp"
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(900, 400))
-renderer = gfx.renderers.WgpuRenderer(canvas)
-scene = gfx.Scene()
-scene.add(gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1))))
+group = gfx.Group()
 
 
 geometry = gfx.torus_knot_geometry(1, 0.3, 128, 32)
@@ -23,15 +20,12 @@ geometry.texcoords = gfx.Buffer(geometry.texcoords.data[:, 0])
 
 camera = gfx.OrthographicCamera(16, 3)
 
-scene.add(gfx.AmbientLight())
-scene.add(gfx.DirectionalLight(position=(0, 1, 1)))
-
 
 def create_object(tex, xpos):
     material = gfx.MeshPhongMaterial(map=tex)
     obj = gfx.Mesh(geometry, material)
     obj.position.x = xpos
-    scene.add(obj)
+    group.add(obj)
 
 
 # === 1-channel colormap: grayscale
@@ -61,13 +55,11 @@ create_object(tex1, +6)
 
 def animate():
     rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.0071, 0.01))
-    for obj in scene.children:
+    for obj in group.children:
         obj.rotation.multiply(rot)
-
-    renderer.render(scene, camera)
-    canvas.request_draw()
 
 
 if __name__ == "__main__":
-    canvas.request_draw(animate)
-    run()
+    disp = gfx.Display()
+    disp.before_render = animate
+    disp.show(group)

--- a/examples/feature_demo/plot_geometry_cubes.py
+++ b/examples/feature_demo/plot_geometry_cubes.py
@@ -6,15 +6,13 @@ Example showing multiple rotating cubes. This also tests the depth buffer.
 """
 
 # sphinx_gallery_pygfx_render = True
+# sphinx_gallery_pygfx_target_name = "disp"
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
-renderer = gfx.renderers.WgpuRenderer(canvas)
-scene = gfx.Scene()
+group = gfx.Group()
 
 im = iio.imread("imageio:chelsea.png")
 tex = gfx.Texture(im, dim=2).get_view(filter="linear")
@@ -24,13 +22,7 @@ geometry = gfx.box_geometry(100, 100, 100)
 cubes = [gfx.Mesh(geometry, material) for i in range(8)]
 for i, cube in enumerate(cubes):
     cube.position.set(350 - i * 100, 0, 0)
-    scene.add(cube)
-
-background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
-scene.add(background)
-
-camera = gfx.PerspectiveCamera(70, 16 / 9)
-camera.position.z = 500
+    group.add(cube)
 
 
 def animate():
@@ -40,10 +32,8 @@ def animate():
         )
         cube.rotation.multiply(rot)
 
-    renderer.render(scene, camera)
-    canvas.request_draw()
-
 
 if __name__ == "__main__":
-    canvas.request_draw(animate)
-    run()
+    disp = gfx.Display()
+    disp.before_render = animate
+    disp.show(group)

--- a/examples/feature_demo/plot_geometry_polyhedron.py
+++ b/examples/feature_demo/plot_geometry_polyhedron.py
@@ -5,14 +5,11 @@ Rotating Polyhedra
 Example showing multiple rotating polyhedrons.
 """
 # sphinx_gallery_pygfx_render = True
+# sphinx_gallery_pygfx_target_name = "disp"
 
-from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
-
-canvas = WgpuCanvas()
-renderer = gfx.renderers.WgpuRenderer(canvas)
-scene = gfx.Scene()
+group = gfx.Group()
 
 material = gfx.MeshPhongMaterial()
 geometries = [
@@ -25,15 +22,7 @@ geometries = [
 polyhedrons = [gfx.Mesh(g, material) for g in geometries]
 for i, polyhedron in enumerate(polyhedrons):
     polyhedron.position.set(6 - i * 3, 0, 0)
-    scene.add(polyhedron)
-
-background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
-scene.add(background)
-
-camera = gfx.PerspectiveCamera(70, 16 / 9)
-camera.position.z = 10
-
-scene.add(gfx.AmbientLight(), camera.add(gfx.DirectionalLight()))
+    group.add(polyhedron)
 
 
 def animate():
@@ -41,10 +30,8 @@ def animate():
         rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.01, 0.02))
         polyhedron.rotation.multiply(rot)
 
-    renderer.render(scene, camera)
-    canvas.request_draw()
-
 
 if __name__ == "__main__":
-    canvas.request_draw(animate)
-    run()
+    disp = gfx.Display()
+    disp.before_render = animate
+    disp.show(group)

--- a/examples/feature_demo/plot_geometry_polyhedron_subdivisions.py
+++ b/examples/feature_demo/plot_geometry_polyhedron_subdivisions.py
@@ -21,9 +21,6 @@ for i, geometry in enumerate(geometries):
     polyhedron.position.set(6 - i * 3, 0, 0)
     scene.add(polyhedron)
 
-background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
-scene.add(background)
-
 
 if __name__ == "__main__":
     disp = gfx.Display()

--- a/examples/feature_demo/plot_manual_matrix_update.py
+++ b/examples/feature_demo/plot_manual_matrix_update.py
@@ -6,15 +6,13 @@ Transform Control without Matrix Updating
 Example showing transform control flow without matrix auto updating.
 """
 # sphinx_gallery_pygfx_render = True
+# sphinx_gallery_pygfx_target_name = "disp"
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
-renderer = gfx.renderers.WgpuRenderer(canvas)
-scene = gfx.Scene()
+group = gfx.Group()
 
 im = iio.imread("imageio:chelsea.png")
 tex = gfx.Texture(im, dim=2).get_view(filter="linear")
@@ -25,10 +23,8 @@ cubes = [gfx.Mesh(geometry, material) for i in range(8)]
 for i, cube in enumerate(cubes):
     cube.matrix_auto_update = False
     cube.matrix = gfx.linalg.Matrix4().set_position_xyz(350 - i * 100, 0, 0)
-    scene.add(cube)
+    group.add(cube)
 
-background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
-scene.add(background)
 
 camera = gfx.PerspectiveCamera(70, 16 / 9)
 camera.matrix_auto_update = False
@@ -47,10 +43,8 @@ def animate():
         rot.premultiply(pos)
         cube.matrix = rot
 
-    renderer.render(scene, camera)
-    canvas.request_draw()
-
 
 if __name__ == "__main__":
-    canvas.request_draw(animate)
-    run()
+    disp = gfx.Display(camera=camera)
+    disp.before_render = animate
+    disp.show(group)

--- a/examples/feature_demo/plot_multi_slice1.py
+++ b/examples/feature_demo/plot_multi_slice1.py
@@ -20,7 +20,9 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+dark_gray = np.array((169, 167, 168, 255)) / 255
+light_gray = np.array((100, 100, 100, 255)) / 255
+background = gfx.Background(None, gfx.BackgroundMaterial(light_gray, dark_gray))
 scene.add(background)
 
 scene.add(gfx.AxesHelper(size=50))

--- a/examples/feature_demo/plot_multi_slice2.py
+++ b/examples/feature_demo/plot_multi_slice2.py
@@ -23,7 +23,9 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+dark_gray = np.array((169, 167, 168, 255)) / 255
+light_gray = np.array((100, 100, 100, 255)) / 255
+background = gfx.Background(None, gfx.BackgroundMaterial(light_gray, dark_gray))
 scene.add(background)
 
 scene.add(gfx.AxesHelper(size=50))

--- a/examples/feature_demo/plot_panzoom_camera.py
+++ b/examples/feature_demo/plot_panzoom_camera.py
@@ -12,6 +12,7 @@ press 'l' to load the last saved state.
 import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
+import numpy as np
 
 
 canvas = WgpuCanvas()
@@ -21,7 +22,9 @@ scene = gfx.Scene()
 axes = gfx.AxesHelper(size=250)
 scene.add(axes)
 
-background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+dark_gray = np.array((169, 167, 168, 255)) / 255
+light_gray = np.array((100, 100, 100, 255)) / 255
+background = gfx.Background(None, gfx.BackgroundMaterial(light_gray, dark_gray))
 scene.add(background)
 
 im = iio.imread("imageio:astronaut.png")

--- a/examples/feature_demo/plot_picking_color.py
+++ b/examples/feature_demo/plot_picking_color.py
@@ -17,7 +17,9 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 0, 1, 1)))
+dark_gray = np.array((169, 167, 168, 255)) / 255
+light_gray = np.array((100, 100, 100, 255)) / 255
+background = gfx.Background(None, gfx.BackgroundMaterial(light_gray, dark_gray))
 scene.add(background)
 
 im = iio.imread("imageio:astronaut.png").astype(np.float32) / 255

--- a/examples/feature_demo/plot_show_scene.py
+++ b/examples/feature_demo/plot_show_scene.py
@@ -10,7 +10,7 @@ Demonstrates show utility for a scene
 import imageio.v3 as iio
 import pygfx as gfx
 
-scene = gfx.Scene()
+group = gfx.Group()
 
 im = iio.imread("imageio:chelsea.png")
 tex = gfx.Texture(im, dim=2).get_view(filter="linear")
@@ -20,11 +20,8 @@ geometry = gfx.box_geometry(100, 100, 100)
 cubes = [gfx.Mesh(geometry, material) for i in range(8)]
 for i, cube in enumerate(cubes):
     cube.position.set(350 - i * 100, 0, 0)
-    scene.add(cube)
-
-background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
-scene.add(background)
+    group.add(cube)
 
 if __name__ == "__main__":
     disp = gfx.Display()
-    disp.show(scene)
+    disp.show(group)

--- a/examples/introductory/plot_orbit_camera.py
+++ b/examples/introductory/plot_orbit_camera.py
@@ -12,6 +12,7 @@ press 'l' to load the last saved state.
 import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
+import numpy as np
 
 
 canvas = WgpuCanvas()
@@ -30,7 +31,9 @@ for i, cube in enumerate(cubes):
     cube.position.set(350 - i * 100, 150, 0)
     scene.add(cube)
 
-background = gfx.Background(None, gfx.BackgroundMaterial((0, 1, 0, 1), (0, 1, 1, 1)))
+dark_gray = np.array((169, 167, 168, 255)) / 255
+light_gray = np.array((100, 100, 100, 255)) / 255
+background = gfx.Background(None, gfx.BackgroundMaterial(light_gray, dark_gray))
 scene.add(background)
 
 camera = gfx.PerspectiveCamera(70, 16 / 9)


### PR DESCRIPTION
This PR updates the examples that currently have a "lsd-background" (blue/green gradient) and replaces those backgrounds with the same background we use in `gfx.Display`. Where possible, I've also updated the examples to use `gfx.Display` instead of creating a renderer explicitly.