### PR TITLE
Shadertoy and some examples

### DIFF
--- a/examples/feature_demo/plot_shadertoy.py
+++ b/examples/feature_demo/plot_shadertoy.py
@@ -1,0 +1,270 @@
+import wgpu
+import time
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+from pygfx.renderers.wgpu import Binding, WorldObjectShader, RenderMask
+
+
+class ShadertoyMaterial(gfx.Material):
+    uniform_type = dict(
+        resolution="2xf4",
+        time="f4",
+        time_delta="f4",
+        mouse="2xf4",
+    )
+
+    def __init__(self, *, resolution=(640, 480), **kwargs):
+        super().__init__(**kwargs)
+        self.resolution = resolution
+        self._last_time = time.time()
+        self.time_delta = 0
+
+    @property
+    def resolution(self):
+        """The uniform resolution of the shadertoy."""
+        return self.uniform_buffer.data["resolution"]
+
+    @resolution.setter
+    def resolution(self, resolution):
+        self.uniform_buffer.data["resolution"] = resolution
+        self.uniform_buffer.update_range(0, 1)
+
+    @property
+    def time(self):
+        """The uniform time of the shadertoy."""
+        return self.uniform_buffer.data["time"]
+
+    @time.setter
+    def time(self, time):
+        self.uniform_buffer.data["time"] = time
+        self.uniform_buffer.update_range(0, 1)
+
+    @property
+    def time_delta(self):
+        """The uniform time_delta of the shadertoy."""
+        return self.uniform_buffer.data["time_delta"]
+
+    @time_delta.setter
+    def time_delta(self, time_delta):
+        self.uniform_buffer.data["time_delta"] = time_delta
+        self.uniform_buffer.update_range(0, 1)
+
+    @property
+    def mouse(self):
+        """The uniform mouse of the shadertoy."""
+        return self.uniform_buffer.data["mouse"]
+
+    @mouse.setter
+    def mouse(self, mouse):
+        self.uniform_buffer.data["mouse"] = mouse
+        self.uniform_buffer.update_range(0, 1)
+
+    def update(self):
+        now = time.time()
+        if self._last_time == 0:
+            self._last_time = now
+
+        self.time_delta = now - self._last_time
+        self._last_time = now
+
+        self.time += self.time_delta
+
+
+class Shadertoy(gfx.WorldObject):
+
+    """
+    @param shader_code: The shader code to use.
+
+    The code must contain a `fn shader_main(frag_coord: vec2<f32>) -> vec4<f32>{}` function.
+    It has a parameter `frag_coord` which is the current pixel coordinate (in range 0..resolution),
+    and it must return a vec4 color, which is the color of the pixel at that coordinate.
+
+    some built-in variables are available: `i_time`, `i_tine_delta`, `i_resolution`, `i_mouse`
+    todo: add more built-in variables
+
+    @param resolution: The resolution of the shadertoy.
+    """
+
+    def __init__(self, shader_code: str, *, resolution=(640, 480), **kwargs):
+
+        material = ShadertoyMaterial(resolution=resolution)
+
+        super().__init__(None, material, **kwargs)
+
+        self._renderer = gfx.WgpuRenderer(WgpuCanvas(max_fps=60, size=resolution))
+        self._camera = gfx.NDCCamera()  # Does not actually use the camera
+        self._scene = gfx.Scene()
+        self._scene.add(self)
+
+        self.shader_code = shader_code
+
+        @self._renderer.add_event_handler("resize")
+        def resize(event=None):
+            w, h = self._renderer.logical_size
+            self.material.resolution = (w, h)
+
+        @self._renderer.add_event_handler("pointer_move", "pointer_down")
+        def mouse_move(event):
+            xy = event.x, event.y
+            if event.button == 1 or 1 in event.buttons:
+                self.material.mouse = xy
+
+    def update(self):
+        self.material.update()
+
+    def show(self):
+        def animate():
+            self.update()
+            self._renderer.render(self._scene, self._camera)
+            self._renderer.request_draw()
+
+        self._renderer.request_draw(animate)
+        run()
+
+
+@gfx.renderers.wgpu.register_wgpu_render_function(Shadertoy, ShadertoyMaterial)
+class ShadertoyShader(WorldObjectShader):
+
+    # Mark as render-shader (as opposed to compute-shader)
+    type = "render"
+
+    def __init__(self, wobject, **kwargs):
+        super().__init__(wobject, **kwargs)
+        self.shader_code = wobject.shader_code
+
+    def get_bindings(self, wobject, shared):
+        # Our only binding is a uniform buffer
+        bindings = {
+            0: Binding("u_material", "buffer/uniform", wobject.material.uniform_buffer),
+        }
+        self.define_bindings(0, bindings)
+        return {
+            0: bindings,
+        }
+
+    def get_pipeline_info(self, wobject, shared):
+        # We draw triangles, no culling
+        return {
+            "primitive_topology": wgpu.PrimitiveTopology.triangle_list,
+            "cull_mode": wgpu.CullMode.none,
+        }
+
+    def get_render_info(self, wobject, shared):
+        # Since we draw only one triangle we need just 3 vertices.
+        # Our triangle is opaque (render mask 1).
+        return {
+            "indices": (3, 1),
+            "render_mask": RenderMask.opaque,
+        }
+
+    def get_code(self):
+        # Here we put together the full (templated) shader code
+        return (
+            self.code_definitions()
+            + self.code_vertex()
+            + self.code_global_variables()
+            + self.shader_code
+            + self.code_fragment()
+        )
+
+    def code_vertex(self):
+        return """
+
+        struct Varyings {
+            @builtin(position) position : vec4<f32>,
+            @location(0) uv : vec2<f32>,
+        };
+
+
+        @stage(vertex)
+        fn vs_main(@builtin(vertex_index) index: u32) -> Varyings {
+            var out: Varyings;
+            if (index == u32(0)) {
+                out.position = vec4<f32>(-1.0, -1.0, 0.0, 1.0);
+                out.uv = vec2<f32>(0.0, 1.0);
+            } else if (index == u32(1)) {
+                out.position = vec4<f32>(3.0, -1.0, 0.0, 1.0);
+                out.uv = vec2<f32>(2.0, 1.0);
+            } else {
+                out.position = vec4<f32>(-1.0, 3.0, 0.0, 1.0);
+                out.uv = vec2<f32>(0.0, -1.0);
+            }
+            return out;
+
+        }
+        """
+
+    def code_global_variables(self):
+        return """
+
+        var<private> i_time: f32;
+        var<private> i_resolution: vec2<f32>;
+        var<private> i_time_delta: f32;
+        var<private> i_mouse: vec2<f32>;
+
+        // TODO: more global variables
+        // var<private> i_frag_coord: vec2<f32>;
+
+
+        """
+
+    def code_fragment(self):
+        return """
+        struct FragmentOutput {
+            @location(0) color: vec4<f32>,
+            @location(1) pick: vec4<u32>,
+        };
+
+        fn srgb2physical(color: vec3<f32>) -> vec3<f32> {
+            // In Python, the below reads as
+            // c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+            let f = pow((color + 0.055) / 1.055, vec3<f32>(2.4));
+            let t = color / 12.92;
+            return select(f, t, color <= vec3<f32>(0.04045));
+        }
+
+        @stage(fragment)
+        fn fs_main(in: Varyings) -> FragmentOutput {
+
+            i_time = u_material.time;
+            i_resolution = u_material.resolution;
+            i_time_delta = u_material.time_delta;
+            i_mouse = u_material.mouse;
+            i_mouse.y = i_resolution.y - i_mouse.y;
+
+
+            let uv = vec2<f32>(in.uv.x, 1.0 - in.uv.y);
+            let frag_coord = uv * i_resolution;
+
+            var fragColor = shader_main(frag_coord);
+
+            var out: FragmentOutput;
+            // out.color = vec4<f32>(fragColor.rgb, 1.0);
+            out.color = vec4<f32>(srgb2physical(fragColor.rgb), 1.0);
+            return out;
+        }
+        """
+
+
+if __name__ == "__main__":
+
+    # A simple example
+
+    shader = Shadertoy(
+        """
+    fn shader_main(frag_coord: vec2<f32>) -> vec4<f32> {
+        let uv = frag_coord / i_resolution;
+
+        if ( length(frag_coord - i_mouse) < 20.0 ) {
+            return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+        }else{
+            return vec4<f32>( 0.5 + 0.5 * sin(i_time * vec3<f32>(uv, 1.0) ), 1.0);
+        }
+
+    }
+
+    """,
+        resolution=(800, 450),
+    )
+
+    shader.show()

--- a/examples/feature_demo/plot_shadertoy_blink.py
+++ b/examples/feature_demo/plot_shadertoy_blink.py
@@ -1,0 +1,42 @@
+from plot_shadertoy import Shadertoy
+
+shader_code = """
+
+fn render(p: vec2<f32>) -> vec3<f32> {
+    let s = sin(i_time) * sin(i_time) * sin(i_time) + 0.5;
+    var p = p;
+    var d = length(p * 0.8) - pow(2.0 * abs(0.5 - fract(atan2(p.y, p.x) / 3.1416 * 2.5 + i_time * 0.3)), 2.5) * 0.1;
+
+    var col = vec3<f32>(0.0);
+    // star
+    col += 0.01 / (d * d) * vec3<f32>(0.5, 0.7, 1.5) * (1.0 + s);
+
+    // spiral
+    d = sin(length(p * 2.0) * 10.0 - i_time * 3.0) - sin(atan2(p.y, p.x) * 5.0) * 1.0;
+    col += 0.1 / (0.2 + d * d) * vec3<f32>(1.0, 0.0, 1.0);
+
+    // background
+    for (var i = 0; i < 6; i+=1) {
+        p = abs(p) / dot(p, p) - 1.0;
+    }
+    col += vec3<f32>(0.001 / dot(p, p));
+
+    return col;
+}
+
+fn shader_main(frag_coord: vec2<f32>) -> vec4<f32> {
+
+    let uv = (frag_coord-i_resolution*0.5)/i_resolution.y;
+
+    let col = render(uv);
+
+    return vec4<f32>(col,1.0);
+
+}
+
+"""
+
+shader = Shadertoy(shader_code, resolution=(800, 450))
+
+if __name__ == "__main__":
+    shader.show()

--- a/examples/feature_demo/plot_shadertoy_circuits.py
+++ b/examples/feature_demo/plot_shadertoy_circuits.py
@@ -1,0 +1,68 @@
+from plot_shadertoy import Shadertoy
+
+shader_code = """
+
+// migrated from https://www.shadertoy.com/view/wlBcDK, By Kali
+
+fn hsv2rgb(c: vec3<f32>) -> vec3<f32> {
+    let K = vec4<f32>(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);
+    let p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);
+    return c.z * mix(K.xxx, clamp(p - K.xxx, vec3<f32>(0.0), vec3<f32>(1.0)), c.y);
+}
+
+fn rot(a: f32) -> mat2x2<f32> {
+    let s=sin(a);
+    let c=cos(a);
+    return mat2x2<f32>(c, s, -s, c);
+}
+
+fn fractal(p: vec2<f32>) -> vec3<f32> {
+    var p = vec2<f32>(p.x/p.y,1./p.y);
+    p.y+=i_time*sign(p.y);
+    p.x+=sin(i_time*.1)*sign(p.y)*4.;
+    p.y=fract(p.y*.05);
+
+    var ot1 = 1000.;
+    var ot2 = ot1;
+    var it = 0.;
+    for (var i = 0.0; i < 10.0; i+=1.0) {
+        p = abs(p);
+        p = p / clamp(p.x*p.y, 0.15, 5.0) - vec2<f32>(1.5, 1.0);
+        var m = abs(p.x);
+        if (m < ot1) {
+            ot1 = m + step(fract(i_time*0.2 + f32(i)*0.05), 0.5*abs(p.y));
+            it = i;
+        }
+        ot2 = min(ot2, length(p));
+    }
+
+    ot1=exp(-30.0*ot1);
+    ot2=exp(-30.0*ot2);
+    return hsv2rgb(vec3<f32>(it*0.1+0.5,0.7,1.0))*ot1+ot2;
+}
+
+fn shader_main(frag_coord: vec2<f32>) -> vec4<f32> {
+    var uv = frag_coord / i_resolution - 0.5;
+    uv.x*=i_resolution.x/i_resolution.y;
+
+    var aa = 6.0;
+    uv *= rot(sin(i_time*0.1)*0.3);
+    var sc = 1.0 / i_resolution.xy / (aa*2.0);
+    var c = vec3<f32>(0.0);
+    for (var i = -aa; i < aa; i+=1.0) {
+        for (var j = -aa; j < aa; j+=1.0) {
+            var p = uv + vec2<f32>(i, j)*sc;
+            c += fractal(p);
+        }
+    }
+
+    return vec4<f32>(c/(aa*aa*4.0)*(1.0-exp(-20.0*uv.y*uv.y)),1.0);
+
+}
+
+"""
+
+shader = Shadertoy(shader_code, resolution=(800, 450))
+
+if __name__ == "__main__":
+    shader.show()

--- a/examples/feature_demo/plot_shadertoy_flyby.py
+++ b/examples/feature_demo/plot_shadertoy_flyby.py
@@ -1,0 +1,190 @@
+from plot_shadertoy import Shadertoy
+
+shader_code = """
+
+// migrated from: https://www.shadertoy.com/view/csjGDD, By Kali
+
+var<private> det : f32 = 0.001;
+var<private> br : f32 = 0.0;
+var<private> tub : f32 = 0.0;
+var<private> hit : f32 = 0.0;
+
+var<private> pos: vec3<f32>;
+var<private> sphpos: vec3<f32>;
+
+
+fn lookat(dir: vec3<f32>, up: vec3<f32>) -> mat3x3<f32> {
+    let rt = normalize(cross(dir, up));
+    return mat3x3<f32>(rt, cross(rt, dir), dir);
+}
+
+fn path(t: f32) -> vec3<f32> {
+    return vec3<f32>(sin(t+cos(t)*0.5)*0.5, cos(t*0.5), t);
+}
+
+fn rot(a: f32) -> mat2x2<f32> {
+    let s=sin(a);
+    let c=cos(a);
+    return mat2x2<f32>(c, s, -s, c);
+}
+
+fn fractal(p: vec2<f32>) -> vec3<f32> {
+    var p = fract(p*0.1);
+    var m = 1000.0;
+    for (var i = 0; i < 7; i = i + 1) {
+        p = ( abs(p) / clamp( abs(p.x*p.y), 0.25, 2.0 ) ) - 1.2;
+        m = min(m,abs(p.y)+fract(p.x*0.3 + i_time*0.5 + f32(i)*0.25));
+    }
+    m=exp(-6.0 * m);
+    return m*vec3<f32>(abs(p.x),m,abs(p.y));
+}
+
+fn coso(pp: vec3<f32>) -> f32 {
+    var pp = pp;
+    pp*=.7;
+
+    pp = vec3<f32>( pp.xy * rot(pp.z*2.0), pp.z);
+
+    let ppxz = pp.xz * rot(i_time*2.0);
+    pp = vec3<f32>(ppxz.x, pp.y, ppxz.y);
+
+    pp = vec3<f32>(pp.x, pp.yz * rot(i_time));
+
+    var sph=length(pp) - 0.04;
+    sph-=length(sin(pp*40.))*.05;
+    sph=max(sph,-length(pp)+.11);
+    var br2=length(pp) - 0.03;
+    br2=min(br2,length(pp.xy)+.005);
+    br2=min(br2,length(pp.xz)+.005);
+    br2=min(br2,length(pp.yz)+.005);
+    br2=max(br2,length(pp) - 1.0);
+    br=min(br2,br);
+    let d=min(br,sph);
+    return d;
+}
+
+fn de(p: vec3<f32>) -> f32 {
+    hit=0.;
+    br=1000.;
+    let pp = p - sphpos;
+    var p = p;
+    let pxy = p.xy - path(p.z).xy;
+    p.x = pxy.x;
+    p.y = pxy.y;
+    let rxy = p.xy * rot(p.z + i_time* 0.5);
+    p.x = rxy.x;
+    p.y = rxy.y;
+
+    let s = sin(p.z*0.5 + i_time * 0.5);
+    p.x *= ( 1.3 - s*s*0.7 );
+    p.y *= ( 1.3 - s*s*0.7 );
+
+    for(var i=0; i<6; i+=1) {
+        p = abs(p) - 0.4;
+    }
+
+    pos = p;
+
+    tub = -length(p.xy) + 0.45 + sin(p.z*10.0) * 0.1 * smoothStep(0.4,0.5,abs(0.5-fract(p.z*0.05))*2.0);
+    var co = coso(pp);
+    co=min(co, coso(pp + 0.7) );
+    co=min(co, coso(pp - 0.7) );
+
+    let d = min(tub,co);
+    if (d==tub) {
+        hit = step(fract(0.1 * length(sin(p*10.0))), 0.05);
+    }
+    return d * 0.3;
+}
+
+
+fn march(from: vec3<f32>, dir: vec3<f32>) -> vec3<f32> {
+    var dir = dir;
+    var uv: vec2<f32> = vec2<f32>( atan2( dir.x , dir.y ) + i_time * 0.5, length(dir.xy) + sin(i_time * 0.2));
+    var col: vec3<f32> = fractal(uv);
+    var d: f32 = 0.0;
+    var td: f32 = 0.0;
+    var g: f32 = 0.0;
+    var ref: f32 = 0.0;
+    var ltd: f32 = 0.0;
+    var li: f32 = 0.0;
+    var p: vec3<f32> = from;
+    for(var i: i32 = 0; i < 200; i += 1) {
+        p += dir * d;
+        d = de(p);
+        if (d < det && ref == 0.0 && hit == 1.0) {
+            var e: vec2<f32> = vec2<f32>(0.0, 0.1);
+            var n: vec3<f32> = normalize(vec3<f32>(de(p + e.yxx), de(p + e.xyx), de(p + e.xxy)) - de(p));
+            p -= dir * d * 2.0;
+            dir = reflect(dir, n);
+            ref = 1.0;
+            td = 0.0;
+            ltd = td;
+            continue;
+        }
+        if (d < det || td > 5.0) {
+            break;
+        }
+        td += d;
+        g += 0.1 / (0.1 + br * 13.0);
+        li += 0.1 / (0.1 + tub * 5.0);
+    }
+    g = max(g, li * 0.15);
+    var f: f32 = 1.0 - td / 3.0;
+    if (ref == 1.0) {
+        f = 1.0 - ltd / 3.0;
+    }
+    if (d < 0.01) {
+        col = vec3<f32>(1.0);
+        var e: vec2<f32> = vec2<f32>(0.0, det);
+        var n: vec3<f32> = normalize(vec3<f32>( de(p + e.yxx), de(p + e.xyx), de(p + e.xxy)) - de(p));
+        col = vec3<f32>(n.x) * 0.7;
+        col += fract(pos.z * 5.0) * vec3<f32>(0.2, 0.1, 0.5);
+        col += fractal(pos.xz * 2.0);
+        if (tub > 0.01) {
+            col = vec3<f32>(0.0);
+        }
+    }
+    col *= f;
+    let so = fract(sin(i_time)*123.456);
+    var glo: vec3<f32> = g * 0.1 * vec3<f32>(2.0, 1.0, 2.0) * (0.5 + so * 1.5) * 0.5;
+
+    let glo_rb = glo.rb * rot(dir.y * 1.5);
+    glo = vec3<f32>(glo_rb.x, glo.y, glo_rb.y);
+    col += glo;
+    col *= vec3<f32>(0.8, 0.7, 0.7);
+    col = mix(col, vec3<f32>(1.0), ref * 0.3);
+    return col;
+}
+
+fn mod( x : f32, y : f32 ) -> f32 {
+    return x - y * floor( x / y );
+}
+
+fn shader_main(frag_coord : vec2<f32>) -> vec4<f32> {
+    var uv = frag_coord / i_resolution;
+    uv = uv - 0.5;
+    uv /= vec2<f32>(i_resolution.y / i_resolution.x, 1.0);
+
+    var t = i_time;
+
+    var from = path(t);
+    if (mod(t, 10.0) > 5.0) {
+        from = path(floor(t / 4.0 + 0.5) * 4.0);
+    }
+    sphpos = path(t + 0.5);
+    from.x += 0.2;
+    var fw = normalize(path(t + 0.5) - from);
+    var dir = normalize(vec3<f32>(uv, 0.5));
+    dir = lookat(fw, vec3<f32>(fw.x * 2.0, 1.0, 0.0)) * dir;
+    dir = vec3<f32>(dir.x+sin(t) * 0.3, dir.y, dir.z+sin(t) * 0.3);
+    var col = march(from, dir);
+    col = mix(vec3<f32>(0.5) * length(col), col, 0.8);
+    return vec4<f32>(col, 1.0);
+}
+
+"""
+shader = Shadertoy(shader_code, resolution=(800, 450))
+
+if __name__ == "__main__":
+    shader.show()

--- a/examples/feature_demo/plot_shadertoy_gen_art.py
+++ b/examples/feature_demo/plot_shadertoy_gen_art.py
@@ -1,0 +1,86 @@
+from plot_shadertoy import Shadertoy
+
+shader_code = """
+
+// migrated from: https://www.shadertoy.com/view/mds3DX
+
+let SHAPE_SIZE : f32 = .618;
+let CHROMATIC_ABBERATION : f32 = .01;
+let ITERATIONS : f32 = 10.;
+let INITIAL_LUMA : f32= .5;
+
+let PI : f32 = 3.14159265359;
+let TWO_PI : f32 = 6.28318530718;
+
+fn rotate2d(_angle : f32) -> mat2x2<f32> {
+    return mat2x2<f32>(cos(_angle),-sin(_angle),sin(_angle),cos(_angle));
+}
+
+fn mod( v: vec2<f32>, y : f32 ) -> vec2<f32> {
+    return vec2<f32>(v.x - y * floor( v.x / y ), v.y - y * floor( v.y / y ));
+}
+
+fn sdPolygon(angle : f32, distance : f32) -> f32 {
+    let segment = TWO_PI / 4.0;
+    return cos(floor(0.5 + angle / segment) * segment - angle) * distance;
+}
+
+fn getColorComponent( st: vec2<f32>, modScale : f32, blur : f32 ) -> f32 {
+    let modSt = mod(st, 1. / modScale) * modScale * 2. - 1.;
+    let dist = length(modSt);
+    let angle = atan2(modSt.x, modSt.y) + sin(i_time * .08) * 9.0;
+    let shapeMap = smoothStep(SHAPE_SIZE + blur, SHAPE_SIZE - blur, sin(dist * 3.0) * .5 + .5);
+    return shapeMap;
+}
+
+fn shader_main(frag_coord: vec2<f32>) -> vec4<f32> {
+    var blur = .4 + sin(i_time * .52) * .2;
+    var st = (2.* frag_coord - i_resolution.xy) / min(i_resolution.x, i_resolution.y);
+    let origSt = st;
+    st *= rotate2d(sin(i_time * 0.14) * .3);
+    st *= (sin( i_time * 0.15) + 2.0) * .3;
+    st *= log(length(st * .428)) * 1.1;
+
+    let modScale = 1.0;
+    var color = vec3<f32>(0.0);
+
+    var luma = INITIAL_LUMA;
+
+    for (var i:f32 = 0.0; i < ITERATIONS; i+=1.0) {
+        let center = st + vec2<f32>(sin(i_time * .12), cos(i_time * .13));
+        let shapeColor = vec3<f32>(
+            getColorComponent(center - st * CHROMATIC_ABBERATION, modScale, blur),
+            getColorComponent(center, modScale, blur),
+            getColorComponent(center + st * CHROMATIC_ABBERATION, modScale, blur)
+        ) * luma;
+        st *= 1.1 + getColorComponent(center, modScale, .04) * 1.2;
+        st *= rotate2d(sin(i_time  * .05) * 1.33);
+        color = color + shapeColor;
+        color = vec3<f32>(clamp( color.r, 0.0, 1.0 ), clamp( color.g, 0.0, 1.0 ), clamp( color.b, 0.0, 1.0 ));
+        luma *= .6;
+        blur *= .63;
+    }
+
+    let GRADING_INTENSITY = .4;
+    let topGrading = vec3<f32>(
+        1. + sin(i_time * 1.13 * .3) * GRADING_INTENSITY,
+        1. + sin(i_time * 1.23 * .3) * GRADING_INTENSITY,
+        1. - sin(i_time * 1.33 * .3) * GRADING_INTENSITY
+    );
+    let bottomGrading = vec3<f32>(
+        1. - sin(i_time * 1.43 * .3) * GRADING_INTENSITY,
+        1. - sin(i_time * 1.53 * .3) * GRADING_INTENSITY,
+        1. + sin(i_time * 1.63 * .3) * GRADING_INTENSITY
+    );
+    let origDist = length(origSt);
+    let colorGrading = mix(topGrading, bottomGrading, origDist - .5);
+    var fragColor = vec4<f32>(pow(color.rgb, colorGrading), 1.);
+    // fragColor *= smoothStep(2.1, .7, origDist);
+    return fragColor;
+}
+
+"""
+shader = Shadertoy(shader_code, resolution=(800, 450))
+
+if __name__ == "__main__":
+    shader.show()

--- a/examples/feature_demo/plot_shadertoy_liberation.py
+++ b/examples/feature_demo/plot_shadertoy_liberation.py
@@ -1,0 +1,144 @@
+from plot_shadertoy import Shadertoy
+
+shader_code = """
+
+// migrated from https://www.shadertoy.com/view/tlGfzd, By Kali
+
+var<private> objcol: vec3<f32>;
+
+fn hash12(p: vec2<f32>) -> f32 {
+    var p3 = fract(vec3<f32>(p.xyx) * 0.1031);
+    p3 += vec3<f32>( dot(p3, p3.yzx + vec3<f32>(33.33)) );
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+fn rot(a: f32) -> mat2x2<f32> {
+    let s=sin(a);
+    let c=cos(a);
+    return mat2x2<f32>(c, s, -s, c);
+}
+
+fn mod( x : f32, y : f32 ) -> f32 {
+    return x - y * floor( x / y );
+}
+
+fn de(pos: vec3<f32>) -> f32 {
+    var t = mod(i_time, 17.0);
+    var a = smoothStep(13.0, 15.0, t) * 8.0 - smoothStep(4.0, 0.0, t) * 4.0;
+    var f = sin(i_time * 5.0 + sin(i_time * 20.0) * 0.2);
+
+    var pos = pos;
+
+    let pxz = pos.xz * rot(i_time + 0.5);
+    pos.x = pxz.x;
+    pos.z = pxz.y;
+
+    let pyz = pos.yz * rot(i_time);
+    pos.y = pyz.x;
+    pos.z = pyz.y;
+
+    var p = pos;
+    var s = 1.0;
+
+    for (var i = 0; i < 4; i+=1) {
+        p = abs(p) * 1.3 - 0.5 - f * 0.1 - a;
+
+        let pxy = p.xy * rot(radians(45.0));
+        p.x = pxy.x;
+        p.y = pxy.y;
+
+        let pxz = p.xz * rot(radians(45.0));
+        p.x = pxz.x;
+        p.z = pxz.y;
+
+        s *= 1.3;
+    }
+
+    var fra = length(p) / s - 0.5;
+
+    let pxy = pos.xy * rot(i_time);
+    pos.x = pxy.x;
+    pos.y = pxy.y;
+
+    p = abs(pos) - 2.0 - a;
+    var d = length(p) - 0.7;
+
+    d = min(d, max(length(p.xz) - 0.1, p.y));
+    d = min(d, max(length(p.yz) - 0.1, p.x));
+    d = min(d, max(length(p.xy) - 0.1, p.z));
+
+    p = abs(pos);
+    p.x -= 4.0 + a + f * 0.5;
+    d = min(d, length(p) - 0.7);
+    d = min(d, length(p.yz - abs(sin(p.x * 0.5 - i_time * 10.0) * 0.3)));
+
+    p = abs(pos);
+    p.y -= 4.0 + a + f * 0.5;
+
+    d = min(d, length(p) - 0.7);
+    d = min(d, max(length(p.xz) - 0.1, p.y));
+    d = min(d, fra);
+
+    objcol = abs(p);
+
+    if (d == fra) {
+        objcol = vec3<f32>(2.0, 0.0, 0.0);
+    }
+
+    return d;
+}
+
+fn normal(p: vec3<f32>) -> vec3<f32> {
+    var d = vec2<f32>(0.0, 0.01);
+    return normalize( vec3<f32>( de(p + d.yxx), de(p + d.xyx), de(p + d.xxy) ) - de(p) );
+}
+
+fn march(from: vec3<f32>, dir: vec3<f32>, frag_coord: vec2<f32>) -> vec3<f32> {
+    var d = 0.0;
+    var td = 0.0;
+    var maxdist = 30.0;
+
+    var p = from;
+    var col = vec3<f32>(0.0);
+    var dir = dir;
+
+    for (var i = 0; i < 100; i+=1) {
+        var d2 = de(p) * (1.0 - hash12(frag_coord.xy + i_time) * 0.2);
+        if (d2 < 0.0) {
+            var n = normal(p);
+            dir = reflect(dir, n);
+            d2 = 0.1;
+        }
+
+        d = max(0.01, abs(d2));
+        p += d * dir;
+        td += d;
+
+        if (td > maxdist) {
+            break;
+        }
+
+        col += 0.01 * objcol;
+    }
+
+    return pow(col, vec3<f32>(2.0));
+}
+
+fn shader_main(frag_coord: vec2<f32>) -> vec4<f32> {
+    var uv = frag_coord / i_resolution - 0.5;
+    uv.x *= i_resolution.x / i_resolution.y;
+
+    var from = vec3<f32>(0.0, 0.0, -10.0);
+    var dir = normalize(vec3<f32>(uv, 1.0));
+
+    var col = march(from, dir, frag_coord);
+
+    return vec4<f32>(col, 1.0);
+}
+
+"""
+
+shader = Shadertoy(shader_code, resolution=(800, 450))
+
+if __name__ == "__main__":
+    shader.show()

--- a/examples/feature_demo/plot_shadertoy_matrix.py
+++ b/examples/feature_demo/plot_shadertoy_matrix.py
@@ -1,0 +1,155 @@
+from plot_shadertoy import Shadertoy
+
+shader_code = """
+
+// migrated from https://www.shadertoy.com/view/NlsXDH, By Kali
+
+let det = 0.001;
+
+var<private> t: f32;
+var<private> boxhit: f32;
+
+var<private> adv: vec3<f32>;
+var<private> boxp: vec3<f32>;
+
+fn hash(p: vec2<f32>) -> f32 {
+    var p3 = fract(vec3<f32>(p.xyx) * 0.1031);
+    p3 += vec3<f32>( dot(p3, p3.yzx + vec3<f32>(33.33)) );
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+fn rot(a: f32) -> mat2x2<f32> {
+    let s=sin(a);
+    let c=cos(a);
+    return mat2x2<f32>(c, s, -s, c);
+}
+
+fn mod( x : f32, y : f32 ) -> f32 {
+    return x - y * floor( x / y );
+}
+
+fn mod_2( v: vec2<f32>, y : f32 ) -> vec2<f32> {
+    return vec2<f32>(v.x - y * floor( v.x / y ), v.y - y * floor( v.y / y ));
+}
+
+fn path(t: f32) -> vec3<f32> {
+    var p = vec3<f32>(sin(t*.1)*10., cos(t*.05)*10., t);
+    p.x += smoothStep(.0,.5,abs(.5-fract(t*.02)))*10.;
+    return p;
+}
+
+fn fractal(p: vec2<f32>) -> f32 {
+    var p = abs( 5.0 - mod_2( p*0.2, 10.0 ) ) - 5.0;
+    var ot = 1000.;
+    for (var i = 0; i < 7; i+=1) {
+        p = abs(p) / clamp(p.x*p.y, 0.25, 2.0) - 1.0;
+        if (i > 0) {
+            ot = min(ot, abs(p.x)+0.7*fract(abs(p.y)*0.05+t*0.05 + f32(i)*0.3));
+        }
+    }
+    ot = exp(-10.*ot);
+    return ot;
+}
+
+fn box(p: vec3<f32>, l: vec3<f32>) -> f32 {
+    let c = abs(p)-l;
+    return length(max(vec3<f32>(0.),c))+min(0.,max(c.x,max(c.y,c.z)));
+}
+
+fn de(p: vec3<f32>) -> f32 {
+    boxhit = 0.0;
+    var p2 = p-adv;
+
+    let p2_xz = p2.xz*rot(t*0.2);
+    p2.x = p2_xz.x;
+    p2.z = p2_xz.y;
+
+    let p2_xy = p2.xy*rot(t*0.1);
+    p2.x = p2_xy.x;
+    p2.y = p2_xy.y;
+
+    let p2_yz = p2.yz*rot(t*0.15);
+    p2.y = p2_yz.x;
+    p2.z = p2_yz.y;
+
+    let b = box(p2, vec3<f32>(1.0));
+
+    var p = p;
+    let p_xy = p.xy - path(p.z).xy;
+    p.x = p_xy.x;
+    p.y = p_xy.y;
+
+    let s = sign(p.y);
+    p.y = -abs(p.y) - 3.0;
+    p.z = mod(p.z, 20.0) - 10.0;
+
+    for (var i = 0; i < 5; i+=1) {
+        p = abs(p) - 1.0;
+
+        let p_xz = p.xz*rot(radians(s*-45.0));
+        p.x = p_xz.x;
+        p.z = p_xz.y;
+
+        let p_yz = p.yz*rot(radians(90.0));
+        p.y = p_yz.x;
+        p.z = p_yz.y;
+
+    }
+
+    let f = -box(p, vec3<f32>(5.0, 5.0, 10.0));
+    let d = min(f,b);
+    if (d == b) {
+        boxp = p2;
+        boxhit = 1.0;
+    }
+    return d*0.7;
+}
+
+fn march(from: vec3<f32>, dir: vec3<f32>, frag_coord: vec2<f32>) -> vec3<f32> {
+    var p = vec3<f32>(0.);
+    var n = vec3<f32>(0.);
+    var g = vec3<f32>(0.);
+
+    var d = 0.0;
+    var td = 0.0;
+
+    for (var i = 0; i < 80; i+=1) {
+        p = from + td*dir;
+        d = de(p) * (1.0- hash( frag_coord.xy + vec2<f32>(t) )*0.3);
+        if (d < det && boxhit < 0.5) {
+            break;
+        }
+        td += max(det, abs(d));
+        let f = fractal(p.xy)+fractal(p.xz)+fractal(p.yz);
+        let b = fractal(boxp.xy)+fractal(boxp.xz)+fractal(boxp.yz);
+        let colf = vec3<f32>(f*f,f,f*f*f);
+        let colb = vec3<f32>(b+.1,b*b+.05,0.);
+        g += colf / (3.0 + d*d*2.0) * exp(-0.0015*td*td) * step(5.0,td) / 2.0 * (1.0-boxhit);
+        g += colb / (10.0 + d*d*20.0) * boxhit*0.5;
+    }
+    return g;
+}
+
+fn lookat(dir: vec3<f32>, up: vec3<f32>) -> mat3x3<f32> {
+    let dir = normalize(dir);
+    let rt = normalize(cross(dir, normalize(up)));
+    return mat3x3<f32>(rt, cross(rt, dir), dir);
+}
+
+fn shader_main(frag_coord: vec2<f32>) -> vec4<f32> {
+    let uv = (frag_coord-i_resolution.xy*.5)/i_resolution.y;
+    t=i_time*7.0;
+    let from=path(t);
+    adv=path(t+6.+sin(t*.1)*3.);
+    let dir=normalize(vec3<f32>(uv, 0.7));
+    let dir=lookat(adv-from, vec3<f32>(0.0, 1.0, 0.0)) * dir;
+    let col=march(from, dir, frag_coord);
+    return vec4<f32>(col,1.0);
+}
+
+"""
+
+shader = Shadertoy(shader_code, resolution=(800, 450))
+
+if __name__ == "__main__":
+    shader.show()

--- a/examples/feature_demo/plot_shadertoy_riders.py
+++ b/examples/feature_demo/plot_shadertoy_riders.py
@@ -1,0 +1,45 @@
+from plot_shadertoy import Shadertoy
+
+shader_code = """
+
+// migrated from https://www.shadertoy.com/view/3sGfD3, By Kali
+
+fn rot(a: f32) -> mat2x2<f32> {
+    let s=sin(a);
+    let c=cos(a);
+    return mat2x2<f32>(c, s, -s, c);
+}
+
+fn render(p: vec2<f32>) -> vec3<f32> {
+    var p = p;
+    p*=rot(i_time*.1)*(.0002+.7*pow(smoothStep(0.0,0.5,abs(0.5-fract(i_time*.01))),3.));
+    p.y-=.2266;
+    p.x+=.2082;
+    var ot = vec2<f32>(100.0);
+    var m = 100.0;
+    for (var i = 0; i < 150; i+=1) {
+        var cp = vec2<f32>(p.x,-p.y);
+        p=p+cp/dot(p,p)-vec2<f32>(0.0,0.25);
+        p*=.1;
+        p*=rot(1.5);
+        ot=min(ot,abs(p)+.15*fract(max(abs(p.x),abs(p.y))*.25+i_time*0.1+f32(i)*0.15));
+        m=min(m,abs(p.y));
+    }
+    ot=exp(-200.*ot)*2.;
+    m=exp(-200.*m);
+    return vec3<f32>(ot.x,ot.y*.5+ot.x*.3,ot.y)+m*.2;
+}
+
+fn shader_main(frag_coord: vec2<f32>) -> vec4<f32> {
+    let uv = (frag_coord - i_resolution / 2.0) / i_resolution.y;
+    let d=vec2<f32>(0.0,0.5)/i_resolution;
+    let col = render(uv)+render(uv+d.xy)+render(uv-d.xy)+render(uv+d.yx)+render(uv-d.yx);
+    return vec4<f32>(col/5.0, 1.0);
+}
+
+
+"""
+shader = Shadertoy(shader_code, resolution=(800, 450))
+
+if __name__ == "__main__":
+    shader.show()

--- a/examples/feature_demo/plot_shadertoy_sea.py
+++ b/examples/feature_demo/plot_shadertoy_sea.py
@@ -1,0 +1,208 @@
+from plot_shadertoy import Shadertoy
+
+shader_code = """
+
+// migrated from https://www.shadertoy.com/view/Ms2SD1, "Seascape" by Alexander Alekseev aka TDM - 2014
+
+let NUM_STEPS = 8;
+let PI = 3.141592;
+let EPSILON = 0.001;
+
+let ITER_GEOMETRY = 3;
+let ITER_FRAGMENT = 5;
+
+let SEA_HEIGHT = 0.6;
+let SEA_CHOPPY = 4.0;
+let SEA_SPEED = 0.8;
+let SEA_FREQ = 0.16;
+let SEA_BASE = vec3<f32>(0.0,0.09,0.18);
+let SEA_WATER_COLOR = vec3<f32>(0.48, 0.54, 0.36);
+
+// let octave_m = mat2x2<f32>(1.6, 1.2, -1.2, 1.6);
+
+// TODO: Perlin gradient noise: The magic number 43758.5453123 in wgpu seems to cause some percession issue?
+// TODO: change another noise function
+
+fn hash( p : vec2<f32> ) -> f32 {
+    let h = dot(p,vec2<f32>(127.1,311.7));
+    // return fract(sin(h)*43758.5453123);
+    return fract(sin(h)); // Use the magic number 43758.5453123 seems to cause some percession issue?
+}
+
+// Perlin gradient noise
+fn noise( p : vec2<f32> ) -> f32 {
+    let i = floor(p);
+    let f = fract(p);
+    let u = f * f * (3.0 - 2.0 * f);
+
+    let mix1 = mix( hash( i + vec2<f32>(0.0,0.0) ), hash( i + vec2<f32>(1.0,0.0) ), u.x);
+    let mix2 = mix( hash( i + vec2<f32>(0.0,1.0) ), hash( i + vec2<f32>(1.0,1.0) ), u.x);
+
+    let mix3 = mix(mix1, mix2, u.y);
+
+    return -1.0 + 2.0 * mix3;
+}
+
+
+// lighting
+fn diffuse( n : vec3<f32>, l : vec3<f32>, p : f32 ) -> f32 {
+    return pow(dot(n,l) * 0.4 + 0.6, p);
+}
+
+fn specular( n : vec3<f32>, l : vec3<f32>, e : vec3<f32>, s : f32 ) -> f32 {
+    let nrm = (s + 8.0) / (PI * 8.0);
+    return pow(max(dot(reflect(e,n),l),0.0),s) * nrm;
+}
+
+// sky
+fn getSkyColor( e : vec3<f32> ) -> vec3<f32> {
+    var e = e;
+    e.y = (max(e.y,0.0) * 0.8 + 0.2) * 0.8;
+    return vec3<f32>(pow(1.0-e.y, 2.0), 1.0-e.y, 0.6+(1.0-e.y)*0.4) * 1.1;
+}
+
+// sea
+fn sea_octave( uv : vec2<f32>, choppy : f32 ) -> f32 {
+    let uv = uv + noise(uv);
+    var wv = 1.0-abs(sin(uv));
+    let swv = abs(cos(uv));
+    wv = mix(wv,swv,wv);
+    return pow(1.0-pow(wv.x * wv.y,0.65),choppy);
+}
+
+fn _map( p : vec3<f32>, iter: i32 ) -> f32 {
+    var freq = SEA_FREQ;
+    var amp = SEA_HEIGHT;
+    var choppy = SEA_CHOPPY;
+
+    let sea_time = 1.0 + i_time * SEA_SPEED;
+
+    var uv = p.xz;
+    uv.x *= 0.75;
+
+    var d = 0.0;
+    var h = 0.0;
+    for (var i = 0; i < iter; i+=1) {
+        d = sea_octave((uv+sea_time)*freq, choppy);
+        d += sea_octave((uv-sea_time)*freq, choppy);
+        h += d * amp;
+        uv *= mat2x2<f32>(1.6, 1.2, -1.2, 1.6);
+        freq *= 1.9;
+        amp *= 0.22;
+        choppy = mix(choppy,1.0,0.2);
+    }
+    return p.y - h;
+}
+
+fn map( p : vec3<f32>) -> f32 {
+    return _map(p, ITER_GEOMETRY);
+}
+
+fn map_detailed( p : vec3<f32> ) -> f32 {
+    return _map(p, ITER_FRAGMENT);
+}
+
+fn getSeaColor( p : vec3<f32>, n : vec3<f32>, l : vec3<f32>, eye : vec3<f32>, dist : vec3<f32> ) -> vec3<f32> {
+    var fresnel = clamp(1.0 - dot(n,-eye), 0.0, 1.0);
+    fresnel = pow(fresnel,3.0) * 0.5;
+
+    let reflected = getSkyColor(reflect(eye,n));
+    let refracted = SEA_BASE + diffuse(n,l,80.0) * SEA_WATER_COLOR * 0.12;
+
+    var color = mix(refracted,reflected,fresnel);
+
+    let atten = max(1.0 - dot(dist,dist) * 0.001, 0.0);
+    color += SEA_WATER_COLOR * (p.y - SEA_HEIGHT) * 0.18 * atten;
+
+    color += vec3<f32>(specular(n, l, eye, 60.0));
+
+    return color;
+
+}
+
+// tracing
+fn getNormal( p : vec3<f32>, eps : f32 ) -> vec3<f32> {
+    var n : vec3<f32>;
+    n.y = map_detailed(p);
+    n.x = map_detailed(vec3<f32>(p.x+eps,p.y,p.z)) - n.y;
+    n.z = map_detailed(vec3<f32>(p.x,p.y,p.z+eps)) - n.y;
+    n.y = eps;
+    return normalize(n);
+}
+
+fn heightMapTracing( ori : vec3<f32>, dir : vec3<f32> ) -> vec3<f32> {
+    var tm = 0.0;
+    var tx = 1000.0;
+    var hx = map(ori + dir * tx);
+    var p : vec3<f32>;
+    if (hx > 0.0){
+        p = ori + dir * tx;
+        return p;
+    }
+    var hm = map(ori + dir * tm);
+    var tmid = 0.0;
+    for (var i = 0; i < NUM_STEPS; i+=1) {
+        tmid = mix(tm,tx, hm/(hm-hx));
+        p = ori + dir * tmid;
+        let hmid = map(p);
+        if (hmid < 0.0) {
+            tx = tmid;
+            hx = hmid;
+        } else {
+            tm = tmid;
+            hm = hmid;
+        }
+    }
+    return p;
+}
+
+fn getPixel( coord: vec2<f32>, time: f32 ) -> vec3<f32> {
+    var uv = coord / i_resolution;
+    uv = uv * 2.0 - 1.0;
+    uv.x *= i_resolution.x / i_resolution.y;
+
+    // ray
+    let ori = vec3<f32>(0.0,3.5,time*5.0);
+    let dir = normalize(vec3<f32>(uv.xy,-2.0));
+
+    // tracing
+    var p = heightMapTracing(ori, dir);
+    let dist = p - ori;
+    let n = getNormal(p, dot(dist,dist) * (0.1/i_resolution.x));
+    let light = normalize(vec3<f32>(0.0,1.0,0.8));
+
+    // color
+    return mix(
+        getSkyColor(dir),
+        getSeaColor(p,n,light,dir,dist),
+        pow(smoothStep(0.0,-0.02,dir.y),0.2)
+    );
+}
+
+fn shader_main(frag_coord: vec2<f32>) -> vec4<f32> {
+
+    let time = i_time * 0.3 + i_mouse.x * 0.01;
+
+    var color: vec3<f32>;
+    for (var i = -1; i <=1; i+=1) {
+        for (var j =-1; j <=1; j+=1) {
+            let uv = frag_coord + vec2<f32>(f32(i),f32(j)) / 3.0;
+            color += getPixel(uv, time);
+        }
+    }
+    color = color / 9.0;
+
+    let color = getPixel(frag_coord, time);
+
+    // post
+    return vec4<f32>(pow(color, vec3<f32>(0.65)), 1.0);
+}
+
+
+
+
+"""
+shader = Shadertoy(shader_code, resolution=(800, 450))
+
+if __name__ == "__main__":
+    shader.show()

--- a/examples/feature_demo/plot_shadertoy_star.py
+++ b/examples/feature_demo/plot_shadertoy_star.py
@@ -1,0 +1,99 @@
+from plot_shadertoy import Shadertoy
+
+shader_code = """
+
+// migrated from: https://www.shadertoy.com/view/XlfGRj, By Kali
+
+let iterations = 17;
+let formuparam = 0.53;
+
+let volsteps = 20;
+let stepsize = 0.1;
+
+let zoom = 0.800;
+let tile = 0.850;
+let speed = 0.010;
+
+let brightness = 0.0015;
+let darkmatter = 0.300;
+let distfading = 0.730;
+let saturation = 0.850;
+
+fn mod( p1 : vec3<f32>, p2 : vec3<f32> ) -> vec3<f32> {
+    let mx = p1.x - p2.x * floor( p1.x / p2.x );
+    let my = p1.y - p2.y * floor( p1.y / p2.y );
+    let mz = p1.z - p2.z * floor( p1.z / p2.z );
+    return vec3<f32>(mx, my, mz);
+}
+
+fn shader_main(frag_coord: vec2<f32>) -> vec4<f32> {
+
+    var uv = frag_coord.xy / i_resolution.xy - vec2<f32>(0.5, 0.5);
+    uv.y *= i_resolution.y / i_resolution.x;
+    var dir = vec3<f32>(uv * zoom, 1.0);
+    let time = i_time * speed + 0.25;
+
+    //mouse rotation
+    let a1 = 0.5 + i_mouse.x / i_resolution.x * 2.0;
+    let a2 = 0.8 + i_mouse.y / i_resolution.y * 2.0;
+    let rot1 = mat2x2<f32>(cos(a1), sin(a1), -sin(a1), cos(a1));
+    let rot2 = mat2x2<f32>(cos(a2), sin(a2), -sin(a2), cos(a2));
+
+    let dir_xz = dir.xz * rot1;
+    dir.x = dir_xz.x;
+    dir.z = dir_xz.y;
+
+    let dir_xy = dir.xy * rot2;
+    dir.x = dir_xy.x;
+    dir.y = dir_xy.y;
+
+    var from = vec3<f32>(1.0, 0.5, 0.5);
+    from += vec3<f32>(time * 2.0, time, -2.0);
+
+    let from_xz = from.xz * rot1;
+    from.x = from_xz.x;
+    from.z = from_xz.y;
+
+    let from_xy = from.xy * rot2;
+    from.x = from_xy.x;
+    from.y = from_xy.y;
+
+    //volumetric rendering
+
+    var s = 0.1;
+    var fade = 1.0;
+    var v = vec3<f32>(0.0);
+
+    for (var r: i32 = 0; r < volsteps; r = r + 1) {
+        var p = from + s * dir * 0.5;
+        p = abs(vec3<f32>(tile) - mod(p, vec3<f32>(tile * 2.0))); // tiling fold
+        var pa = 0.0;
+        var a = 0.0;
+        for (var i : i32 = 0; i < iterations; i = i + 1) {
+            p = abs(p) / dot(p, p) - formuparam; // the magic formula
+            a += abs(length(p) - pa); // absolute sum of average change
+            pa = length(p);
+        }
+        let dm = max(0.0, darkmatter - a * a * 0.001); //dark matter
+        a = a * a * a; // add contrast
+        if (r > 6) {
+            fade = fade * (1.0 - dm); // dark matter, don't render near
+        }
+
+        v += vec3<f32>(fade);
+        v += vec3<f32>(s, s * s, s * s * s * s) * a * brightness * fade; // coloring based on distance
+        fade = fade * distfading; // distance fading
+        s = s + stepsize;
+    }
+
+    v = mix(vec3<f32>(length(v)), v, saturation); //color adjust
+    return vec4<f32>(v * 0.01, 1.0);
+
+}
+
+"""
+
+shader = Shadertoy(shader_code, resolution=(800, 450))
+
+if __name__ == "__main__":
+    shader.show()


### PR DESCRIPTION
I am very interested in [shadertoy](https://www.shadertoy.com/) recently. It is a great website for learning and sharing shaders. There are many great shaders on it. 
I implemented a tool class `Shadertoy` with pygfx, which provides a screen pixel shader programming interface similar to "shadertoy".

I transplanted or adapted several representative or visually striking examples, they performed well on pygfx.

**Sea:**

https://user-images.githubusercontent.com/8044566/207863907-4dc13cd9-c2e5-4b79-b1cf-37e23dc36b26.mp4

**Star:**

https://user-images.githubusercontent.com/8044566/207864142-39c5aec4-2510-44be-8f9c-7ca64459b9e5.mp4


**Other examples:**

https://user-images.githubusercontent.com/8044566/207864626-51c9a90f-d0bd-4c30-8d48-cb285d0a9511.mp4

https://user-images.githubusercontent.com/8044566/207865233-529566bb-4a68-4ee8-9a27-cef1d065e295.mp4

https://user-images.githubusercontent.com/8044566/207865348-6b92dfb7-8dc3-4c9d-9ddb-2b2ed702c7d5.mp4


There are also some other examples that you can run to view.

I'm not sure whether it is appropriate to merge them into pygfx. Maybe we just need to select a few examples to merge into the main branch.




