### PR TITLE
Check against expected wgpu version at runtime

### DIFF
--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -32,13 +32,13 @@ def _test_wgpu_version():
     min_ver, max_ver = __wgpu_version_range__
     min_ver_info = tuple(map(int, min_ver.split(".")))
     max_ver_info = tuple(map(int, max_ver.split(".")))
-    detected = f"Detected {wgpu.__version__}, need >={min_ver}, <{max_ver} ."
+    detected = f"Detected {wgpu.__version__}, need >={min_ver}, <{max_ver}."
     if wgpu.version_info < min_ver_info:
-        raise RuntimeError(
+        logger.error(
             f"Incompatible version of wgpu-py:\n    {detected}\n    To update, use e.g. `pip install -U wgpu`."
         )
     elif wgpu.version_info >= max_ver_info:
-        print(f"Possible incompatible version of wgpu-py:\n    {detected}")
+        logger.warning(f"Possible incompatible version of wgpu-py:\n    {detected}")
 
 
 _test_wgpu_version()

--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -23,6 +23,26 @@ from .utils import cm, logger
 __version__ = "0.1.10"
 version_info = tuple(map(int, __version__.split(".")))
 
+__wgpu_version_range__ = "0.9.0", "0.10.0"
+
+
+def _test_wgpu_version():
+    import wgpu  # noqa
+
+    min_ver, max_ver = __wgpu_version_range__
+    min_ver_info = tuple(map(int, min_ver.split(".")))
+    max_ver_info = tuple(map(int, max_ver.split(".")))
+    detected = f"Detected {wgpu.__version__}, need >={min_ver}, <{max_ver} ."
+    if wgpu.version_info < min_ver_info:
+        raise RuntimeError(
+            f"Incompatible version of wgpu-py:\n    {detected}\n    To update, use e.g. `pip install -U wgpu`."
+        )
+    elif wgpu.version_info >= max_ver_info:
+        print(f"Possible incompatible version of wgpu-py:\n    {detected}")
+
+
+_test_wgpu_version()
+
 
 def _get_sg_image_scraper():
     import sphinx_gallery.scrapers

--- a/setup.py
+++ b/setup.py
@@ -6,13 +6,16 @@ from setuptools import find_packages, setup
 NAME = "pygfx"
 SUMMARY = "A threejs-like render engine based on wgpu"
 
-with open(f"{NAME}/__init__.py") as fh:
-    VERSION = re.search(r"__version__ = \"(.*?)\"", fh.read()).group(1)
+with open(f"{NAME}/__init__.py", "rb") as fh:
+    init_text = fh.read().decode()
+    VERSION = re.search(r"__version__ = \"(.*?)\"", init_text).group(1)
+    match = re.search(r"__wgpu_version_range__ = \"(.*?)\", \"(.*?)\"", init_text)
+    wgpu_min_ver, wgpu_max_ver = match.group(1), match.group(2)
 
 
 runtime_deps = [
     "numpy",
-    "wgpu>=0.9.0,<0.10.0",
+    f"wgpu>={wgpu_min_ver},<{wgpu_max_ver}",
     "freetype-py",
     "uharfbuzz",
     "Jinja2",


### PR DESCRIPTION
We're tightly bound to the versioning of wgpu-py. On a mismatch, the errors that you get can make little sense. So let's check the expected version.

This brings the definition of the expected version to the `__init__`, and in setup.py we read it from there.