### PR TITLE
Fix in offscreen example

### DIFF
--- a/examples/introductory/offscreen.py
+++ b/examples/introductory/offscreen.py
@@ -16,7 +16,7 @@ from wgpu.gui.offscreen import WgpuCanvas
 
 
 # Create offscreen canvas, renderer and scene
-canvas = WgpuCanvas(640, 480, 1)
+canvas = WgpuCanvas(size=(640, 480), pixel_ratio=1)
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 


### PR DESCRIPTION
There was a bug in the args of `offscreen.WgpuCanvas()` all along, but until recently, the invalid args were swallowed.