### PR TITLE
Put advanced usage in own section

### DIFF
--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -1,0 +1,9 @@
+Advanced wgpu
+=============
+
+.. toctree::
+    :maxdepth: 2
+
+    advanced_api.rst
+    advanced_shaders.rst
+

--- a/docs/advanced_api.rst
+++ b/docs/advanced_api.rst
@@ -1,0 +1,17 @@
+API for advanced wgpu usage
+---------------------------
+
+
+.. autofunction:: pygfx.renderers.wgpu.register_wgpu_render_function
+
+.. autoclass:: pygfx.renderers.wgpu.Binding
+    :members:
+    :member-order: bysource
+
+.. autoclass:: pygfx.renderers.wgpu.WorldObjectShader
+    :members:
+    :inherited-members:
+
+.. autoclass:: pygfx.renderers.wgpu.Shared
+    :members:
+    :member-order: bysource

--- a/docs/advanced_shaders.rst
+++ b/docs/advanced_shaders.rst
@@ -1,5 +1,5 @@
-Writing pygfx shaders
-=====================
+Writing custom shaders
+======================
 
 This document explains how to write shaders for pygfx for the WgpuRenderer.
 This may be useful if you want to improve the existing shaders, add new
@@ -340,21 +340,3 @@ Other functions
 Other function that can be used in wgsl are:
 
 * ``ndc_to_world_pos(vec4<f32>) -> vec3<f32>``
-
-
-Reference docs
---------------
-
-.. autofunction:: pygfx.renderers.wgpu.register_wgpu_render_function
-
-.. autoclass:: pygfx.renderers.wgpu.Binding
-    :members:
-    :member-order: bysource
-
-.. autoclass:: pygfx.renderers.wgpu.WorldObjectShader
-    :members:
-    :inherited-members:
-
-.. autoclass:: pygfx.renderers.wgpu.Shared
-    :members:
-    :member-order: bysource

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ _ignore_offscreen_run()
 # -- Project information -----------------------------------------------------
 
 project = "pygfx"
-copyright = "2021, Almar Klein, Korijn van Golen"
+copyright = "2021-2023, Almar Klein, Korijn van Golen"
 author = "Almar Klein, Korijn van Golen"
 
 # The full version, including alpha/beta/rc tags

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ Contents
    Guide <guide.rst>
    Gallery <_gallery/index.rst>
    Reference <reference.rst>
-   Writing shaders <shaders.rst>
+   Advanced <advanced.rst>
 
 
 Indices and tables


### PR DESCRIPTION
Right now, the docs have a toplevel sections on shaders, which contains both API docs and a guide on writing custom shaders. I split these in two and put it in a new section "Advanced".