### PR TITLE
add Texture format for uint32

### DIFF
--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -248,8 +248,7 @@ def format_from_memoryview(mem, size):
         "h": "i2",
         "H": "u2",
         "i": "i4",
-        "I": "i4",
-        "U": "u4",
+        "I": "u4",
         "e": "f2",
         "f": "f4",
     }

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -248,6 +248,7 @@ def format_from_memoryview(mem, size):
         "h": "i2",
         "H": "u2",
         "i": "i4",
+        "I": "i4",
         "U": "u4",
         "e": "f2",
         "f": "f4",


### PR DESCRIPTION
unsigned int32 uses big `"I"` whereas `int32` uses `"i"`

```python
import numpy as np
import pygfx

shape = 100, 100
size = shape[0] * shape[1]

a = np.random.randint(0, 255, size, dtype=np.int32).reshape(shape)
au = np.random.randint(0, 255, size, dtype=np.uint32).reshape(shape)

print(memoryview(a).format, memoryview(au).format)

# returns: i I
```

works for images

```python
tex = pygfx.Texture(au, dim=2).get_view()

geo = pygfx.Geometry(grid=tex)
mat = pygfx.ImageBasicMaterial(clim=(0, 255))

wo = pygfx.Image(geo, mat)

pygfx.show(wo)
```

![image](https://user-images.githubusercontent.com/9403332/222947789-1f30c42e-6851-46dd-b5e7-6754f674275c.png)
