### PR TITLE
Generate class docs in normal Sphinx way

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -12,6 +12,11 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
+clean :
+	-rm -r _build
+	-rm -r _autosummary
+	-rm -r _gallery
+
 .PHONY: help Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new

--- a/docs/_templates/custom_layout.rst
+++ b/docs/_templates/custom_layout.rst
@@ -8,52 +8,9 @@
 .. automodule:: {{ fullname }}
 {% else %}
 .. autoclass:: {{ objname }}
-   {% block methods %}
-   {% if methods %}
-   
-   {# work out if there are local methods #}
-   {# Note: jinja hack to work around missing list comprehension #}
-   {% set local_methods = [] %}
-   {% for item in methods %}
-      {% if not item.startswith("__") %}
-      {% if item not in inherited_members %}
-      {% set foo = local_methods.append(item) %}
-      {% endif %}
-      {% endif %}
-   {% endfor %}
-   {% endif %}
-   
-   {% if local_methods %}
-   .. rubric:: {{ _('Methods') }}
-   .. autosummary::
-
-   {% for item in local_methods %}
-      ~{{ name }}.{{ item }}
-   {% endfor %}
-   {% endif %}
-   {% endblock %}
-
-   {% block attributes %}
-   {% if attributes %}
-   {# work out if there are local attributes #}
-   {% set local_attributes = [] %}
-   {% for item in attributes %}
-      {% if item not in inherited_members %}
-      {% set foo = local_attributes.append(item) %}
-      {% endif %}
-   {% endfor %}
-   {% endif %}
-   
-   {% if local_attributes %}
-   .. rubric:: {{ _('Attributes') }}
-
-   .. autosummary::
-
-   {% for item in local_attributes %}
-      ~{{ name }}.{{ item }}
-   {% endfor %}
-   {% endif %}
-   {% endblock %}
+   :members:
+   :show-inheritance:
+   :member-order: bysource
 
 {% endif %}
 {% if objtype != "module" %}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,6 +2,8 @@
 
 import os
 import sys
+import shutil
+
 from sphinx_gallery.sorting import ExplicitOrder
 import wgpu.gui.offscreen
 
@@ -46,6 +48,9 @@ extensions = [
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
+
+# Just let autosummary produce a new version each time
+shutil.rmtree(os.path.join(os.path.dirname(__file__), "_autosummary"), True)
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,6 @@ author = "Almar Klein, Korijn van Golen"
 # The full version, including alpha/beta/rc tags
 # release = '0.1.0'
 
-
 # -- General configuration ---------------------------------------------------
 
 # Add any Sphinx extension module names here, as strings. They can be
@@ -104,6 +103,3 @@ sphinx_gallery_conf = {
 html_static_path = ["_static"]
 html_favicon = "_static/pygfx.ico"
 html_logo = "_static/pygfx.svg"
-
-if not (os.getenv("READTHEDOCS") or os.getenv("CI")):
-    html_theme = "sphinx_rtd_theme"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,3 +99,6 @@ sphinx_gallery_conf = {
 html_static_path = ["_static"]
 html_favicon = "_static/pygfx.ico"
 html_logo = "_static/pygfx.svg"
+
+if not (os.getenv("READTHEDOCS") or os.getenv("CI")):
+    html_theme = "sphinx_rtd_theme"

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -12,6 +12,8 @@ set BUILDDIR=_build
 
 if "%1" == "" goto help
 
+if "%1" == "clean" goto clean
+
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
 	echo.
@@ -30,6 +32,13 @@ goto end
 
 :help
 %SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:clean
+rmdir /s/q "_build"
+rmdir /s/q "_autosummary"
+rmdir /s/q "_gallery"
+goto end
 
 :end
 popd

--- a/pygfx/geometries/_text.py
+++ b/pygfx/geometries/_text.py
@@ -259,7 +259,7 @@ class TextGeometry(Geometry):
         Parameters
         ----------
         text_items : list
-            A list of :class:`pygfx.TextItem`s to update the text with.
+            A list of :class:`pygfx.TextItem` objects to update the text with.
 
         Notes
         -----


### PR DESCRIPTION
The current documentation for classes shows a list of methods and attributes, which is nice in the sense that they are separated, but it only shows the summary (first line) of their docstrings, and does not show method signatures. You can also not crossref to methods or properties.

This PR is a proposal to render documentation for classes in the common Sphinx way using:

```
.. autoclass:: lib.Foo
   :members:
   :show-inheritance:
   :member-order: bysource
```

