### PR TITLE
Require pylinalg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,8 +62,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Test py37
-            pyversion: '3.7'
           - name: Test py38
             pyversion: '3.8'
           - name: Test py39

--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -19,6 +19,10 @@ from .utils.viewport import Viewport
 from .utils.text import font_manager
 from .utils import cm, logger
 
+# Temp fix for pyinstaller to pick up pylinalg
+import pylinalg
+
+del pylinalg
 
 __version__ = "0.1.12"
 version_info = tuple(map(int, __version__.split(".")))

--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -24,7 +24,7 @@ __version__ = "0.1.12"
 version_info = tuple(map(int, __version__.split(".")))
 
 __wgpu_version_range__ = "0.9.4", "0.10.0"
-__pylinalg_version_range__ = "0.3.0", "0.4.0"
+__pylinalg_version_range__ = "0.3.1", "0.4.0"
 
 
 def _check_lib_version(libname, pipname, version_range):

--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -24,24 +24,28 @@ __version__ = "0.1.12"
 version_info = tuple(map(int, __version__.split(".")))
 
 __wgpu_version_range__ = "0.9.4", "0.10.0"
+__pylinalg_version_range__ = "0.3.0", "0.4.0"
 
 
-def _test_wgpu_version():
-    import wgpu  # noqa
+def _check_lib_version(libname, pipname, version_range):
+    import importlib  # noqa
 
-    min_ver, max_ver = __wgpu_version_range__
+    lib = importlib.import_module(libname)
+
+    min_ver, max_ver = version_range
     min_ver_info = tuple(map(int, min_ver.split(".")))
     max_ver_info = tuple(map(int, max_ver.split(".")))
-    detected = f"Detected {wgpu.__version__}, need >={min_ver}, <{max_ver}."
-    if wgpu.version_info < min_ver_info:
+    detected = f"Detected {lib.__version__}, need >={min_ver}, <{max_ver}."
+    if lib.version_info < min_ver_info:
         logger.error(
-            f"Incompatible version of wgpu-py:\n    {detected}\n    To update, use e.g. `pip install -U wgpu`."
+            f"Incompatible version of {libname}:\n    {detected}\n    To update, use e.g. `pip install -U {pipname}`."
         )
-    elif wgpu.version_info >= max_ver_info:
-        logger.warning(f"Possible incompatible version of wgpu-py:\n    {detected}")
+    elif lib.version_info >= max_ver_info:
+        logger.warning(f"Possible incompatible version of {libname}:\n    {detected}")
 
 
-_test_wgpu_version()
+_check_lib_version("wgpu", "wgpu", __wgpu_version_range__)
+_check_lib_version("pylinalg", "pylinalg", __pylinalg_version_range__)
 
 
 def _get_sg_image_scraper():

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
         exclude=["tests", "tests.*", "examples", "examples.*", "exp", "exp.*"]
     ),
     package_data={f"{NAME}.data_files": resources_globs},
-    python_requires=">=3.7.0",
+    python_requires=">=3.8.0",
     install_requires=runtime_deps,
     extras_require=extras_require,
     license="BSD 2-Clause",

--- a/setup.py
+++ b/setup.py
@@ -11,11 +11,14 @@ with open(f"{NAME}/__init__.py", "rb") as fh:
     VERSION = re.search(r"__version__ = \"(.*?)\"", init_text).group(1)
     match = re.search(r"__wgpu_version_range__ = \"(.*?)\", \"(.*?)\"", init_text)
     wgpu_min_ver, wgpu_max_ver = match.group(1), match.group(2)
+    match = re.search(r"__pylinalg_version_range__ = \"(.*?)\", \"(.*?)\"", init_text)
+    pylinalg_min_ver, pylinalg_max_ver = match.group(1), match.group(2)
 
 
 runtime_deps = [
     "numpy",
     f"wgpu>={wgpu_min_ver},<{wgpu_max_ver}",
+    f"pylinalg>={pylinalg_min_ver},<{pylinalg_max_ver}",
     "freetype-py",
     "uharfbuzz",
     "Jinja2",


### PR DESCRIPTION
In preparation for using pylinalg in #457 and #482, let's require it in a separate PR. I adopted the same strategy as we use for wgpu, so that people using dev installs are also notified at runtime.