### PR TITLE
Add look-at example

### DIFF
--- a/examples/feature_demo/look_at.py
+++ b/examples/feature_demo/look_at.py
@@ -1,0 +1,72 @@
+"""
+Look At
+=======
+
+In this example shows how to do the rendering world's hello world: Show a 3D
+Cube on screen.
+"""
+# sphinx_gallery_pygfx_animate = True
+# sphinx_gallery_pygfx_target_name = "disp"
+from time import perf_counter_ns
+import numpy as np
+import pygfx as gfx
+
+scene = gfx.Scene()
+
+sphere = gfx.Mesh(
+    gfx.sphere_geometry(100, 20, 20),
+    gfx.MeshPhongMaterial(color="#336699"),
+)
+sphere.receive_shadow = sphere.cast_shadow = True
+scene.add(sphere)
+
+plane = gfx.Mesh(
+    gfx.plane_geometry(4000, 4000),
+    gfx.MeshPhongMaterial(color="#336699"),
+)
+plane.position.set(0, -2500, 0)
+plane.rotation.set_from_euler(gfx.linalg.Euler(-np.pi / 2))
+plane.receive_shadow = True
+scene.add(plane)
+
+sun = gfx.DirectionalLight(position=(0, 3000, 0))
+sun.cast_shadow = True
+sun.shadow.camera.depth_range = (1, 6000)
+sun.shadow.camera.width = 4000
+sun.shadow.camera.height = 4000
+scene.add(gfx.AmbientLight())
+scene.add(sun)
+
+geometry = gfx.cylinder_geometry(10, 0, 100, 12)
+material = gfx.MeshPhongMaterial(color="#336699")
+cones = gfx.Group()
+
+for i in range(100):
+    cone = gfx.Mesh(geometry, material)
+    cone.position.set(
+        *(np.random.rand(3) * 4000 - 2000)
+    )
+    cone.scale.set_scalar(np.random.rand() * 4 + 2)
+    cone.receive_shadow = cone.cast_shadow = True
+    cones.add(cone)
+
+scene.add(cones)
+
+
+def animate():
+    t = perf_counter_ns() // 1_000_000 * 0.0005
+    sphere.position.set(
+        np.sin(t * 0.7) * 2000,
+        np.cos(t * 0.5) * 2000,
+        np.cos(t * 0.3) * 2000,
+    )
+
+    for c in cones.children:
+        c.look_at(sphere.position)
+
+
+if __name__ == "__main__":
+    disp = gfx.Display()
+    disp.before_render = animate
+    disp.stats = True
+    disp.show(scene)

--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -28,7 +28,7 @@ __version__ = "0.1.12"
 version_info = tuple(map(int, __version__.split(".")))
 
 __wgpu_version_range__ = "0.9.4", "0.10.0"
-__pylinalg_version_range__ = "0.3.1", "0.4.0"
+__pylinalg_version_range__ = "0.3.2", "0.4.0"
 
 
 def _check_lib_version(libname, pipname, version_range):

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -376,7 +376,7 @@ class PerspectiveCamera(Camera):
         # Obtain view direction
         if view_dir is None:
             rotation = self.rotation.to_array()
-            view_dir = la.quaternion_rotate((0, 0, -1), rotation)
+            view_dir = la.vector_apply_quaternion((0, 0, -1), rotation)
         elif isinstance(view_dir, (tuple, list, np.ndarray)) and len(view_dir) == 3:
             view_dir = tuple(view_dir)
         else:
@@ -431,7 +431,7 @@ class PerspectiveCamera(Camera):
         # Obtain view direction
         if view_dir is None:
             rotation = self.rotation.to_array()
-            view_dir = la.quaternion_rotate((0, 0, -1), rotation)
+            view_dir = la.vector_apply_quaternion((0, 0, -1), rotation)
         elif isinstance(view_dir, (tuple, list, np.ndarray)) and len(view_dir) == 3:
             view_dir = tuple(view_dir)
         else:
@@ -453,7 +453,7 @@ class PerspectiveCamera(Camera):
         rotation = self.rotation.to_array()
 
         offset = 0.5 * (left + right), 0.5 * (top + bottom), 0
-        new_position = position + la.quaternion_rotate(offset, rotation)
+        new_position = position + la.vector_apply_quaternion(offset, rotation)
         self.position.set(*new_position)
 
 

--- a/pygfx/controllers/_base.py
+++ b/pygfx/controllers/_base.py
@@ -86,7 +86,7 @@ class Controller:
         fov = kwargs.get("fov", camera_state.get("fov"))
 
         distance = fov_distance_factor(fov) * extent
-        return la.quaternion_rotate((0, 0, -distance), rotation)
+        return la.vector_apply_quaternion((0, 0, -distance), rotation)
 
     def register_events(self, viewport_or_renderer: Union[Viewport, Renderer]):
         """Apply the default interaction mechanism to a wgpu autogui canvas.

--- a/pygfx/controllers/_orbit.py
+++ b/pygfx/controllers/_orbit.py
@@ -62,7 +62,7 @@ class OrbitController(PanZoomController):
         up = camera_state["up"]
 
         # Where is the camera looking at right now
-        forward = la.quaternion_rotate((0, 0, -1), rotation)
+        forward = la.vector_apply_quaternion((0, 0, -1), rotation)
 
         # # Get a reference vector, that is orthogonal to up, in a deterministic way.
         # # Might need this if we ever want the azimuth


### PR DESCRIPTION
* Adds a look_at example
* Closes #487

This example really stretches the performance limits of pygfx a little bit more, so I hope it will prove useful in combination with the new `Stats` helper.

You can just increase the amount of cones in the for loop to push the CPU and GPU even more.

![look-at](https://user-images.githubusercontent.com/1882046/226630066-a129249a-e468-41ae-9bee-8ba86a2e6366.gif)
