### PR TITLE
Show depth buffer

### DIFF
--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -246,7 +246,7 @@ class SimpleTransparencyPass(BasePass):
         return {
             "view": blender.depth_view,
             "depth_load_op": wgpu.LoadOp.load,
-            "depth_store_op": wgpu.StoreOp.discard,
+            "depth_store_op": wgpu.StoreOp.store,
         }
 
     def get_shader_code(self, blender):
@@ -344,7 +344,7 @@ class WeightedTransparencyPass(BasePass):
         return {
             "view": blender.depth_view,
             "depth_load_op": wgpu.LoadOp.load,
-            "depth_store_op": wgpu.StoreOp.discard,
+            "depth_store_op": wgpu.StoreOp.store,
         }
 
     def get_shader_code(self, blender):
@@ -466,7 +466,7 @@ class BaseFragmentBlender:
         # The depth buffer is 32 bit - we need that precision.
         self._texture_info["depth"] = (
             wgpu.TextureFormat.depth32float,
-            usg.RENDER_ATTACHMENT | usg.COPY_SRC,
+            usg.RENDER_ATTACHMENT | usg.COPY_SRC | usg.TEXTURE_BINDING,
         )
 
         # The pick texture has 4 16bit channels, adding up to 64 bits.

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -516,7 +516,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
             physical_viewport,
             clear_color,
         )
-        command_buffers += self._blender.perform_combine_pass(self._shared.device)
+        # command_buffers += self._blender.perform_combine_pass(self._shared.device)
         command_buffers
 
         # Collect commands and submit
@@ -551,7 +551,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
 
         command_buffers = self._flusher.render(
             self._blender.color_view,
-            None,
+            self._blender.depth_view,
             raw_texture_view,
             self._target_tex_format,
             self._gamma_correction * self._gamma_correction_srgb,


### PR DESCRIPTION
This is a bit of an experiment to what we'd need to make the values of the depth buffer available (for users, via an API, and for post-processing). It also contains a few tweaks to the blender code to avoid resetting the depth buffer in transparent passes.

For most examples, this nicely shows the depth:
<img width="528" alt="image" src="https://user-images.githubusercontent.com/3015475/228215055-4693143c-3c88-4c92-91eb-9beca4e4d76e.png">

Some observations:
* Transparent fragments do not have a depth value, unless the blend_mode is "opaque"  or "ordered1". 
* For subplots, only the last drawn plot has a depth, because the full depth buffer is reset for each subplot.
* Similarly, for overlays, only the depth of the final pass is visible.
