### PR TITLE
Add frustum property to perspective camera

### DIFF
--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -458,7 +458,7 @@ class PerspectiveCamera(Camera):
 
     @property
     def frustum(self):
-        """Corner positions of the viewing frustum in world coordinates.
+        """Corner positions of the viewing frustum in world space.
 
         Returns
         -------

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -456,6 +456,32 @@ class PerspectiveCamera(Camera):
         new_position = position + la.vector_apply_quaternion(offset, rotation)
         self.position.set(*new_position)
 
+    @property
+    def frustum(self):
+        """Corner positions of the viewing frustum in world coordinates.
+
+        Returns
+        -------
+        frustum : ndarray, [2, 4, 3]
+            The coordinates of the frustum. The first axis corresponds to the
+            frustum's plane (near, far), the second to the corner within the
+            plane ((left, bottom), (right, bottom), (right, top), (left, top)),
+            and the third to the world position of that corner.
+
+        """
+
+        projection_matrix = self.projection_matrix.to_ndarray()
+
+        ndc_corners = np.array([(-1, -1), (1, -1), (1, 1), (-1, 1)])
+        depths = np.array((0, 1))[:, None]
+        local_corners = la.vector_unproject(
+            ndc_corners, projection_matrix, depth=depths
+        )
+        world_corners = la.vector_apply_matrix(
+            local_corners, self.matrix_world.to_ndarray()
+        )
+        return world_corners
+
 
 def fov_distance_factor(fov):
     # It's important that controller and camera use the same distance calculations

--- a/tests/cameras/test_cameras.py
+++ b/tests/cameras/test_cameras.py
@@ -124,3 +124,23 @@ def _run_for_camera(camera, near, far, check_halfway):
     assert np.allclose(pos_world3.to_array(), [0, 0, -far])
     if check_halfway:
         assert np.allclose(pos_world2.to_array(), [0, 0, -0.5 * (near + far)])
+
+
+def test_frustum():
+    unit_cube_corners = np.array(
+        [
+            [-1.0, -1.0, 1.0],
+            [1.0, -1.0, 1.0],
+            [1.0, 1.0, 1.0],
+            [-1.0, 1.0, 1.0],
+            [-1.0, -1.0, -1.0],
+            [1.0, -1.0, -1.0],
+            [1.0, 1.0, -1.0],
+            [-1.0, 1.0, -1.0],
+        ]
+    )
+
+    camera = gfx.OrthographicCamera(2, 2, depth_range=(-1, 1))
+    frustum_corners = camera.frustum
+
+    assert np.allclose(frustum_corners, unit_cube_corners.reshape(2, 4, 3))

--- a/tests/cameras/test_cameras.py
+++ b/tests/cameras/test_cameras.py
@@ -144,3 +144,21 @@ def test_frustum():
     frustum_corners = camera.frustum
 
     assert np.allclose(frustum_corners, unit_cube_corners.reshape(2, 4, 3))
+
+    expected_corners = np.array(
+        [
+            [-1.0, -1.0, -1.0],
+            [1.0, -1.0, -1.0],
+            [1.0, 1.0, -1.0],
+            [-1.0, 1.0, -1.0],
+            [-2.0, -2.0, -2.0],
+            [2.0, -2.0, -2.0],
+            [2.0, 2.0, -2.0],
+            [-2.0, 2.0, -2.0],
+        ]
+    )
+
+    camera = gfx.PerspectiveCamera(fov=90.0, aspect=1, depth_range=(1, 2))
+    frustum_corners = camera.frustum
+
+    assert np.allclose(frustum_corners, expected_corners.reshape(2, 4, 3))


### PR DESCRIPTION
This PR adds a `camera.frustum` property to both the perspective and orthographic camera. It returns the camera's frustum as a set of corners/vertices of shape `(2, 4, 3)`. The first axis corresponds to the near/far plane, the second to the type of the corner (e.g., "bottom left"), and the third axis is that corner's 3D position in world space.

I've been using this while hunting bugs in the pylinalg integration PR, but realized that this might be useful on its own, so I am proposing it as a dedicated feature here. So far, I've used it to comprehend (and numerically access) the area of the scene that a camera has in view whenever the render itself just shows grey/background. It's surprisingly useful in figuring out if it is the camera or the WorldObject that is behaving funny. 

I also think it might come in handy in the future if we decide to do things like exclude objects from updating their GPU data if they are not in view by the main camera. The same idea might also work for skipping render passes of lights that are not in view.

Curious if you think this is useful, or if this already exists and I simply missed it.