### PR TITLE
Mipmap with proper smoothing

### DIFF
--- a/examples/feature_demo/dynamic_env_map.py
+++ b/examples/feature_demo/dynamic_env_map.py
@@ -40,7 +40,7 @@ env_static = gfx.Texture(
 # Create the dynamic env map
 
 env_dynamic = gfx.Texture(
-    dim=2, size=(512, 512, 6), format="rgba8unorm-srgb", generate_mipmaps=True
+    dim=2, size=(512, 512, 6), format="rgba8unorm", generate_mipmaps=True
 )
 
 cube_camera = CubeCamera(env_dynamic)

--- a/examples/feature_demo/image_plus_points.py
+++ b/examples/feature_demo/image_plus_points.py
@@ -15,7 +15,7 @@ scene = gfx.Scene()
 
 # %% add image
 
-im = iio.imread("imageio:astronaut.png")[::2]
+im = iio.imread("imageio:astronaut.png")
 
 image = gfx.Image(
     gfx.Geometry(grid=gfx.Texture(im, dim=2)),

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -707,7 +707,7 @@ class MeshStandardMaterial(MeshBasicMaterial):
         else:
             if not map.generate_mipmaps:
                 logger.warning(
-                    "The env_map texture must have generate_mipmaps=True to avoid a fully metalic look."
+                    "The env_map texture must have generate_mipmaps=True in order for roughness to work."
                 )
             width, height, _ = map.size
             max_level = math.floor(math.log2(max(width, height))) + 1

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -1,7 +1,7 @@
 import math
 from ._base import Material
 from ..resources import Texture
-from ..utils import unpack_bitfield
+from ..utils import unpack_bitfield, logger
 from ..utils.color import Color
 
 
@@ -689,10 +689,13 @@ class MeshStandardMaterial(MeshBasicMaterial):
         """A texture that provides the environment map (in srgb colorspace). Default None.
 
         This makes the surroundings of the object be reflected on its
-        surface. To ensure a physically correct rendering, you should
-        use a prefilterd texture. We provide a built-in mipmap
-        generation process by setting the "Texture.generate_mipmaps".
+        surface. The given texture should have its ``generate_mipmaps`` set to
+        True. Otherwise the roughness has no effect (as if its always zero).
         """
+        # Note: to obtain a “physically correct” result, an advanced
+        # mipmap technique is needed: PMREM (Prefiltered Mipmap Radiance
+        # Environment Maps). We could (I think) add this technique in addition
+        # to our normal mipmapping.
         return self._env_map
 
     @env_map.setter
@@ -702,6 +705,10 @@ class MeshStandardMaterial(MeshBasicMaterial):
         if map is None:
             self.uniform_buffer.data["env_map_max_mip_level"] = 0
         else:
+            if not map.generate_mipmaps:
+                logger.warning(
+                    "The env_map texture must have generate_mipmaps=True to avoid a fully metalic look."
+                )
             width, height, _ = map.size
             max_level = math.floor(math.log2(max(width, height))) + 1
             self.uniform_buffer.data["env_map_max_mip_level"] = float(max_level)

--- a/pygfx/renderers/wgpu/_update.py
+++ b/pygfx/renderers/wgpu/_update.py
@@ -144,7 +144,7 @@ def ensure_wgpu_object(device, resource):
             fmt = ALTTEXFORMAT[fmt][0]
         usage = resource._wgpu_usage
         if resource.generate_mipmaps:
-            usage |= wgpu.TextureUsage.RENDER_ATTACHMENT  # mipmap needs this
+            usage |= wgpu.TextureUsage.STORAGE_BINDING  # mipmap needs this
             resource._wgpu_mip_level_count = get_mip_level_count(resource)
         resource._wgpu_object = device.create_texture(
             size=resource.size,


### PR DESCRIPTION
Closes #499 

* [x] Gaussian smoothing.
* [x] Improve docs.
* [x] Add a check -> env map on StandardMaterial needs to be mipmapped.
* [x] Try to do the mipmapping with a compute shader instead.

The use of a compute shader made the mipmap generation about 3-4 times faster (on my machine).

The only downside of the compute shader is that srgb textures cannot be attached as a storage texture (unless there's a trick that I am not aware of). This is not really a problem, because the only benefit of such a texture is that it automatically handles srgb conversions in hardware. (The renderer knows what texture is used and will apply the conversion in the shader if necessary.)