### PR TITLE
More efficient Buffer and Texture updates

### DIFF
--- a/examples/other/collection_line.py
+++ b/examples/other/collection_line.py
@@ -51,11 +51,13 @@ camera = gfx.OrthographicCamera(cols, rows, maintain_aspect=False)
 camera.show_object(scene)
 controller = gfx.PanZoomController(camera, register_events=renderer)
 
+stats = gfx.Stats(viewport=renderer)
+
 
 def animate():
-    t0 = time.perf_counter()  # noqa
-    renderer.render(scene, camera)
-    # print(time.perf_counter() - t0)
+    with stats:
+        renderer.render(scene, camera, flush=False)
+    stats.render()
     canvas.request_draw()
 
 

--- a/pygfx/controllers/_fly.py
+++ b/pygfx/controllers/_fly.py
@@ -149,7 +149,6 @@ class FlyController(Controller):
 
         new_position = position + delta_world * self.speed
         self._set_camera_state({"position": new_position})
-        print(new_position)
 
     def _update_speed(self, delta):
         assert isinstance(delta, float)

--- a/pygfx/objects/_lights.py
+++ b/pygfx/objects/_lights.py
@@ -505,8 +505,8 @@ class LightShadow:
         # self._map_size = [1024, 1024]
 
         # TODO: move bias and cull_mode to Light so they can be reactive?
-        self._bias = 0
-        self._cull_mode = "FRONT"
+        self.bias = 0
+        self.cull_mode = "FRONT"
         self._gfx_matrix_buffer = Buffer(array_from_shadertype(shadow_uniform_type))
 
     @property

--- a/pygfx/renderers/wgpu/_pipeline.py
+++ b/pygfx/renderers/wgpu/_pipeline.py
@@ -464,7 +464,7 @@ class PipelineContainer:
     def collect_flat_resources(self):
         """Collect a list of all used resources, and also set their usage."""
         pipeline_resources = []  # List, because order matters
-
+        # todo: looks like this is called when wgpu_objects are already created, so it won't have use anymore, right?
         for bindings_dict in self.bindings_dicts.values():
             for binding in bindings_dict.values():
                 resource = binding.resource

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -513,11 +513,8 @@ class WgpuRenderer(RootEventHandler, Renderer):
             render_pipeline_containers.extend(container_group.render_containers)
 
         # Update *all* buffers and textures that have changed
-        update_count = 0
         for resource in resource_registry.get_syncable_resources(flush=True):
-            update_count += 1
             update_resource(self.device, resource)
-        # print("updated", update_count, "resources")
 
         # Command buffers cannot be reused. If we want some sort of re-use we should
         # look into render bundles. See https://github.com/gfx-rs/wgpu-native/issues/154

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -22,13 +22,13 @@ from ...objects import (
     WorldObject,
 )
 from ...cameras import Camera
-from ...resources import Texture
+from ...resources import Texture, registry as resource_registry
 from ...utils import Color
 
 from . import _blender as blender_module
 from ._flusher import RenderFlusher
 from ._pipeline import get_pipeline_container_group
-from ._update import update_buffer, ensure_wgpu_object
+from ._update import update_resource, ensure_wgpu_object
 from ._shared import Shared
 from ._environment import get_environment
 from ._shadowutil import ShadowUtil
@@ -512,6 +512,13 @@ class WgpuRenderer(RootEventHandler, Renderer):
             compute_pipeline_containers.extend(container_group.compute_containers)
             render_pipeline_containers.extend(container_group.render_containers)
 
+        # Update *all* buffers and textures that have changed
+        update_count = 0
+        for resource in resource_registry.get_syncable_resources(flush=True):
+            update_count += 1
+            update_resource(self.device, resource)
+        print("updated", update_count, "resources")
+
         # Command buffers cannot be reused. If we want some sort of re-use we should
         # look into render bundles. See https://github.com/gfx-rs/wgpu-native/issues/154
         # If we do get this to work, we should trigger a new recording
@@ -650,7 +657,6 @@ class WgpuRenderer(RootEventHandler, Renderer):
         stdinfo_data["logical_size"] = logical_size
         # Upload to GPU
         self._shared.uniform_buffer.update_range(0, 1)
-        update_buffer(self._shared.device, self._shared.uniform_buffer)
 
     # Picking
 

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -517,7 +517,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
         for resource in resource_registry.get_syncable_resources(flush=True):
             update_count += 1
             update_resource(self.device, resource)
-        print("updated", update_count, "resources")
+        # print("updated", update_count, "resources")
 
         # Command buffers cannot be reused. If we want some sort of re-use we should
         # look into render bundles. See https://github.com/gfx-rs/wgpu-native/issues/154

--- a/pygfx/renderers/wgpu/_shadowutil.py
+++ b/pygfx/renderers/wgpu/_shadowutil.py
@@ -85,7 +85,7 @@ class ShadowUtil:
             },
             primitive={
                 "topology": wgpu.PrimitiveTopology.triangle_list,
-                "cull_mode": cull_mode,
+                "cull_mode": cull_mode.lower(),
             },
             depth_stencil={
                 "format": wgpu.TextureFormat.depth32float,
@@ -129,6 +129,7 @@ class ShadowUtil:
                             if isinstance(light, PointLight)
                             else light.shadow._gfx_matrix_buffer
                         )
+                        buffer._wgpu_usage = wgpu.BufferUsage.UNIFORM
                         wgpu_buffer = ensure_wgpu_object(self.device, buffer)
 
                         setattr(

--- a/pygfx/renderers/wgpu/_shadowutil.py
+++ b/pygfx/renderers/wgpu/_shadowutil.py
@@ -1,5 +1,5 @@
 import wgpu
-from ._update import ensure_wgpu_object
+from ._update import ensure_wgpu_object, update_resource
 from ._utils import to_vertex_format
 
 from ...objects import PointLight
@@ -131,6 +131,10 @@ class ShadowUtil:
                         )
                         buffer._wgpu_usage = wgpu.BufferUsage.UNIFORM
                         wgpu_buffer = ensure_wgpu_object(self.device, buffer)
+                        # We also update the buffer now, because this code gets called
+                        # *after* the renderer has synced all resources. Note that this
+                        # code is only reached once for each shadow map.
+                        update_resource(self.device, buffer)
 
                         setattr(
                             light.shadow,

--- a/pygfx/renderers/wgpu/_update.py
+++ b/pygfx/renderers/wgpu/_update.py
@@ -36,8 +36,8 @@ def update_resource(device, resource):
 
 
 def _update_buffer(device, buffer):
-    # ensure_wgpu_object(device, buffer)
     wgpu_buffer = buffer._wgpu_object
+    assert wgpu_buffer is not None
 
     # Get and reset pending uploads
     pending_uploads = buffer._gfx_pending_uploads
@@ -67,8 +67,8 @@ def _update_buffer(device, buffer):
 
 
 def _update_texture(device, texture):
-    # ensure_wgpu_object(device, texture)
     wgpu_texture = texture._wgpu_object
+    assert wgpu_texture is not None
 
     # Get and reset pending uploads
     pending_uploads = texture._gfx_pending_uploads

--- a/pygfx/renderers/wgpu/_update.py
+++ b/pygfx/renderers/wgpu/_update.py
@@ -35,6 +35,21 @@ def update_resource(device, resource):
         raise ValueError(f"Invalid resource type: {resource.__class__.__name__}")
 
 
+# Note on how buffer and texture updates work:
+#
+# * When a resource is first created, it's _wgpu_object attribute is None
+#   and its _wgpu_flags is unset.
+# * When the resource is actually being used somewhere, it will end up
+#   in the logic that creates a pipeline object (e.g. in _pipeline.py), which
+#   sets the appropriate usage flags (because that code knows how the resource
+#   is used) and then uses ensure_wgpu_object to create the object.
+# * Resources that need to be synced are tracked in the resource_registry,
+#   but only go into it when they have their _wgpu_object set (i.e. when
+#   the resource actually exists on the GPU).
+# * Right before the renderer performs a draw, it queries the registry
+#   and calls update_resource on each.
+
+
 def _update_buffer(device, buffer):
     wgpu_buffer = buffer._wgpu_object
     assert wgpu_buffer is not None

--- a/pygfx/resources/__init__.py
+++ b/pygfx/resources/__init__.py
@@ -17,7 +17,7 @@ In pygfx, data is stored in buffers and textures. We collectively call these res
 
 # flake8: noqa
 
-from ._base import Resource
+from ._base import Resource, registry  # registry stays in this namespace
 from ._buffer import Buffer
 from ._texture import Texture
 

--- a/pygfx/resources/__init__.py
+++ b/pygfx/resources/__init__.py
@@ -17,7 +17,8 @@ In pygfx, data is stored in buffers and textures. We collectively call these res
 
 # flake8: noqa
 
-from ._buffer import Resource, Buffer
+from ._base import Resource
+from ._buffer import Buffer
 from ._texture import Texture
 
 __all__ = ["Resource", "Buffer", "Texture"]

--- a/pygfx/resources/_base.py
+++ b/pygfx/resources/_base.py
@@ -1,3 +1,5 @@
+import weakref
+
 from ..utils.trackable import Trackable
 
 
@@ -18,4 +20,47 @@ FORMAT_MAP = {
 class Resource(Trackable):
     """Resource base class."""
 
-    pass
+    def __init__(self):
+        super().__init__()
+        registry.register(self)
+
+    def _mark_for_sync(self):
+        registry.mark_for_sync(self)
+
+
+class ResourceRegistry:
+    """Singleton registry for resources."""
+
+    def __init__(self):
+        self._all = weakref.WeakSet()
+        self._syncable = weakref.WeakSet()
+
+    def register(self, resource):
+        if not isinstance(resource, Resource):
+            raise TypeError("Given object is not a Resource")
+        self._all.add(resource)
+
+    def mark_for_sync(self, resource):
+        if not isinstance(resource, Resource):
+            raise TypeError("Given object is not a Resource")
+        self._syncable.add(resource)
+
+    def get_resource_count(self):
+        """Get a dictionary indicating how many buffers and texture are currently alive."""
+        counts = {"Buffer": 0, "Texture": 0}
+        for r in self._all:
+            name = r.__class__.__name__
+            counts[name] = counts.get(name, 0) + 1
+        return counts
+
+    def get_syncable_resources(self, flush=False):
+        """Get the set of resources that need syncing. If setting flush
+        to True, the caller is responsible for syncing the resources.
+        """
+        syncable = set(self._syncable)
+        if flush:
+            self._syncable.clear()
+        return syncable
+
+
+registry = ResourceRegistry()

--- a/pygfx/resources/_base.py
+++ b/pygfx/resources/_base.py
@@ -22,10 +22,10 @@ class Resource(Trackable):
 
     def __init__(self):
         super().__init__()
-        registry.register(self)
+        registry._gfx_register(self)
 
     def _gfx_mark_for_sync(self):
-        registry.mark_for_sync(self)
+        registry._gfx_mark_for_sync(self)
 
 
 class ResourceRegistry:
@@ -35,14 +35,19 @@ class ResourceRegistry:
         self._all = weakref.WeakSet()
         self._syncable = weakref.WeakSet()
 
-    def register(self, resource):
+    def _gfx_register(self, resource):
+        """Add a resource to the registry."""
         if not isinstance(resource, Resource):
             raise TypeError("Given object is not a Resource")
         self._all.add(resource)
 
-    def mark_for_sync(self, resource):
+    def _gfx_mark_for_sync(self, resource):
+        """Register the given resource for synchonization. Only adds the resource
+        if it's wgpu-counterpart already exists, and when it has pending uploads.
+        """
         if not isinstance(resource, Resource):
             raise TypeError("Given object is not a Resource")
+        # Note: very obvious wgpu abstraction leak here :(
         if resource._wgpu_object is not None and resource._gfx_pending_uploads:
             self._syncable.add(resource)
 

--- a/pygfx/resources/_base.py
+++ b/pygfx/resources/_base.py
@@ -24,7 +24,7 @@ class Resource(Trackable):
         super().__init__()
         registry.register(self)
 
-    def _mark_for_sync(self):
+    def _gfx_mark_for_sync(self):
         registry.mark_for_sync(self)
 
 
@@ -43,7 +43,8 @@ class ResourceRegistry:
     def mark_for_sync(self, resource):
         if not isinstance(resource, Resource):
             raise TypeError("Given object is not a Resource")
-        self._syncable.add(resource)
+        if resource._wgpu_object is not None and resource._gfx_pending_uploads:
+            self._syncable.add(resource)
 
     def get_resource_count(self):
         """Get a dictionary indicating how many buffers and texture are currently alive."""

--- a/pygfx/resources/_base.py
+++ b/pygfx/resources/_base.py
@@ -53,7 +53,7 @@ class ResourceRegistry:
             counts[name] = counts.get(name, 0) + 1
         return counts
 
-    def get_syncable_resources(self, flush=False):
+    def get_syncable_resources(self, *, flush=False):
         """Get the set of resources that need syncing. If setting flush
         to True, the caller is responsible for syncing the resources.
         """

--- a/pygfx/resources/_base.py
+++ b/pygfx/resources/_base.py
@@ -1,0 +1,21 @@
+from ..utils.trackable import Trackable
+
+
+STRUCT_FORMAT_ALIASES = {"c": "B", "l": "i", "L": "I"}
+
+FORMAT_MAP = {
+    "b": "i1",
+    "B": "u1",
+    "h": "i2",
+    "H": "u2",
+    "i": "i4",
+    "I": "u4",
+    "e": "f2",
+    "f": "f4",
+}
+
+
+class Resource(Trackable):
+    """Resource base class."""
+
+    pass

--- a/pygfx/resources/_base.py
+++ b/pygfx/resources/_base.py
@@ -45,9 +45,14 @@ class ResourceRegistry:
         """Register the given resource for synchonization. Only adds the resource
         if it's wgpu-counterpart already exists, and when it has pending uploads.
         """
+        # Note: this method is very specific to the wgpu renderer, and
+        # its logic to handle updates to buffers and textures. We could
+        # create some sort of plugin system so that each renderer can
+        # register a registry (and that registry could attach the
+        # _wgpu_xx attributes to the buffers/texture) but that feels
+        # like overdesigning at this point. Let's track in #272.
         if not isinstance(resource, Resource):
             raise TypeError("Given object is not a Resource")
-        # Note: very obvious wgpu abstraction leak here :(
         if resource._wgpu_object is not None and resource._gfx_pending_uploads:
             self._syncable.add(resource)
 

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -62,6 +62,7 @@ class Buffer(Resource):
             the_nbytes = mem.nbytes
             the_nitems = mem.shape[0] if mem.shape else 1
             self._gfx_pending_uploads.append((0, the_nitems))
+            self._mark_for_sync()
             if nbytes is not None and nbytes != the_nbytes:
                 raise ValueError("Given nbytes does not match size of given data.")
             if nitems is not None and nitems != the_nitems:

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -62,7 +62,6 @@ class Buffer(Resource):
             the_nbytes = mem.nbytes
             the_nitems = mem.shape[0] if mem.shape else 1
             self._gfx_pending_uploads.append((0, the_nitems))
-            self._mark_for_sync()
             if nbytes is not None and nbytes != the_nbytes:
                 raise ValueError("Given nbytes does not match size of given data.")
             if nitems is not None and nitems != the_nitems:
@@ -165,7 +164,7 @@ class Buffer(Resource):
         # Limit and apply
         self._gfx_pending_uploads.append((offset, size))
         self._rev += 1
-        self._mark_for_sync()
+        self._gfx_mark_for_sync()
         # note: this can be smarter, we have logic for chunking in the morph tool
 
     def _get_subdata(self, offset, size):

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -164,6 +164,7 @@ class Buffer(Resource):
         # Limit and apply
         self._gfx_pending_uploads.append((offset, size))
         self._rev += 1
+        self._mark_for_sync()
         # note: this can be smarter, we have logic for chunking in the morph tool
 
     def _get_subdata(self, offset, size):

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -1,14 +1,6 @@
-from ..utils.trackable import Trackable
-
 import numpy as np
 
-STRUCT_FORMAT_ALIASES = {"c": "B", "l": "i", "L": "I"}
-
-
-class Resource(Trackable):
-    """Resource base class."""
-
-    pass
+from ._base import Resource, STRUCT_FORMAT_ALIASES, FORMAT_MAP
 
 
 class Buffer(Resource):
@@ -194,17 +186,6 @@ class Buffer(Resource):
 
 
 def format_from_memoryview(mem):
-    formatmap = {
-        "b": "i1",
-        "B": "u1",
-        "h": "i2",
-        "H": "u2",
-        "i": "i4",
-        "I": "u4",
-        "e": "f2",
-        "f": "f4",
-    }
-
     shape = mem.shape
     if len(shape) == 1:
         shape = shape + (1,)
@@ -213,9 +194,9 @@ def format_from_memoryview(mem):
     format = STRUCT_FORMAT_ALIASES.get(format, format)
     if format in ("d", "float64"):
         raise ValueError("64-bit float is not supported, use 32-bit float instead")
-    elif format not in formatmap:
+    elif format not in FORMAT_MAP:
         raise TypeError(
             f"Cannot convert {format!r} to vertex format. Maybe specify format?"
         )
-    format = f"{shape[-1]}x" + formatmap[format]
+    format = f"{shape[-1]}x" + FORMAT_MAP[format]
     return format.lstrip("1x")

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from ._buffer import Resource, STRUCT_FORMAT_ALIASES
+from ._base import Resource, STRUCT_FORMAT_ALIASES, FORMAT_MAP
 
 
 class Texture(Resource):
@@ -244,17 +244,6 @@ class Texture(Resource):
 
 
 def format_from_memoryview(mem, size):
-    formatmap = {
-        "b": "i1",
-        "B": "u1",
-        "h": "i2",
-        "H": "u2",
-        "i": "i4",
-        "I": "u4",
-        "e": "f2",
-        "f": "f4",
-    }
-
     format = str(mem.format)
     format = STRUCT_FORMAT_ALIASES.get(format, format)
     # Process channels
@@ -268,9 +257,9 @@ def format_from_memoryview(mem, size):
     assert 1 <= nchannels <= 4
     if format in ("d", "float64"):
         raise TypeError("GPU's don't support float64 texture formats.")
-    elif format not in formatmap:
+    elif format not in FORMAT_MAP:
         raise TypeError(
             f"Cannot convert {format!r} to texture format. Maybe specify format?"
         )
-    format = f"{nchannels}x" + formatmap[format]
+    format = f"{nchannels}x" + FORMAT_MAP[format]
     return format.lstrip("1x")

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -184,6 +184,7 @@ class Texture(Resource):
         else:
             self._gfx_pending_uploads.append((offset, size))
         self._rev += 1
+        self._mark_for_sync()
 
     def _size_from_data(self, data, dim, size):
         # Check if shape matches dimension

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -184,7 +184,7 @@ class Texture(Resource):
         else:
             self._gfx_pending_uploads.append((offset, size))
         self._rev += 1
-        self._mark_for_sync()
+        self._gfx_mark_for_sync()
 
     def _size_from_data(self, data, dim, size):
         # Check if shape matches dimension

--- a/pygfx/utils/text/_atlas.py
+++ b/pygfx/utils/text/_atlas.py
@@ -398,7 +398,7 @@ class PygfxGlyphAtlas(GlyphAtlas):
         # Do the normal behavior
         array = self._array
         super()._set_new_glyphs_array(*args)
-        # Create wgpu object if needed
+        # Create resource object if needed
         if self._array is not array:
             self._texture = Texture(self._array, dim=2)
         # Schedule an update. Note that the infos array is updated due to repacking.
@@ -410,7 +410,7 @@ class PygfxGlyphAtlas(GlyphAtlas):
         # Do the normal behavior
         infos = self._infos
         super()._set_new_infos_array(*args)
-        # Create wgpu object if needed
+        # Create resource object if needed
         if self._infos is not infos:
             self._infos_buffer = Buffer(self._infos)
         # Schedule an update


### PR DESCRIPTION
Closes #321

### Todo

* [x] Introduce a registry that is aware of all buffers and textures, and which ones need an update (uses weakrefs).
* [x] Make the renderer use that instead of checking *all* resources whether they need to be synced.
* [x] Removed a bit of wgpu-specific logic from lights.py
* [x] Updated the list in #272 along the way.
* [x] Removed a print-call from the fly controller. 

### How it now works

(also added this to the code in a comment).

* When a resource is first created, it's _wgpu_object attribute is None
  and its _wgpu_flags is unset.
* When the resource is actually being used somewhere, it will end up
  in the logic that creates a pipeline object (e.g. in _pipeline.py), which
  sets the appropriate usage flags (because that code knows how the resource
  is used) and then uses ensure_wgpu_object to create the object.
* Resources that need to be synced are tracked in the resource_registry,
  but only go into it when they have their _wgpu_object set (i.e. when
  the resource actually exists on the GPU).
* Right before the renderer performs a draw, it queries the registry
  and calls update_resource on each.

This PR basically makes the above work, and then removes the old system (which required updates more spread out over the code).
