### PR TITLE
more informative exception message for `Buffer.update_range` valid types

### DIFF
--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -154,7 +154,12 @@ class Buffer(Resource):
         """
         # See ThreeJS BufferAttribute.updateRange
         # Check input
-        assert isinstance(offset, int) and isinstance(size, int)
+        if not isinstance(offset, int) and isinstance(size, int):
+            raise TypeError(
+                f"`offset` and `size` must be native `int` type, you have passed: "
+                f"offset: <{type(offset)}>, size: <{type(size)}>"
+            )
+
         if size == 0:
             return
         elif size < 0:


### PR DESCRIPTION
I run into this often since `numpy.integer` types (such as `np.int64`) often end up being sent to `update_range()`. I thought about potentially just allowing `update_range()` to take `numpy.integer` types, however that might open up a can of worms where it is expected to support integer types from all array libraries?
