### PR TITLE
New cache class, apply to mipmaps

### DIFF
--- a/pygfx/controllers/_panzoom.py
+++ b/pygfx/controllers/_panzoom.py
@@ -54,7 +54,7 @@ class PanZoomController(Controller):
     def _update_pan(self, delta, *, vecx, vecy):
         # These update methods all accept one positional arg: the delta.
         # it can additionally require keyword args, from a set of names
-        # that new actions cache. These include:
+        # that new actions store. These include:
         # rect, screen_pos, vecx, vecy
 
         assert isinstance(delta, tuple) and len(delta) == 2

--- a/pygfx/geometries/_text.py
+++ b/pygfx/geometries/_text.py
@@ -35,7 +35,8 @@ ANCHOR_Y_ALTS = {
 }
 
 
-WHITESPACE_EXTENTS = {}  # A cache
+# We cache the extents of small whitespace strings to improve performance
+WHITESPACE_EXTENTS = {}
 
 
 class TextItem:

--- a/pygfx/renderers/wgpu/_mipmapsutil.py
+++ b/pygfx/renderers/wgpu/_mipmapsutil.py
@@ -1,4 +1,4 @@
-import math
+import numpy as np
 import wgpu
 from ...resources._texture import Texture
 from ._utils import GfxTextureView, GpuCache
@@ -59,9 +59,10 @@ mipmap_source = """
 
 def get_mip_level_count(texture):
     """Get the number of mipmap levels from the texture size."""
-    assert isinstance(texture, Texture)
+    if not isinstance(texture, Texture):
+        raise TypeError("Expecting a Texture object.")
     width, height, _ = texture.size
-    return math.floor(math.log2(max(width, height))) + 1
+    return int(np.floor(np.log2(max(width, height))) + 1)
 
 
 def generate_texture_mipmaps(device, target):

--- a/pygfx/renderers/wgpu/_mipmapsutil.py
+++ b/pygfx/renderers/wgpu/_mipmapsutil.py
@@ -1,7 +1,10 @@
 import math
 import wgpu
 from ...resources._texture import Texture
-from ._utils import GfxTextureView
+from ._utils import GfxTextureView, GpuCache
+
+
+MIPMAP_CACHE = GpuCache("mipmap_pipelines")
 
 
 mipmap_source = """
@@ -54,127 +57,19 @@ mipmap_source = """
 """
 
 
-class MipmapsUtil:
-    def __init__(self, device) -> None:
-        self.device = device
-
-        # Cache pipelines for every texture format used.
-        self.pipelines = {}
-
-    def get_mipmap_pipeline(self, format):
-        pipeline = self.pipelines.get(format, None)
-
-        if pipeline is None:
-            if format.endswith("srgb"):
-                raise RuntimeError("Cannot create mipmaps for srgb textures.")
-
-            type, textype = "f32", "float"
-            if format.endswith(("norm", "float")):
-                type, textype = "f32", "float"
-            elif format.endswith("sint"):
-                type, textype = "i32", "sint"
-            elif format.endswith("uint"):
-                type, textype = "u32", "uint"
-
-            shader = mipmap_source.replace("FORMAT", format).replace("TYPE", type)
-            module = self.device.create_shader_module(code=shader)
-
-            pipeline = self.device.create_compute_pipeline(
-                layout=self._create_pipeline_layout(format, textype),
-                compute={
-                    "module": module,
-                    "entry_point": "c_main",
-                },
-            )
-
-            self.pipelines[format] = pipeline
-
-        return pipeline
-
-    def _create_pipeline_layout(self, format, textype):
-        bind_group_layouts = []
-
-        entries = []
-        entries.append(
-            {
-                "binding": 0,
-                "visibility": wgpu.ShaderStage.COMPUTE,
-                "texture": {"sample_type": textype},
-            }
-        )
-        entries.append(
-            {
-                "binding": 1,
-                "visibility": wgpu.ShaderStage.COMPUTE,
-                "storage_texture": {
-                    "access": "write-only",
-                    "view_dimension": "2d",
-                    "format": format,
-                },
-            }
-        )
-
-        bind_group_layout = self.device.create_bind_group_layout(entries=entries)
-        bind_group_layouts.append(bind_group_layout)
-        pipeline_layout = self.device.create_pipeline_layout(
-            bind_group_layouts=bind_group_layouts
-        )
-        return pipeline_layout
-
-    def generate_mipmaps(
-        self,
-        wgpu_texture: "wgpu.GPUTexture",
-        format,
-        mip_level_count,
-        base_array_layer=0,
-    ):
-        pipeline = self.get_mipmap_pipeline(format)
-
-        command_encoder: "wgpu.GPUCommandEncoder" = self.device.create_command_encoder()
-        bind_group_layout = pipeline.get_bind_group_layout(0)
-
-        dst_size = wgpu_texture.size[:2]
-        src_view = wgpu_texture.create_view(
-            base_mip_level=0,
-            mip_level_count=1,
-            dimension="2d",
-            base_array_layer=base_array_layer,
-        )
-
-        for i in range(1, mip_level_count):
-            dst_size = dst_size[0] // 2, dst_size[1] // 2
-
-            dst_view = wgpu_texture.create_view(
-                base_mip_level=i,
-                mip_level_count=1,
-                dimension="2d",
-                base_array_layer=base_array_layer,
-            )
-
-            pass_encoder = command_encoder.begin_compute_pass()
-
-            bind_group = self.device.create_bind_group(
-                layout=bind_group_layout,
-                entries=[
-                    {"binding": 0, "resource": src_view},
-                    {"binding": 1, "resource": dst_view},
-                ],
-            )
-
-            pass_encoder.set_pipeline(pipeline)
-            pass_encoder.set_bind_group(0, bind_group, [], 0, 99)
-            pass_encoder.dispatch_workgroups(dst_size[0], dst_size[1])
-            pass_encoder.end()
-
-            src_view = dst_view
-
-        self.device.queue.submit([command_encoder.finish()])
-
-
-_the_mipmap_util = None
+def get_mip_level_count(texture):
+    """Get the number of mipmap levels from the texture size."""
+    assert isinstance(texture, Texture)
+    width, height, _ = texture.size
+    return math.floor(math.log2(max(width, height))) + 1
 
 
 def generate_texture_mipmaps(device, target):
+    """Generate mipmaps for the given target. The target can be a
+    Texture or GfxTextureView and can be a 2D texture as well as a cube
+    texture.
+    """
+
     # If this looks like a cube or stack, generate mipmaps for each individual layer
     if isinstance(target, Texture) and target.dim == 2 and target.size[2] > 1:
         for i in range(target.size[2]):
@@ -183,26 +78,123 @@ def generate_texture_mipmaps(device, target):
             )
         return
 
-    # Get the util
-    global _the_mipmap_util
-    if not _the_mipmap_util:
-        _the_mipmap_util = MipmapsUtil(device)
-
     if isinstance(target, Texture):
         texture = target
-        wgpu_texture = texture._wgpu_object
         layer = 0
     elif isinstance(target, GfxTextureView):
         view, texture = target, target.texture
-        wgpu_texture = texture._wgpu_object
         layer = view.layer_range[0]
 
-    _the_mipmap_util.generate_mipmaps(
-        wgpu_texture, wgpu_texture.format, texture._wgpu_mip_level_count, layer
+    generate_mipmaps(device, texture, layer)
+
+
+def generate_mipmaps(device, texture, base_array_layer):
+    pipeline = get_mipmap_pipeline(device, texture)
+
+    command_encoder: "wgpu.GPUCommandEncoder" = device.create_command_encoder()
+    bind_group_layout = pipeline.get_bind_group_layout(0)
+
+    dst_size = texture.size[:2]
+    src_view = texture._wgpu_object.create_view(
+        base_mip_level=0,
+        mip_level_count=1,
+        dimension="2d",
+        base_array_layer=base_array_layer,
     )
 
+    for i in range(1, texture._wgpu_mip_level_count):
+        dst_size = dst_size[0] // 2, dst_size[1] // 2
 
-def get_mip_level_count(texture):
-    assert isinstance(texture, Texture)
-    width, height, _ = texture.size
-    return math.floor(math.log2(max(width, height))) + 1
+        dst_view = texture._wgpu_object.create_view(
+            base_mip_level=i,
+            mip_level_count=1,
+            dimension="2d",
+            base_array_layer=base_array_layer,
+        )
+
+        pass_encoder = command_encoder.begin_compute_pass()
+
+        bind_group = device.create_bind_group(
+            layout=bind_group_layout,
+            entries=[
+                {"binding": 0, "resource": src_view},
+                {"binding": 1, "resource": dst_view},
+            ],
+        )
+
+        pass_encoder.set_pipeline(pipeline)
+        pass_encoder.set_bind_group(0, bind_group, [], 0, 99)
+        pass_encoder.dispatch_workgroups(dst_size[0], dst_size[1])
+        pass_encoder.end()
+
+        src_view = dst_view
+
+    device.queue.submit([command_encoder.finish()])
+
+
+def get_mipmap_pipeline(device, texture):
+    format = texture._wgpu_object.format
+    pipeline = MIPMAP_CACHE.get(format)
+
+    if pipeline is None:
+        if format.endswith("srgb"):
+            raise RuntimeError("Cannot create mipmaps for srgb textures.")
+
+        type, textype = "f32", "float"
+        if format.endswith(("norm", "float")):
+            type, textype = "f32", "float"
+        elif format.endswith("sint"):
+            type, textype = "i32", "sint"
+        elif format.endswith("uint"):
+            type, textype = "u32", "uint"
+
+        shader = mipmap_source.replace("FORMAT", format).replace("TYPE", type)
+        module = device.create_shader_module(code=shader)
+
+        pipeline = device.create_compute_pipeline(
+            layout=create_pipeline_layout(device, format, textype),
+            compute={
+                "module": module,
+                "entry_point": "c_main",
+            },
+        )
+
+        MIPMAP_CACHE.set(format, pipeline)
+
+    # Strore a ref of the pipeline, the cache uses weak refs.
+    # I.e. the pipeline for this format is in the cache for as long as
+    # any textures that use it are alive.
+    texture._wgpu_mipmap_pipeline = pipeline
+
+    return pipeline
+
+
+def create_pipeline_layout(device, format, textype):
+    bind_group_layouts = []
+
+    entries = []
+    entries.append(
+        {
+            "binding": 0,
+            "visibility": wgpu.ShaderStage.COMPUTE,
+            "texture": {"sample_type": textype},
+        }
+    )
+    entries.append(
+        {
+            "binding": 1,
+            "visibility": wgpu.ShaderStage.COMPUTE,
+            "storage_texture": {
+                "access": "write-only",
+                "view_dimension": "2d",
+                "format": format,
+            },
+        }
+    )
+
+    bind_group_layout = device.create_bind_group_layout(entries=entries)
+    bind_group_layouts.append(bind_group_layout)
+    pipeline_layout = device.create_pipeline_layout(
+        bind_group_layouts=bind_group_layouts
+    )
+    return pipeline_layout

--- a/pygfx/renderers/wgpu/_shared.py
+++ b/pygfx/renderers/wgpu/_shared.py
@@ -8,6 +8,7 @@ from ...resources import Buffer
 from ...utils.trackable import Trackable
 from ...utils import array_from_shadertype
 from ...utils.text import glyph_atlas
+from ._utils import GpuCache
 
 
 # Definition uniform struct with standard info related to transforms,
@@ -128,10 +129,10 @@ def print_wgpu_report():
 
     if adapter and device:
         print()
-        print("FEATURES:".ljust(50), "adapter".rjust(8), "device".rjust(8))
+        print("FEATURES:".ljust(50), "adapter".rjust(10), "device".rjust(10))
         for key in adapter.features:
             device_has_it = "Y" if key in device.features else "-"
-            print(f"{key}:".rjust(50), "Y".rjust(8), device_has_it.rjust(8))
+            print(f"{key}:".rjust(50), "Y".rjust(10), device_has_it.rjust(10))
 
     if adapter and device:
         print()
@@ -140,6 +141,15 @@ def print_wgpu_report():
             val1 = adapter.limits[key]
             val2 = device.limits.get(key, "-")
             print(f"{key}:".rjust(50), str(val1).rjust(10), str(val2).rjust(10))
+
+    if shared:
+        print()
+        print("CACHES:".ljust(50), "count".rjust(10))
+        for cache_name, count in GpuCache.get_cache_stats().items():
+            print(
+                f"{cache_name}:".rjust(50),
+                str(count).rjust(10),
+            )
 
     print()
     wgpu.print_report()

--- a/pygfx/renderers/wgpu/_utils.py
+++ b/pygfx/renderers/wgpu/_utils.py
@@ -216,15 +216,15 @@ class GpuCache:
         """Get the number of (alive) objects in the cache."""
         return len(list(self._objects.values()))
 
-    def get(self, hash):
+    def get(self, key):
         """Get the cached object or None."""
-        return self._objects.get(hash, None)
+        return self._objects.get(key, None)
 
-    def set(self, hash, ob):
-        """Store the given object under the given hash.
+    def set(self, key, ob):
+        """Store the given object under the given key.
         Note that the cache does not have a (strong) ref to the object.
         """
-        self._objects[hash] = ob
+        self._objects[key] = ob
 
 
 class GfxSampler:

--- a/pygfx/renderers/wgpu/_utils.py
+++ b/pygfx/renderers/wgpu/_utils.py
@@ -202,6 +202,7 @@ class GpuCache:
 
     @classmethod
     def get_cache_stats(cls):
+        """Get a dict mapping cache names to item counts."""
         return {name: cache.get_count() for name, cache in GpuCache._caches.items()}
 
     def __init__(self, name):


### PR DESCRIPTION
See #322 

This PR introduces a new GPUCache class, intended for use within the `renderers.wgpu` subpackage. The cache uses weakrefs, so the objects being cached should still be stored somehow, e.g. by attaching them to an world object or Buffer.

The stats of all caches can also be obtained. The `gfx.print_wgpu_report()` function uses it to now also print cache stats!

In this PR I only apply the new cache to the mipmap code. I plan to adopt it in other places in new PR's. Because of the new cache, the MipmapUtil class become absolete, falling apart into a few functions, which I also reordered for readability. Other than that, the mipmap util should not have any logical changes to the code.

While searching the code-base for "cache" I found same comments which I tweaked in a few cases.
