### PR TITLE
Tweak resource update code a bit

### DIFF
--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -22,7 +22,8 @@ from ...objects import (
     WorldObject,
 )
 from ...cameras import Camera
-from ...resources import Texture, registry as resource_registry
+from ...resources import Texture
+from ...resources._base import resource_update_registry
 from ...utils import Color
 
 from . import _blender as blender_module
@@ -503,7 +504,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
             render_pipeline_containers.extend(container_group.render_containers)
 
         # Update *all* buffers and textures that have changed
-        for resource in resource_registry.get_syncable_resources(flush=True):
+        for resource in resource_update_registry.get_syncable_resources(flush=True):
             update_resource(self.device, resource)
 
         # Command buffers cannot be reused. If we want some sort of re-use we should

--- a/pygfx/renderers/wgpu/_shared.py
+++ b/pygfx/renderers/wgpu/_shared.py
@@ -4,7 +4,7 @@ A global object shared by all renderers.
 
 import wgpu
 
-from ...resources import Buffer
+from ...resources import Resource, Buffer
 from ...utils.trackable import Trackable
 from ...utils import array_from_shadertype
 from ...utils.text import glyph_atlas
@@ -148,6 +148,15 @@ def print_wgpu_report():
         for cache_name, count in GpuCache.get_cache_stats().items():
             print(
                 f"{cache_name}:".rjust(50),
+                str(count).rjust(10),
+            )
+
+    if shared:
+        print()
+        print("RESOURCES:".ljust(50), "count".rjust(10))
+        for name, count in Resource._resource_counts.items():
+            print(
+                f"{name}:".rjust(50),
                 str(count).rjust(10),
             )
 

--- a/pygfx/resources/__init__.py
+++ b/pygfx/resources/__init__.py
@@ -17,7 +17,7 @@ In pygfx, data is stored in buffers and textures. We collectively call these res
 
 # flake8: noqa
 
-from ._base import Resource, registry  # registry stays in this namespace
+from ._base import Resource
 from ._buffer import Buffer
 from ._texture import Texture
 


### PR DESCRIPTION
An addendum to #508. I think the purpose of the registry class was too broad. This makes it leaner. Tracking how many buffers and textures exist is still useful, but that can be handled more gracefully. 

TODO:
* [x] Make `gfx.print_wgpu_report()` print the number of existing buffers and textures. Let's wait for #516 to avoid merge conflicts.