### PR TITLE
Remove pyinstaller workaround for freetype

### DIFF
--- a/pygfx/__pyinstaller/hook-pygfx.py
+++ b/pygfx/__pyinstaller/hook-pygfx.py
@@ -1,9 +1,5 @@
-from PyInstaller.utils.hooks import collect_data_files, collect_dynamic_libs
+from PyInstaller.utils.hooks import collect_data_files
 
-
-# until https://github.com/rougier/freetype-py/pull/162/files is released
-# we ensure the freetype binaries are included here
-binaries = collect_dynamic_libs("freetype")
 
 hiddenimports = ["pygfx.data_files"]
 datas = collect_data_files("pygfx.data_files")


### PR DESCRIPTION
Closes #522

https://github.com/rougier/freetype-py/pull/162 was merged and released in freetype v2.4.0:

https://github.com/rougier/freetype-py/releases/tag/v2.4.0