### PR TITLE
Implement hashing for renderer, blender, flusher

### DIFF
--- a/examples/other/two_canvases.py
+++ b/examples/other/two_canvases.py
@@ -8,6 +8,7 @@ Example demonstrating rendering the same scene into two different canvases.
 import numpy as np
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
+import pylinalg as la
 
 
 # Create two canvases and two renderers
@@ -37,7 +38,7 @@ line = gfx.Line(geometry2, material2)
 scene.add(line)
 
 camera = gfx.PerspectiveCamera(70, 16 / 9)
-camera.position.z = 400
+camera.local.z = 400
 
 scene.add(camera.add(gfx.DirectionalLight()))
 
@@ -45,8 +46,8 @@ scene.add(camera.add(gfx.DirectionalLight()))
 
 
 def animate_a():
-    rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.005, 0.01))
-    cube.rotation.multiply(rot)
+    rot = la.quat_from_euler((0.005, 0.01), order="XY")
+    cube.local.rotation = la.quat_mul(rot, cube.local.rotation)
     renderer_a.render(scene, camera)
     canvas_a.request_draw()
 

--- a/pygfx/renderers/wgpu/_blender.py
+++ b/pygfx/renderers/wgpu/_blender.py
@@ -494,12 +494,12 @@ class BaseFragmentBlender:
 
         # Recreate internal textures
         for name, (format, usage) in self._texture_info.items():
-            texture = device.create_texture(
+            wgpu_texture = device.create_texture(
                 size=tex_size, usage=usage, dimension="2d", format=format
             )
             setattr(self, name + "_format", format)
-            setattr(self, name + "_tex", texture)
-            setattr(self, name + "_view", texture.create_view())
+            setattr(self, name + "_tex", wgpu_texture)
+            setattr(self, name + "_view", wgpu_texture.create_view())
 
     # The five methods below represent the API that the render system uses.
 

--- a/pygfx/renderers/wgpu/_flusher.py
+++ b/pygfx/renderers/wgpu/_flusher.py
@@ -187,23 +187,21 @@ class RenderFlusher:
             sigma = 0.5
             support = 2
 
+        # Compose
         self._uniform_data["size"] = src_color_tex.size[:2]
         self._uniform_data["sigma"] = sigma
         self._uniform_data["support"] = support
         self._uniform_data["gamma"] = gamma
 
+        # Sync to gpu
+        self._device.queue.write_buffer(
+            self._uniform_buffer, 0, self._uniform_data, 0, self._uniform_data.nbytes
+        )
+
     def _render(self, render_pipeline, bind_group, dst_color_tex):
         device = self._device
 
         command_encoder = device.create_command_encoder()
-
-        tmp_buffer = device.create_buffer_with_data(
-            data=self._uniform_data,
-            usage=wgpu.BufferUsage.COPY_SRC,
-        )
-        command_encoder.copy_buffer_to_buffer(
-            tmp_buffer, 0, self._uniform_buffer, 0, self._uniform_data.nbytes
-        )
 
         render_pass = command_encoder.begin_render_pass(
             color_attachments=[

--- a/pygfx/renderers/wgpu/_mipmapsutil.py
+++ b/pygfx/renderers/wgpu/_mipmapsutil.py
@@ -4,7 +4,7 @@ from ...resources._texture import Texture
 from ._utils import GfxTextureView, GpuCache
 
 
-# This cache enable re-using gpu pipelines for calculating mipmaps, so
+# This cache enables re-using gpu pipelines for calculating mipmaps, so
 # that these don't have to be created on each draw, which would make
 # things very slow. The number of pipelines in the cache won't be large
 # since there are only so many texture formats, but it seems cleaner

--- a/pygfx/renderers/wgpu/_pipeline.py
+++ b/pygfx/renderers/wgpu/_pipeline.py
@@ -744,7 +744,10 @@ class RenderPipelineContainer(PipelineContainer):
 
         pipeline_layout = get_cached_pipeline_layout(device, bind_group_layouts)
 
-        # Instantiate the pipeline objects
+        # Instantiate the pipeline objects.
+        # Note: The pipeline relies on the color and depth descriptors, which
+        # include the texture format and a few other static things.
+        # This step should *not* rerun when e.g. the canvas resizes.
         pipelines = {}
         blender = env.blender
         for pass_index in range(blender.get_pass_count()):

--- a/pygfx/renderers/wgpu/_shadowutil.py
+++ b/pygfx/renderers/wgpu/_shadowutil.py
@@ -5,7 +5,7 @@ from ._utils import to_vertex_format, GpuCache
 from ... import objects
 
 
-# This cache enable re-using gpu pipelines for calculating shadows,
+# This cache enables re-using gpu pipelines for calculating shadows,
 # these can be shared between multiple world-objects that have a
 # positions buffer with a matching stride and format.
 SHADOW_CACHE = GpuCache("shadow_pipelines")


### PR DESCRIPTION
Relates to  #322

* [x] Checked for needs of caching in `renderer.py` - I don't see any :)
* [x] Refactor `_create_full_quad_pipeline` in `flusher.py`, to use the new GpuCache. I also moved the creation of the bind_group out, because that one requires much more re-creations than the pipeline. 
* [x] Review caching in `blender.py`, it makes use of `_create_full_quad_pipeline` so it has updates to the new usage.
* [x] Found one more case where `pyfx.linalg` was used.  