### PR TITLE
Show line caps on line segments separated by nan

### DIFF
--- a/examples/feature_demo/line_basic.py
+++ b/examples/feature_demo/line_basic.py
@@ -19,7 +19,9 @@ renderer_svg = gfx.SvgRenderer(640, 480, "~/line.svg")
 
 scene = gfx.Scene()
 positions = [[200 + np.sin(i) * i * 6, 200 + np.cos(i) * i * 6, 0] for i in range(20)]
+positions += [[np.nan, np.nan, np.nan]]
 positions += [[400 - np.sin(i) * i * 6, 200 + np.cos(i) * i * 6, 0] for i in range(20)]
+positions += [[np.nan, np.nan, np.nan]]
 positions += [
     [450, 400, 0],
     [375, 400, 0],

--- a/pygfx/renderers/wgpu/lineshader.py
+++ b/pygfx/renderers/wgpu/lineshader.py
@@ -191,6 +191,10 @@ class LineShader(WorldObjectShader):
             let world_pos = u_wobject.world_transform * vec4<f32>(raw_pos.xyz, 1.0);
             return u_stdinfo.projection_transform * u_stdinfo.cam_transform * world_pos;
         }
+
+        fn is_nan(v:f32) -> bool {
+            return !(0.0 < v) && !(0.0 > v);
+        }
         """
 
     def code_vertex(self):
@@ -320,7 +324,9 @@ class LineShader(WorldObjectShader):
             var nd: vec2<f32>;
             var ne: vec2<f32>;
 
-            if (i == 0) {
+            let prev = load_s_positions(i - 1);
+
+            if ( i == 0 || is_nan(npos1[1]) ) {
                 // This is the first point on the line: create a cap.
                 v1 = v2;
                 nc = normalize(vec2<f32>(v2.y, -v2.x));
@@ -328,7 +334,7 @@ class LineShader(WorldObjectShader):
                 na = nd;
                 nb = nd - normalize(v2);
                 ne = nc - normalize(v2);
-            } else if (i == u_renderer.last_i) {
+            } else if ( i == u_renderer.last_i || is_nan(npos3[1]) )  {
                 // This is the last point on the line: create a cap.
                 v2 = v1;
                 na = normalize(vec2<f32>(v1.y, -v1.x));

--- a/pygfx/renderers/wgpu/lineshader.py
+++ b/pygfx/renderers/wgpu/lineshader.py
@@ -192,8 +192,16 @@ class LineShader(WorldObjectShader):
             return u_stdinfo.projection_transform * u_stdinfo.cam_transform * world_pos;
         }
 
-        fn is_nan(v:f32) -> bool {
-            return !(0.0 < v) && !(0.0 > v);
+        fn is_nan_or_zero(v:f32) -> bool {
+            // Naga has removed isNan checks, because backends may be using fast-math,
+            // in which case nan is assumed not to happen, and isNan would always be false.
+            // If we assume that some nan mechanics still work, we can still detect it.
+            // This won't work however: `return v != v`, because the compiler will
+            // optimize it out. The same holds for similar constructs.
+            // Maybe the same happens if we turn `<`  into `<=`.
+            // So we and up with an equation that detects either NaN or zero,
+            // which is fine if we use it on a .w attribute.
+            return !(v < 0.0) && !(v > 0.0);
         }
         """
 
@@ -326,7 +334,7 @@ class LineShader(WorldObjectShader):
 
             let prev = load_s_positions(i - 1);
 
-            if ( i == 0 || is_nan(npos1[1]) ) {
+            if ( i == 0 || is_nan_or_zero(npos1.w) ) {
                 // This is the first point on the line: create a cap.
                 v1 = v2;
                 nc = normalize(vec2<f32>(v2.y, -v2.x));
@@ -334,7 +342,7 @@ class LineShader(WorldObjectShader):
                 na = nd;
                 nb = nd - normalize(v2);
                 ne = nc - normalize(v2);
-            } else if ( i == u_renderer.last_i || is_nan(npos3[1]) )  {
+            } else if ( i == u_renderer.last_i || is_nan_or_zero(npos3.w) )  {
                 // This is the last point on the line: create a cap.
                 v2 = v1;
                 na = normalize(vec2<f32>(v1.y, -v1.x));


### PR DESCRIPTION
A convenient feature of lines is that one can introduce a nan-point to separate two line segments. This feature is also supported by e.g. matplotlib. This just happened to work for our current line shader 😄. This PR also adds caps to these loose line endings.

Implementation note: apparently wgsl has dropped `isNan` and co. The `isFinite` still exists, but it has been removed from Naga januari this year, which is why I rolled our own little `is_nan()`. See e.g. https://github.com/gpuweb/gpuweb/pull/2311.