### PR TITLE
Fix that the polyhedron indices array was 3 times too long

### DIFF
--- a/pygfx/geometries/_polyhedron.py
+++ b/pygfx/geometries/_polyhedron.py
@@ -373,7 +373,7 @@ def polyhedron_geometry(
     faces *= radius
 
     # technically if meshmaterial didn't require an index buffer we could leave this out
-    indices = np.arange(positions.size, dtype=np.int32).reshape(-1, 3)
+    indices = np.arange(positions.shape[0], dtype=np.int32).reshape(-1, 3)
 
     return Geometry(
         indices=indices,

--- a/tests/geometries/test_polyhedron.py
+++ b/tests/geometries/test_polyhedron.py
@@ -26,8 +26,9 @@ def test_polyhedrons():
         assert g.indices.data.dtype == np.int32
         assert g.positions.data.shape == (nr_faces * 3, 3)
         assert g.positions.data.shape == g.normals.data.shape
-        assert g.positions.data.shape == g.indices.data.shape
         assert g.positions.data.shape[:-1] + (2,) == g.texcoords.data.shape
+        assert g.indices.data.size == g.positions.data.shape[0]
+        assert g.indices.data.size == len(set(g.indices.data.flat))
         assert np.allclose(np.linalg.norm(g.positions.data, axis=-1), 1)
 
 


### PR DESCRIPTION
Detected while working on unit tests for the morph-tool-logic that validates the mesh 🥳 