### PR TITLE
fix image plus points example, flip camera call

### DIFF
--- a/examples/feature_demo/image_plus_points.py
+++ b/examples/feature_demo/image_plus_points.py
@@ -37,8 +37,8 @@ points = gfx.Points(
 scene.add(points)
 
 camera = gfx.PerspectiveCamera(0)
-camera.local.scale_y = -1
 camera.show_rect(-10, 522, -10, 522)
+camera.local.scale_y = -1
 
 controller = gfx.PanZoomController(camera, register_events=renderer)
 


### PR DESCRIPTION
`camera.local.scale_y = 1` has to be called after `camera.show_rect()`, I guess it changed during the #482 
