### PR TITLE
Enable picking of transparent pixels

### DIFF
--- a/examples/feature_demo/picking_mesh.py
+++ b/examples/feature_demo/picking_mesh.py
@@ -4,6 +4,10 @@ Mesh Picking
 
 Example showing picking a mesh. Showing two meshes that can be clicked
 on. Upon clicking, the vertex closest to the pick location is moved.
+
+One of the shown objects is semi-transparent. In order for picking to
+work on such objects, the ``renderer.blend_mode`` must be set to
+"weighted_plus".
 """
 # sphinx_gallery_pygfx_render = True
 
@@ -18,14 +22,16 @@ import pylinalg as la
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
+renderer.blend_mode = "weighted_plus"
 scene = gfx.Scene()
 
 im = iio.imread("imageio:astronaut.png").astype(np.float32) / 255
 tex = gfx.Texture(im, dim=2)
 
-geometry = gfx.box_geometry(200, 200, 200)
-material = gfx.MeshBasicMaterial(map=tex)
-cube = gfx.Mesh(geometry, material)
+cube = gfx.Mesh(
+    gfx.box_geometry(200, 200, 200),
+    gfx.MeshBasicMaterial(map=tex, opacity=0.8),
+)
 cube.local.x += 150
 scene.add(cube)
 

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -582,6 +582,8 @@ class WgpuRenderer(RootEventHandler, Renderer):
 
         command_encoder = self._device.create_command_encoder()
         blender = self._blender
+        if clear_color:
+            blender.clear()
 
         # ----- compute pipelines
 
@@ -603,7 +605,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
         render_shadow_maps(lights, wobject_list, command_encoder)
 
         for pass_index in range(blender.get_pass_count()):
-            color_attachments = blender.get_color_attachments(pass_index, clear_color)
+            color_attachments = blender.get_color_attachments(pass_index)
             depth_attachment = blender.get_depth_attachment(pass_index)
             render_mask = blender.passes[pass_index].render_mask
             if not color_attachments:


### PR DESCRIPTION
Relates to discussions in #474. Also takes #492 and #491 into consideration.

* [x] The render pass in `blender.py` can decide whether to be pickable, independent on the render mask (previously it enabled picking only when the render mask indicated that it rendered opaque fragments).
* [x] Refactored the mechanism to clear buffers, so multiple passes using the same buffers behave better. Also for the depth buffer, which is a small step towards #474.
* [x] The front-most transparency pass allows picking.

This means that to enable picking of transparent fragments, one needs to:
* Use `renderer.blend_mode = "weighted_plus"`.
* Make sure the alpha value is nonzero, because such fragments are dropped. So you cannot make completely invisible fragments, but you can uses an alpha of 0.001 or so. (Note that to accommodate for roundoff errors, there is a small margin of 1e-6.)

The motivation for refactoring the clearing of the depth buffers is that it allows doing the front-most transparency pass last. If you'd do it first (as before this pr), if you click a transparent fragment, and there is an opaque fragment behind it, you'd click the opaque one.
