### PR TITLE
Don't build pipelines that wont be used

### DIFF
--- a/examples/feature_demo/picking_mesh.py
+++ b/examples/feature_demo/picking_mesh.py
@@ -25,6 +25,8 @@ renderer = gfx.renderers.WgpuRenderer(canvas)
 renderer.blend_mode = "weighted_plus"
 scene = gfx.Scene()
 
+scene.add(gfx.Background(None, gfx.BackgroundMaterial("#446")))
+
 im = iio.imread("imageio:astronaut.png").astype(np.float32) / 255
 tex = gfx.Texture(im, dim=2)
 

--- a/pygfx/renderers/wgpu/_pipeline.py
+++ b/pygfx/renderers/wgpu/_pipeline.py
@@ -712,9 +712,14 @@ class RenderPipelineContainer(PipelineContainer):
         (one for each pass of the blender).
         """
         blender = env.blender
+        render_mask = self.render_info["render_mask"]
 
         shader_modules = {}
         for pass_index in range(blender.get_pass_count()):
+            # No need to compile pass for transparent fragments if the object has none
+            if not render_mask & blender.passes[pass_index].render_mask:
+                continue
+
             color_descriptors = blender.get_color_descriptors(pass_index)
             if not color_descriptors:
                 continue
@@ -740,6 +745,7 @@ class RenderPipelineContainer(PipelineContainer):
         strip_index_format = self.strip_index_format
         primitive_topology = self.pipeline_info["primitive_topology"]
         cull_mode = self.pipeline_info["cull_mode"]
+        render_mask = self.render_info["render_mask"]
 
         # Create pipeline layout object from list of layouts
         env_bind_group_layout, _ = env.wgpu_bind_group
@@ -754,6 +760,10 @@ class RenderPipelineContainer(PipelineContainer):
         pipelines = {}
         blender = env.blender
         for pass_index in range(blender.get_pass_count()):
+            # No need to compose pass for transparent fragments if the object has none
+            if not render_mask & blender.passes[pass_index].render_mask:
+                continue
+
             color_descriptors = blender.get_color_descriptors(pass_index)
             depth_descriptor = blender.get_depth_descriptor(pass_index)
             if not color_descriptors:


### PR DESCRIPTION
We were building a pipeline object for each pass, even if we know (from the render_mask) that  some won't be used. This was a problem for the background material, which' shader appliers a trick (or hack, if you like) to draw even transparent fragments in the opaque pass (backgrounds are allowed to do that). However, the resulting shader is invalid for the transparent passes in *weighted* and *weighted_plus* blend modes. Apparently backgrounds never worked with those 🤷.

Apart from that, this change also saves some build time, and memory for gpu objects.