### PR TITLE
Fix bounding box

### DIFF
--- a/examples/feature_demo/world_bounding_box.py
+++ b/examples/feature_demo/world_bounding_box.py
@@ -34,7 +34,7 @@ camera = gfx.PerspectiveCamera(70, 16 / 9)
 camera.show_object(scene, view_dir=(-1, -1, -1), up=(0, 0, 1))
 controller = gfx.OrbitController(camera, register_events=renderer)
 
-print("World bounding box:", scene.get_world_bounding_box())
+print("World bounding box:\n", scene.get_world_bounding_box())
 
 
 def animate():

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -388,7 +388,7 @@ class PerspectiveCamera(Camera):
 
         # Do the math ...
         view_pos = bsphere[:3]
-        radius = bsphere[3]
+        radius = max(0.0, bsphere[3]) or 1.0
         extent = radius * 2 * scale
         distance = fov_distance_factor(self.fov) * extent
 

--- a/pygfx/geometries/_base.py
+++ b/pygfx/geometries/_base.py
@@ -98,7 +98,7 @@ class Geometry(Trackable):
         x.extend(dict.keys(self._store))
         return x
 
-    def bounding_box(self):
+    def get_bounding_box(self):
         """Compute the axis-aligned bounding box.
 
         Computes the aabb based on either positions or the shape of the grid
@@ -107,23 +107,35 @@ class Geometry(Trackable):
 
         Returns
         -------
-        aabb : ndarray, [2, 3]
+        aabb : ndarray, [2, 3] or None
             The axis-aligned bounding box given by the "smallest" (lowest value)
-            and "largest" (highest value) corners.
+            and "largest" (highest value) corners. Is None when the geometry has
+            no finite positions.
 
         """
         if hasattr(self, "positions"):
             if self._aabb_rev == self.positions.rev:
                 return self._aabb
+            aabb = None
+            # Get positions and check expected shape
             pos = self.positions.data
-            self._aabb = np.array([np.nanmin(pos, axis=0), np.nanmax(pos, axis=0)])
-            # If positions contains xy, but not z, assume z=0
-            if self._aabb.shape[1] == 2:
-                self._aabb = np.column_stack([self._aabb, np.zeros((2, 1), np.float32)])
+            if pos.ndim == 2 and pos.shape[1] in (2, 3):
+                # Select finite positions
+                finite_mask = np.isfinite(pos).all(axis=1)
+                if finite_mask.sum() > 0:
+                    # Construct aabb
+                    pos_finite = pos[finite_mask]
+                    aabb = np.array(
+                        [pos_finite.min(axis=0), pos_finite.max(axis=0)], np.float32
+                    )
+                    # If positions contains xy, but not z, assume z=0
+                    if aabb.shape[1] == 2:
+                        aabb = np.column_stack([aabb, np.zeros((2, 1), np.float32)])
+            self._aabb = aabb
             self._aabb_rev = self.positions.rev
             return self._aabb
 
-        if hasattr(self, "grid"):
+        elif hasattr(self, "grid"):
             if self._aabb_rev == self.grid.rev:
                 return self._aabb
             # account for multi-channel image data
@@ -141,12 +153,10 @@ class Geometry(Trackable):
             self._aabb = aabb
             self._aabb_rev = self.grid.rev
             return self._aabb
+        else:
+            return None
 
-        raise ValueError(
-            "No positions or grid buffer available for bounding volume computation"
-        )
-
-    def bounding_sphere(self):
+    def get_bounding_sphere(self):
         """Compute a bounding sphere.
 
         Uses the geometry's axis-aligned bounding box, to estimate a sphere
@@ -154,8 +164,9 @@ class Geometry(Trackable):
 
         Returns
         -------
-        sphere : ndarray, [4]
+        sphere : ndarray, [4] or None
             A sphere given by it's center and radius. Format: ``(x, y, z, radius)``.
+            Is None when the geometry has no finite positions.
 
         Notes
         -----
@@ -163,9 +174,10 @@ class Geometry(Trackable):
         be the minimally binding sphere.
 
         """
-        if self._bsphere is not None and self._bsphere_rev == self._aabb_rev:
+        if self._bsphere_rev == self._aabb_rev:
             return self._bsphere
 
-        self._bsphere = la.aabb_to_sphere(self.bounding_box())
+        aabb = self.get_bounding_box()
+        self._bsphere = None if aabb is None else la.aabb_to_sphere(aabb)
         self._bsphere_rev = self._aabb_rev
         return self._bsphere

--- a/pygfx/geometries/_text.py
+++ b/pygfx/geometries/_text.py
@@ -549,15 +549,20 @@ class TextGeometry(Geometry):
 
     # %%%%% Layout
 
-    def bounding_box(self):
+    def get_bounding_box(self):
         if self.screen_space:
-            # The space occupied by the text is essentially a point
+            # There is no sensible bounding box for text in screen
+            # space, except for the anchor point. Although the point
+            # has no volume, it does contribute to e.g. the scene's
+            # bounding box.
             return np.array([[0, 0, 0], [0, 0, 0]], np.float32)
         else:
             if self._aabb_rev == self.positions.rev:
                 return self._aabb
             pos = self.positions.data
-            aabb_2d = np.array([pos.min(axis=0), pos.max(axis=0)], np.float32)
+            aabb_2d = np.array(
+                [np.nanmin(pos, axis=0), np.nanmax(pos, axis=0)], np.float32
+            )
             self._aabb[1, 0] += self.font_size  # positions do not include char width
             self._aabb = np.column_stack([aabb_2d, np.zeros((2, 1), np.float32)])
             self._aabb_rev = self.positions.rev

--- a/pygfx/helpers/_box.py
+++ b/pygfx/helpers/_box.py
@@ -137,7 +137,7 @@ class BoxHelper(Line):
         if space == "world":
             aabb = object.get_world_bounding_box()
         elif space == "local" and object.geometry is not None:
-            aabb = object.geometry.bounding_box()
+            aabb = object.geometry.get_bounding_box()
         if aabb is None:
             raise ValueError(
                 "No bounding box could be determined "

--- a/pygfx/helpers/_gizmo.py
+++ b/pygfx/helpers/_gizmo.py
@@ -288,7 +288,7 @@ class TransformGizmo(WorldObject):
 
         # work out local extent
         self._local_extents = np.empty((6, 3), dtype=float)
-        scales = self.get_bounding_box().ravel()
+        scales = self.get_bounding_box().ravel()  # we know our bb is not None
         self._local_extents[:3] = np.diag(scales[3:])
         self._local_extents[3:] = np.diag(scales[:3])
 

--- a/tests/cameras/test_cameras.py
+++ b/tests/cameras/test_cameras.py
@@ -200,3 +200,35 @@ def test_frustum():
     frustum_corners = camera.frustum
 
     assert np.allclose(frustum_corners, expected_corners.reshape(2, 4, 3))
+
+
+def test_repeated_show():
+    # Repeated calls to show_object should keep the same camera
+    # position. At some point it did not, because the camera contributed
+    # to the scene's bounding box, and since it's positioned away from
+    # the (rest of the) scene, repeated calles, just made the scene's
+    # bounding box bigger.
+
+    mesh = gfx.Mesh(
+        gfx.sphere_geometry(),
+        gfx.MeshPhongMaterial(),
+    )
+    camera = gfx.PerspectiveCamera()
+
+    scene = gfx.Scene()
+    scene.add(mesh, camera.add(gfx.DirectionalLight()))
+
+    camera.show_object(scene)
+
+    cam_width = camera.width
+    scene_radius = scene.get_world_bounding_sphere()[3]
+
+    # If you want to run this test interactively, you can uncommentt below lines
+    # d= gfx.Display(camera=camera)
+    # d.show(scene, )
+
+    for _ in range(9):
+        camera.show_object(scene)
+
+    assert cam_width == camera.width
+    assert scene_radius == scene.get_world_bounding_sphere()[3]

--- a/tests/geometries/test_bounding_box.py
+++ b/tests/geometries/test_bounding_box.py
@@ -1,0 +1,40 @@
+import pygfx as gfx
+import numpy as np
+
+
+def test_bounding_box():
+    pos = np.array([(0, 0, 0), (1, 1, 1), (3, 3, 3)], np.float32)
+    geo = gfx.Geometry(positions=pos)
+    assert geo.get_bounding_box().tolist() == [[0, 0, 0], [3, 3, 3]]
+
+    pos = np.array([(0, 1, 3), (3, 0, 1), (1, 3, 0)], np.float32)
+    geo = gfx.Geometry(positions=pos)
+    assert geo.get_bounding_box().tolist() == [[0, 0, 0], [3, 3, 3]]
+
+    pos = np.array([(1, 1, 1), (1, 1, 1), (1, 1, 1)], np.float32)
+    geo = gfx.Geometry(positions=pos)
+    assert geo.get_bounding_box().tolist() == [[1, 1, 1], [1, 1, 1]]
+
+    pos = np.array([(0, 1, 2), (0, 1, 2), (0, 1, 2)], np.float32)
+    geo = gfx.Geometry(positions=pos)
+    assert geo.get_bounding_box().tolist() == [[0, 1, 2], [0, 1, 2]]
+
+    pos = np.array([(0, 0, np.nan), (1, 1, 1), (2, 2, 2)], np.float32)
+    geo = gfx.Geometry(positions=pos)
+    assert geo.get_bounding_box().tolist() == [[1, 1, 1], [2, 2, 2]]
+
+    pos = np.array([(0, np.inf, 0), (1, 1, 1), (2, 2, 2)], np.float32)
+    geo = gfx.Geometry(positions=pos)
+    assert geo.get_bounding_box().tolist() == [[1, 1, 1], [2, 2, 2]]
+
+    pos = np.array([(-np.inf, 0, 0), (1, 1, 1), (2, 2, 2)], np.float32)
+    geo = gfx.Geometry(positions=pos)
+    assert geo.get_bounding_box().tolist() == [[1, 1, 1], [2, 2, 2]]
+
+    pos = np.zeros((0, 3), np.float32)
+    geo = gfx.Geometry(positions=pos)
+    assert geo.get_bounding_box() is None
+
+    pos = np.array([(-np.inf, 0, 0), (1, np.nan, 1)], np.float32)
+    geo = gfx.Geometry(positions=pos)
+    assert geo.get_bounding_box() is None

--- a/tests/geometries/test_bounding_box.py
+++ b/tests/geometries/test_bounding_box.py
@@ -1,5 +1,6 @@
 import pygfx as gfx
 import numpy as np
+import pylinalg as la
 
 
 def test_bounding_box():
@@ -38,3 +39,13 @@ def test_bounding_box():
     pos = np.array([(-np.inf, 0, 0), (1, np.nan, 1)], np.float32)
     geo = gfx.Geometry(positions=pos)
     assert geo.get_bounding_box() is None
+
+
+def test_bounding_sphere():
+    pos = np.array([(0, 0, -8), (1, 1, 1), (2, 2, 10)], np.float32)
+    geo = gfx.Geometry(positions=pos)
+    bsphere = geo.get_bounding_sphere()
+    bsphere_via_aabb = la.aabb_to_sphere(geo.get_bounding_box())
+
+    assert np.allclose(bsphere, [1, 1, 1, 12.7279])
+    assert np.allclose(bsphere_via_aabb, [1, 1, 1, 9.1104])

--- a/tests/objects/test_world_object.py
+++ b/tests/objects/test_world_object.py
@@ -330,3 +330,63 @@ def test_reference_up():
     assert np.allclose(obj1.world.reference_up, la.vec_normalize((1, 2, 3)))
     assert np.allclose(obj2.world.reference_up, (isqrt2, 0, isqrt2))
     assert np.allclose(obj3.world.reference_up, (0, 1, 0))
+
+
+def test_bounding_box():
+    scene = gfx.Group()
+
+    # Start out without a bounding box
+
+    assert scene.get_bounding_box() is None
+
+    # Add a camera, still no box
+    scene.add(gfx.PerspectiveCamera())
+    assert scene.get_bounding_box() is None
+
+    # Add a light, still no box
+    scene.add(gfx.DirectionalLight())
+    assert scene.get_bounding_box() is None
+
+    # Add a point, we've got a bbox with no volume
+    ob = gfx.Points(
+        gfx.Geometry(positions=np.array([(0, 0, 0)], np.float32)),
+        gfx.PointsMaterial,
+    )
+    scene.add(ob)
+    assert scene.get_bounding_box().tolist() == [[0, 0, 0], [0, 0, 0]]
+
+    # Add another point to get a larger bbox
+    ob = gfx.Points(
+        gfx.Geometry(positions=np.array([(0, 3, 1)], np.float32)),
+        gfx.PointsMaterial,
+    )
+    scene.add(ob)
+    assert scene.get_bounding_box().tolist() == [[0, 0, 0], [0, 3, 1]]
+
+    # Adding a point with no valid positions ... has no effect
+    ob = gfx.Points(
+        gfx.Geometry(positions=np.array([(99, np.nan, 99)], np.float32)),
+        gfx.PointsMaterial,
+    )
+    scene.add(ob)
+    assert ob.get_bounding_box() is None
+    assert ob.get_world_bounding_box() is None
+    assert scene.get_bounding_box().tolist() == [[0, 0, 0], [0, 3, 1]]
+
+    # Add a point that is transformed, to make sure that is taken into account
+    ob = gfx.Points(
+        gfx.Geometry(positions=np.array([(-1, 0, 2)], np.float32)),
+        gfx.PointsMaterial,
+    )
+    ob.local.scale = 3, 3, 3
+    ob.local.x = -2
+    scene.add(ob)
+    assert scene.get_bounding_box().tolist() == [[-5, 0, 0], [0, 3, 6]]
+
+    # Create a point with all of the above ... to make sure the own geo is taken into account
+    point_with_children = gfx.Points(
+        gfx.Geometry(positions=np.array([(9, 1, 0)], np.float32)),
+        gfx.PointsMaterial,
+    )
+    point_with_children.add(scene)
+    assert point_with_children.get_bounding_box().tolist() == [[-5, 0, 0], [9, 3, 6]]


### PR DESCRIPTION
Closes #549 

In particular, allow objects to return `None` to not participate in the bounding box.

This fixes a problem where repeated calls to `camera.show_object(scene)` (or `d.camera.show_object(d.scene)`)  caused the camera to increasingly zoom out.

This somewhat relates to #560, because when new data is added to a scene, you may want to reset the view repeatedly.