### PR TITLE
Euler and rotation matrix support on Transform

### DIFF
--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -150,9 +150,19 @@ class AffineBase:
     def _inverse_matrix(self) -> np.ndarray:
         return np.linalg.inv(self.matrix)
 
+    @property
+    def scaling_signs(self):
+        return self._scaling_signs
+
     @cached
     def _decomposed(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        return la.mat_decompose(self.matrix, scaling_signs=self._scaling_signs)
+        try:
+            return la.mat_decompose(self.matrix, scaling_signs=self.scaling_signs)
+        except ValueError:
+            # the matrix has been set manually
+            # and so there is no scaling component to preserve
+            # any decomposed scaling is acceptable
+            return la.mat_decompose(self.matrix)
 
     @cached
     def _directions(self):
@@ -663,5 +673,5 @@ class RecursiveTransform(AffineBase):
             return np.asarray(self) @ other
 
     @cached
-    def _decomposed(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-        return la.mat_decompose(self.matrix)
+    def scaling_signs(self):
+        return self._parent.scaling_signs * self.own.scaling_signs

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -179,6 +179,14 @@ class AffineBase:
     def _direction_components(self):
         return (*self._directions,)
 
+    @cached
+    def _rotation_matrix(self):
+        return la.mat_from_quat(self._decomposed[1])
+
+    @cached
+    def _euler(self):
+        return la.quat_to_euler(self._decomposed[1])
+
     def flag_update(self):
         """Signal that this transform has updated."""
         for callback in self.update_callbacks.values():
@@ -240,8 +248,33 @@ class AffineBase:
 
     @property
     def rotation(self) -> np.ndarray:
-        """The orientation of source."""
+        """The orientation of source as a quaternion."""
         return self._decomposed[1]
+
+    @property
+    def rotation_matrix(self) -> np.ndarray:
+        """The orientation of source as a rotation matrix."""
+        return self._rotation_matrix
+
+    @property
+    def euler(self) -> np.ndarray:
+        """The orientation of source as XYZ euler angles."""
+        return self._euler
+
+    @property
+    def euler_x(self) -> float:
+        """The X component of source's orientation as XYZ euler angles."""
+        return self._euler[0]
+
+    @property
+    def euler_y(self) -> float:
+        """The Y component of source's orientation as XYZ euler angles."""
+        return self._euler[1]
+
+    @property
+    def euler_z(self) -> float:
+        """The Z component of source's orientation as XYZ euler angles."""
+        return self._euler[2]
 
     @property
     def scale(self) -> np.ndarray:
@@ -305,6 +338,26 @@ class AffineBase:
     @rotation.setter
     def rotation(self, value):
         self.matrix = la.mat_compose(self.position, value, self.scale)
+
+    @euler.setter
+    def euler(self, value):
+        self.rotation = la.quat_from_euler(value)
+
+    @rotation_matrix.setter
+    def rotation_matrix(self, value):
+        self.rotation = la.quat_from_mat(value)
+
+    @euler_x.setter
+    def euler_x(self, value):
+        self.euler = (value, self._euler[1], self._euler[2])
+
+    @euler_y.setter
+    def euler_y(self, value):
+        self.euler = (self._euler[0], value, self._euler[2])
+
+    @euler_z.setter
+    def euler_z(self, value):
+        self.euler = (self._euler[0], self._euler[1], value)
 
     @scale.setter
     def scale(self, value):

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -349,15 +349,15 @@ class AffineBase:
 
     @euler_x.setter
     def euler_x(self, value):
-        self.euler = (value, self._euler[1], self._euler[2])
+        self.euler = (value, 0, 0)
 
     @euler_y.setter
     def euler_y(self, value):
-        self.euler = (self._euler[0], value, self._euler[2])
+        self.euler = (0, value, 0)
 
     @euler_z.setter
     def euler_z(self, value):
-        self.euler = (self._euler[0], self._euler[1], value)
+        self.euler = (0, 0, value)
 
     @scale.setter
     def scale(self, value):

--- a/tests/objects/test_world_object.py
+++ b/tests/objects/test_world_object.py
@@ -470,5 +470,18 @@ def test_rotation_derived():
     npt.assert_array_almost_equal(obj.local.right, [0, 0, 1])
     npt.assert_array_almost_equal(obj.local.up, [0, 1, 0])
 
-    # obj.world.rotation = la.quat_from_euler((np.pi / 4, np.pi / 4), order="XZ")
-    # assert np.allclose(obj.local.forward, (0, -np.cos(np.pi / 4), np.sin(np.pi / 4)))
+    obj.local.euler = [0, 0, 0]
+    npt.assert_array_almost_equal(obj.local.rotation, [0, 0, 0, 1])
+    npt.assert_array_almost_equal(obj.local.rotation_matrix, np.eye(4))
+    npt.assert_array_almost_equal(obj.local.forward, [0, 0, 1])
+    npt.assert_array_almost_equal(obj.local.right, [-1, 0, 0])
+    npt.assert_array_almost_equal(obj.local.up, [0, 1, 0])
+
+    obj.local.euler_x = np.pi / 2
+    npt.assert_array_almost_equal(obj.local.rotation, la.quat_from_euler(np.pi / 2, order="X"))
+
+    obj.local.euler_y = np.pi / 2
+    npt.assert_array_almost_equal(obj.local.rotation, la.quat_from_euler(np.pi / 2, order="Y"))
+
+    obj.local.euler_z = np.pi / 2
+    npt.assert_array_almost_equal(obj.local.rotation, la.quat_from_euler(np.pi / 2, order="Z"))

--- a/tests/objects/test_world_object.py
+++ b/tests/objects/test_world_object.py
@@ -441,3 +441,34 @@ def test_scaling_signs_manual_matrix():
     child.local.scale = s2
     npt.assert_array_almost_equal(child.local.scale, s2)
     npt.assert_array_almost_equal(child.world.scale, [-4, 8, 12])
+
+
+def test_rotation_derived():
+    obj = gfx.WorldObject()
+    e1 = np.array([0, np.pi / 2, 0])
+    q1 = la.quat_from_euler(e1, order="XYZ")
+    m1 = la.mat_from_quat(q1)
+
+    obj.local.rotation = q1
+    npt.assert_array_almost_equal(obj.local.rotation, q1)
+    npt.assert_array_almost_equal(obj.local.rotation_matrix, m1)
+    npt.assert_array_almost_equal(obj.local.forward, [1, 0, 0])
+    npt.assert_array_almost_equal(obj.local.right, [0, 0, 1])
+    npt.assert_array_almost_equal(obj.local.up, [0, 1, 0])
+
+    obj.local.rotation_matrix = m1
+    npt.assert_array_almost_equal(obj.local.rotation, q1)
+    npt.assert_array_almost_equal(obj.local.rotation_matrix, m1)
+    npt.assert_array_almost_equal(obj.local.forward, [1, 0, 0])
+    npt.assert_array_almost_equal(obj.local.right, [0, 0, 1])
+    npt.assert_array_almost_equal(obj.local.up, [0, 1, 0])
+
+    obj.local.euler = e1
+    npt.assert_array_almost_equal(obj.local.rotation, q1)
+    npt.assert_array_almost_equal(obj.local.rotation_matrix, m1)
+    npt.assert_array_almost_equal(obj.local.forward, [1, 0, 0])
+    npt.assert_array_almost_equal(obj.local.right, [0, 0, 1])
+    npt.assert_array_almost_equal(obj.local.up, [0, 1, 0])
+
+    # obj.world.rotation = la.quat_from_euler((np.pi / 4, np.pi / 4), order="XZ")
+    # assert np.allclose(obj.local.forward, (0, -np.cos(np.pi / 4), np.sin(np.pi / 4)))

--- a/tests/objects/test_world_object.py
+++ b/tests/objects/test_world_object.py
@@ -478,10 +478,16 @@ def test_rotation_derived():
     npt.assert_array_almost_equal(obj.local.up, [0, 1, 0])
 
     obj.local.euler_x = np.pi / 2
-    npt.assert_array_almost_equal(obj.local.rotation, la.quat_from_euler(np.pi / 2, order="X"))
+    npt.assert_array_almost_equal(
+        obj.local.rotation, la.quat_from_euler(np.pi / 2, order="X")
+    )
 
     obj.local.euler_y = np.pi / 2
-    npt.assert_array_almost_equal(obj.local.rotation, la.quat_from_euler(np.pi / 2, order="Y"))
+    npt.assert_array_almost_equal(
+        obj.local.rotation, la.quat_from_euler(np.pi / 2, order="Y")
+    )
 
     obj.local.euler_z = np.pi / 2
-    npt.assert_array_almost_equal(obj.local.rotation, la.quat_from_euler(np.pi / 2, order="Z"))
+    npt.assert_array_almost_equal(
+        obj.local.rotation, la.quat_from_euler(np.pi / 2, order="Z")
+    )


### PR DESCRIPTION
Depends on #565

There are still some improvements to make here; specifically the euler angles are reconstructed via a roundtrip through the matrix, so the inputs are not preserved. Having a stateful euler_x/y/z API would be nice but it requires some more work. I want to do that in a separate PR.