### PR TITLE
Fix normal interpolation

### DIFF
--- a/examples/feature_demo/pbr2.py
+++ b/examples/feature_demo/pbr2.py
@@ -92,7 +92,8 @@ while alpha <= 1.0:
 
 # Create camera and controls
 camera = gfx.PerspectiveCamera(45, 640 / 480)
-camera.show_object(scene)
+camera.show_object(scene, view_dir=(-2, -1.5, -3), scale=1.2)
+
 controller = gfx.OrbitController(camera, register_events=renderer)
 
 
@@ -100,9 +101,9 @@ def animate():
     timer = next(frame_idx) / 30
 
     point_light.local.position = (
-        math.sin(timer / 3 * (2 * np.pi)) * 300,
-        math.cos(timer * 2 / 3 * (2 * np.pi)) * 400,
-        math.cos(timer / 3 * (2 * np.pi)) * 300,
+        math.sin(timer / 30 * (2 * np.pi)) * 300,
+        math.cos(timer * 2 / 30 * (2 * np.pi)) * 400,
+        math.cos(timer / 30 * (2 * np.pi)) * 300,
     )
 
     renderer.render(scene, camera)

--- a/pygfx/renderers/wgpu/meshshader.py
+++ b/pygfx/renderers/wgpu/meshshader.py
@@ -348,7 +348,7 @@ class MeshShader(WorldObjectShader):
 
             // Get the surface normal from the geometry.
             // This is the unflipped normal, because thet NormalMaterial needs that.
-            var surface_normal = vec3<f32>(varyings.normal);
+            var surface_normal = normalize(vec3<f32>(varyings.normal));
             $$ if flat_shading
                 let u = dpdx(varyings.world_pos);
                 let v = dpdy(varyings.world_pos);


### PR DESCRIPTION
This issue has been bothering me for some time, as shown in the following image:

![image](https://github.com/pygfx/pygfx/assets/8044566/875c595c-7e0f-47d1-89fa-b69e8903726a)

The lighting calculation is a bit strange, as specular lights are discontinuous at the junction of vertex and face edges on the spherical mesh. The "MeshPhongMaterial" have this issue too.

I have written some test cases using the most basic Phong lighting model for testing, and the issue still persists:
![image](https://github.com/pygfx/pygfx/assets/8044566/8d230753-fba6-4ff6-9c5b-87023670c440)

It is easy to assume that there is an error in the normal calculation. The normal of each fragment is interpolated from the vertex normal, which I have checked to be correct. However, the normal interpolation seems to be not smooth. I once thought it was a floating-point calculation precision issue. However, after a period of investigation, I finally discovered the problem, which was quite simple but covert: the normal vectors were not correctly normalized in the fragment shader. Although the vertex normals were already normalized in the vertex shader, the interpolated normals could not guarantee normalization and needed to be normalized again.

Now, we have a smooth specular, 😅:

![image](https://github.com/pygfx/pygfx/assets/8044566/ae6dba7d-b8ac-4b83-81e1-0c0c0ee006f6)
![image](https://github.com/pygfx/pygfx/assets/8044566/a4d027e9-ccf8-4c99-b7ae-a79562f0fc6a)

Additionally, I have slightly adjusted the display effect of the “pbr2.py” example.



