### PR TITLE
Make enable_wgpu_features part of the advanced api

### DIFF
--- a/docs/advanced_api.rst
+++ b/docs/advanced_api.rst
@@ -1,6 +1,7 @@
 API for advanced wgpu usage
 ---------------------------
 
+.. autofunction:: pygfx.renderers.wgpu.enable_wgpu_features
 
 .. autofunction:: pygfx.renderers.wgpu.register_wgpu_render_function
 

--- a/pygfx/renderers/__init__.py
+++ b/pygfx/renderers/__init__.py
@@ -34,13 +34,11 @@ canvas, averaging neighbouring fragments for anti-aliasing.
     WgpuRenderer
     SvgRenderer
     print_wgpu_report
-    enable_wgpu_features
-
 
 """
 
 # flake8: noqa
 
 from ._base import Renderer
-from .wgpu import WgpuRenderer, print_wgpu_report, enable_wgpu_features
+from .wgpu import WgpuRenderer, print_wgpu_report
 from .svg import SvgRenderer


### PR DESCRIPTION
In #575, while making sure the function ended up in the docs, I imported `enable_wgpu_features` into `pygfx.renderers`, making it part of the global gfx namespace.

In retrospect I think it makes more sense to make it part of the [advanced api](https://pygfx.readthedocs.io/en/stable/advanced_api.html). People who use this feature are not likely to use vanilla pygfx, but have a custom shader that requires the specific feature.