### PR TITLE
Consistency for showing warnings

### DIFF
--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -4,12 +4,11 @@ import threading
 import enum
 from typing import List
 import pylinalg as la
-import warnings
 
 import numpy as np
 
 from ..resources import Buffer
-from ..utils import array_from_shadertype
+from ..utils import array_from_shadertype, logger
 from ..utils.trackable import RootTrackable
 from ._events import EventTarget
 from ..utils.transform import (
@@ -200,18 +199,16 @@ class WorldObject(EventTarget, RootTrackable):
 
         """
 
-        warnings.warn(
+        logger.warning(
             "`WorldObject.up` is deprecated. Use `WorldObject.world.reference_up` instead.",
-            DeprecationWarning,
         )
 
         return self.world.reference_up
 
     @up.setter
     def up(self, value):
-        warnings.warn(
+        logger.warning(
             "`WorldObject.up` is deprecated. Use `WorldObject.world.reference_up` instead.",
-            DeprecationWarning,
         )
 
         self.world.reference_up = np.asarray(value)
@@ -389,9 +386,7 @@ class WorldObject(EventTarget, RootTrackable):
             try:
                 self.children.remove(obj)
             except ValueError:
-                warnings.warn(
-                    "Attempting to remove object that was not a child.", UserWarning
-                )
+                logger.warning("Attempting to remove object that was not a child.")
                 continue
             else:
                 obj._reset_parent(keep_world_matrix=keep_world_matrix)

--- a/pygfx/renderers/wgpu/_renderer.py
+++ b/pygfx/renderers/wgpu/_renderer.py
@@ -5,7 +5,6 @@ manages the rendering process.
 
 import time
 import weakref
-import logging
 
 import numpy as np
 import wgpu.backends.rs
@@ -35,8 +34,6 @@ from ._environment import get_environment
 from ._shadowutil import render_shadow_maps
 from ._mipmapsutil import generate_texture_mipmaps
 from ._utils import GfxTextureView
-
-logger = logging.getLogger("pygfx")
 
 
 def _get_sort_function(camera: Camera):

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -5,7 +5,6 @@ little boilerplate as possible.
 
 import sys
 import numpy as np
-import warnings
 
 from ..objects import (
     Background,
@@ -16,6 +15,7 @@ from ..objects import (
     Light,
 )
 
+from ..utils import logger
 from ..cameras import Camera, PerspectiveCamera
 from ..controllers import OrbitController
 from ..materials import BackgroundMaterial
@@ -155,8 +155,8 @@ class Display:
         self.scene = scene
 
         if not any(scene.iter(lambda x: isinstance(x, Light))):
-            warnings.warn(
-                "Your scene does not contain any lights. Some objects may not be visible"
+            logger.warning(
+                "Your scene does not contain any lights. Some objects may not be visible."
             )
 
         # Process renderer


### PR DESCRIPTION
We use the standard logging mechanism, but also the `warnings` module in a few places. This PR replaces these cases with `logger.warning()`  to make this more consistent.