### PR TITLE
Supports aomap

### DIFF
--- a/examples/feature_demo/aomap.py
+++ b/examples/feature_demo/aomap.py
@@ -1,6 +1,6 @@
 """
 Ambient occlusion
-========
+=================
 
 
 This example demonstrates the ambient occlusion map effects for MeshBasicMaterial, MeshPhongMaterial, and MeshStandardMaterial.

--- a/examples/feature_demo/aomap.py
+++ b/examples/feature_demo/aomap.py
@@ -1,0 +1,108 @@
+"""
+Ambient occlusion
+========
+
+
+This example demonstrates the ambient occlusion map effects for MeshBasicMaterial, MeshPhongMaterial, and MeshStandardMaterial.
+"""
+
+################################################################################
+# .. warning::
+#     An external model is needed to run this example.
+#
+# To run this example, you need a model from the source repo's example
+# folder. If you are running this example from a local copy of the code (dev
+# install) no further actions are needed. Otherwise, you may have to replace
+# the path below to point to the location of the model.
+
+import os
+from pathlib import Path
+
+try:
+    # modify this line if your model is located elsewhere
+    model_dir = Path(__file__).parents[1] / "data"
+except NameError:
+    # compatibility with sphinx-gallery
+    model_dir = Path(os.getcwd()).parent / "data"
+
+
+################################################################################
+# Once the path is set correctly, you can use the model as follows:
+
+# sphinx_gallery_pygfx_render = True
+
+import imageio.v3 as iio
+import numpy as np
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+
+
+# Init
+canvas = WgpuCanvas(size=(1200, 400), title="aomap")
+renderer = gfx.renderers.WgpuRenderer(canvas)
+
+meshes = gfx.load_scene(model_dir / "lightmap" / "scene.gltf")
+
+ao_map = iio.imread(model_dir / "lightmap" / "lightmap-ao-shadow.png")
+ao_map_tex = gfx.Texture(ao_map, dim=2)
+
+texcoords1 = np.ascontiguousarray(
+    np.loadtxt(model_dir / "lightmap" / "texcoords1.txt"), dtype="f4"
+)
+texcoords1 = gfx.Buffer(texcoords1)
+
+# Create camera and controller
+camera = gfx.PerspectiveCamera(45, 1)
+camera.local.position = 500, 1000, 1500
+camera.look_at((0, 0, 0))
+controller = gfx.OrbitController(camera, register_events=renderer)
+
+# Text
+text_scene = gfx.Scene()
+text_camera = gfx.OrthographicCamera(12, 4)
+
+
+def create_scene(material, x_pos):
+    scene = gfx.Scene()
+    m = meshes[0]
+    m.geometry.texcoords1 = texcoords1
+    material.ao_map = ao_map_tex
+    mesh = gfx.Mesh(m.geometry, material)
+    scene.add(mesh)
+
+    # illumination the scene for MeshPhongMaterial and MeshStandardMaterial
+    scene.add(gfx.AmbientLight(intensity=1.0))
+
+    t = gfx.Text(
+        gfx.TextGeometry(material.__class__.__name__, screen_space=True, font_size=20),
+        gfx.TextMaterial(),
+    )
+    t.local.position = (x_pos, 1.5, 0)
+    text_scene.add(t)
+
+    return scene
+
+
+vp1 = gfx.Viewport(renderer, (5, 0, 390, 400))
+scene1 = create_scene(gfx.MeshBasicMaterial(), -4)
+
+vp2 = gfx.Viewport(renderer, (405, 0, 390, 400))
+scene2 = create_scene(gfx.MeshPhongMaterial(), 0)
+
+vp3 = gfx.Viewport(renderer, (805, 0, 390, 400))
+scene3 = create_scene(gfx.MeshStandardMaterial(), 4)
+
+vp4 = gfx.Viewport(renderer, (0, 0, 1200, 400))
+
+
+def animate():
+    vp1.render(scene1, camera)
+    vp2.render(scene2, camera)
+    vp3.render(scene3, camera)
+    vp4.render(text_scene, text_camera)
+    renderer.flush()
+
+
+if __name__ == "__main__":
+    renderer.request_draw(animate)
+    run()

--- a/examples/feature_demo/pbr.py
+++ b/examples/feature_demo/pbr.py
@@ -62,6 +62,7 @@ gltf_path = model_dir / "DamagedHelmet" / "glTF" / "DamagedHelmet.gltf"
 meshes = gfx.load_scene(gltf_path)
 scene.add(*meshes)
 m = meshes[0]  # this example has just one mesh
+m.geometry.texcoords1 = m.geometry.texcoords  # use second set of texcoords for ao map
 m.material.env_map = env_tex
 
 # Add extra light more or less where the sun seems to be in the skybox

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -377,7 +377,7 @@ class MeshBasicMaterial(MeshAbstractMaterial):
 
     @property
     def ao_map_intensity(self):
-        """Intensity of the ambient occlusion effect. Default is 1.0 Zero is no occlusion effect."""
+        """Intensity of the ambient occlusion effect. Default is 1.0, zero is no occlusion effect."""
         return float(self.uniform_buffer.data["ao_map_intensity"])
 
     @ao_map_intensity.setter

--- a/pygfx/renderers/wgpu/_shaderlib.py
+++ b/pygfx/renderers/wgpu/_shaderlib.py
@@ -541,6 +541,14 @@ class Shaderlib:
             $$ endif
 
             reflected_light = RE_IndirectDiffuse_BlinnPhong( irradiance, geometry, material, reflected_light );
+
+            // Ambient occlusion
+            $$ if use_ao_map is defined
+            let ao_map_intensity = u_material.ao_map_intensity;
+            let ambientOcclusion = ( textureSample( t_ao_map, s_ao_map, varyings.texcoord1 ).r - 1.0 ) * ao_map_intensity + 1.0;
+            reflected_light.indirect_diffuse *= ambientOcclusion;
+            $$ endif
+
             return reflected_light.direct_diffuse + reflected_light.direct_specular + reflected_light.indirect_diffuse + reflected_light.indirect_specular + u_material.emissive_color.rgb;
         }
         """
@@ -690,7 +698,7 @@ class Shaderlib:
             // Ambient occlusion
             $$ if use_ao_map is defined
             let ao_map_intensity = u_material.ao_map_intensity;
-            let ambientOcclusion = ( textureSample( t_ao_map, s_ao_map, varyings.texcoord ).r - 1.0 ) * ao_map_intensity + 1.0;
+            let ambientOcclusion = ( textureSample( t_ao_map, s_ao_map, varyings.texcoord1 ).r - 1.0 ) * ao_map_intensity + 1.0;
             reflected_light = RE_AmbientOcclusion_Physical(ambientOcclusion, geometry, material, reflected_light);
             $$ endif
 


### PR DESCRIPTION
Modified aomap to use the second set of texture coordinates and improved the support for aomap in MeshBasicMaterial, MeshPhongMaterial, and MeshStandardMaterial.

![image](https://github.com/pygfx/pygfx/assets/8044566/8c37e595-63f6-48aa-8eb3-b11fe02460de)
