### PR TITLE
Track tuples better

### DIFF
--- a/pygfx/utils/trackable.py
+++ b/pygfx/utils/trackable.py
@@ -74,6 +74,8 @@ simple_value_types = None.__class__, bool, int, float, str
 def get_comp_value(value):
     if isinstance(value, simple_value_types):
         return value
+    elif isinstance(value, tuple):
+        return tuple(get_comp_value(v) for v in value)
     else:
         return f"id:{id(value)}"
 


### PR DESCRIPTION
### Introduction

I ran into very strange behavior where the `draw_range` was changed, but did not affect the rendering, causing glitches in the mesh that was being modified.

### The cause

Took me a deep dive to find out that the problem is this:
```py
# At some point in time ...
buf.draw_range = (0, 400)

# At another point in time, in one event-handler cycle ...

buf.draw_range = (0, 380)  # at this point, the previous tuple is de-allocated, and a new one is allocated
...
buf.draw_range = (0, 410)  # same here
```

What I observed was that, in some cases, the last two changes do not register a change of `draw_range` because the `id` of the value did not change. So it seems like when that last tuple is allocated, it may re-use the memory where the original tuple was stored, causing it to have the same id, so it appears as though the object is set back to its original.

### Solution

This PR changes the trackable code so it can deal with tuples. This is a nice improvement anyhow, because we use tuples in quite a few places. It also means that it compares the actual value, resulting in expected behavior when a property is set to the same value.

  