### PR TITLE
Let load_scene also work for single meshes

### DIFF
--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -176,6 +176,7 @@ class Buffer(Resource):
                 f"`offset` and `size` must be native `int` type, you have passed: "
                 f"offset: <{type(offset)}>, size: <{type(size)}>"
             )
+        offset, size = int(offset), int(size)  # convert np ints to real ints
 
         if size == 0:
             return

--- a/pygfx/utils/load.py
+++ b/pygfx/utils/load.py
@@ -25,15 +25,23 @@ def load_scene(path):
     import trimesh  # noqa
 
     scene = trimesh.load(path)
-    for node_name in scene.graph.nodes_geometry:
-        transform, geometry_name = scene.graph[node_name]
-        current = scene.geometry[geometry_name]
-        current.apply_transform(transform)
-
-    return [
-        gfx.Mesh(
-            gfx.geometry_from_trimesh(m),
-            gfx.material_from_trimesh(m.visual.material),
+    if isinstance(scene, trimesh.Trimesh):
+        m = gfx.Mesh(
+            gfx.geometry_from_trimesh(scene),
+            gfx.MeshPhongMaterial(),
         )
-        for m in scene.geometry.values()
-    ]
+        return [m]
+
+    if isinstance(scene, trimesh.Scene):
+        for node_name in scene.graph.nodes_geometry:
+            transform, geometry_name = scene.graph[node_name]
+            current = scene.geometry[geometry_name]
+            current.apply_transform(transform)
+
+        return [
+            gfx.Mesh(
+                gfx.geometry_from_trimesh(m),
+                gfx.material_from_trimesh(m.visual.material),
+            )
+            for m in scene.geometry.values()
+        ]


### PR DESCRIPTION
The `gfx.load_scene` expects a file containing an actual scene. This pr also allows using it to load a simple stl file. I later realized one can do `trimesh.load()` and then `gfx.geometry_from_trimesh()`, though this change does make that a bit easier, and ppl wont have to know about trimesh.