### PR TITLE
Run CI tests with can_use_wgpu_lib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,18 +61,22 @@ jobs:
 
   test-builds:
     name: ${{ matrix.name }}
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - name: Test py38
+            os: ubuntu-latest
             pyversion: '3.8'
           - name: Test py39
+            os: ubuntu-latest
             pyversion: '3.9'
           - name: Test py310
+            os: ubuntu-latest
             pyversion: '3.10'
           - name: Test py311
+            os: ubuntu-latest
             pyversion: '3.11'
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,11 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.pyversion }}
+    - name: Install llvmpipe and lavapipe for offscreen canvas
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update -y -qq
+        sudo apt install -y libegl1-mesa libgl1-mesa-dri libxcb-xfixes0-dev mesa-vulkan-drivers
     - name: Install package and dev dependencies
       run: |
         python -m pip install --upgrade pip

--- a/pygfx/renderers/wgpu/_pipeline.py
+++ b/pygfx/renderers/wgpu/_pipeline.py
@@ -497,8 +497,10 @@ class PipelineContainer:
             changed.update(("bindings", "pipeline_info", "render_info"))
 
         if "bindings" in changed:
+            self.shader.unlock_hash()
             with wobject.tracker.track_usage("!bindings"):
                 self.bindings_dicts = self.shader.get_bindings(wobject, self.shared)
+            self.shader.lock_hash()
             self._check_bindings()
             self.update_shader_hash()
             self.update_bind_groups()

--- a/pygfx/renderers/wgpu/_pipeline.py
+++ b/pygfx/renderers/wgpu/_pipeline.py
@@ -730,7 +730,8 @@ class RenderPipelineContainer(PipelineContainer):
 
             blender_kwargs = blender.get_shader_kwargs(pass_index)
             env_kwargs = env.get_shader_kwargs(env_bind_group_index)
-            shader_kwargs = blender_kwargs | env_kwargs
+            shader_kwargs = blender_kwargs.copy()
+            shader_kwargs.update(env_kwargs)
 
             shader_module = get_cached_shader_module(
                 self.device, self.shader, shader_kwargs

--- a/pygfx/renderers/wgpu/_shader.py
+++ b/pygfx/renderers/wgpu/_shader.py
@@ -161,7 +161,9 @@ class WorldObjectShader(BaseShader):
             return ""
 
         typemap = {"1d": "f32", "2d": "vec2<f32>", "3d": "vec3<f32>"}
-        self["colormap_coord_type"] = typemap.get(self["colormap_dim"], "f32")
+        self.derived_kwargs["colormap_coord_type"] = typemap.get(
+            self["colormap_dim"], "f32"
+        )
 
         return """
         fn sample_colormap(texcoord: {{ colormap_coord_type }}) -> vec4<f32> {

--- a/pygfx/renderers/wgpu/_shaderbase.py
+++ b/pygfx/renderers/wgpu/_shaderbase.py
@@ -248,7 +248,16 @@ class BaseShader:
     """
 
     def __init__(self, **kwargs):
+        # The shader kwargs
         self.kwargs = kwargs
+        # Additional shader kwargs for private stuff. Only use for derived values:
+        # values that are already defined by an item in kwargs!!
+        self.derived_kwargs = {}
+        # The stored hash. If set, the hash is locked, and kwargs cannot
+        # be set. This is to prevent the shader implementations setting
+        # shader kwargs *after* the pipeline has obtained the hash.
+        self._hash = None
+
         self._typedefs = {}
         self._binding_codes = {}
         self._uniform_struct_names = {}  # dtype -> name
@@ -257,23 +266,39 @@ class BaseShader:
         if hasattr(self.__class__, key):
             msg = f"Templating variable {key} causes name clash with class attribute."
             raise KeyError(msg)
+        if self._hash is not None:
+            raise RuntimeError(
+                "Shader is trying to set shaders kwargs while they're locked."
+            )
         self.kwargs[key] = value
 
     def __getitem__(self, key):
         return self.kwargs[key]
+
+    def lock_hash(self):
+        self._hash = self._get_hash()
+
+    def unlock_hash(self):
+        self._hash = None
 
     @property
     def hash(self):
         """A hash of the current state of the shader. If the hash changed,
         it's likely that the shader changed.
         """
+        if self._hash is None:
+            return self._get_hash()
+        else:
+            return self._hash
+
+    def _get_hash(self):
         # The full name of this shader class.
         fullname = self.__class__.__module__ + "." + self.__class__.__name__
 
         # If we assume that the shader class produces the same code for
         # a specific set of kwargs, we can use the fullname in the hash
         # instead of the actual code. This assumption is valid in
-        # general, but can breaks down in a few specific situation, the
+        # general, but can break down in a few specific situations, the
         # most common one being an interactive session. In this case,
         # the fullname would be something like "__main__.CustomShader".
         # To be on the safe side, we use the full code when the fullname
@@ -311,17 +336,24 @@ class BaseShader:
         the templating variables, varyings, and depth output.
         """
 
-        old_kwargs = self.kwargs
-        self.kwargs = old_kwargs.copy()
-        self.kwargs.update(kwargs)
+        # Compose shader kwargs
+        shader_kwargs = self.kwargs.copy()
+        shader_kwargs.update(kwargs)
+
+        # Set self.kwargs, because self.get_code() might use it.
+        ori_kwargs = self.kwargs
+        self.kwargs = shader_kwargs
 
         try:
             code1 = self.get_code()
             t = jinja_env.from_string(code1)
 
+            # Also add some additional kwargs, some of these may be set during get_code()
+            shader_kwargs.update(self.derived_kwargs)
+
             err_msg = None
             try:
-                code2 = t.render(**self.kwargs)
+                code2 = t.render(**shader_kwargs)
             except jinja2.UndefinedError as err:
                 err_msg = f"Canot compose shader: {err.args[0]}"
 
@@ -332,9 +364,8 @@ class BaseShader:
                 code2 = resolve_varyings(code2)
                 code2 = resolve_depth_output(code2)
                 return code2
-
         finally:
-            self.kwargs = old_kwargs
+            self.kwargs = ori_kwargs
 
     def define_bindings(self, bindgroup, bindings_dict):
         """Define a collection of bindings organized in a dict."""

--- a/pygfx/renderers/wgpu/meshshader.py
+++ b/pygfx/renderers/wgpu/meshshader.py
@@ -89,6 +89,12 @@ class MeshShader(WorldObjectShader):
         # We're assuming the presence of an index buffer for now
         assert getattr(geometry, "indices", None)
 
+        # Triangles or quads?
+        if geometry.indices.data is not None and geometry.indices.data.shape[-1] == 4:
+            self["indexer"] = 6
+        else:
+            self["indexer"] = 3
+
         # Normals. Usually it'd be given. If not, we'll calculate it from the vertices.
         if getattr(geometry, "normals", None) is not None:
             normal_buffer = geometry.normals
@@ -228,11 +234,9 @@ class MeshShader(WorldObjectShader):
         material = wobject.material
 
         if geometry.indices.data is not None and geometry.indices.data.shape[-1] == 4:
-            self["indexer"] = 6
             offset, size = geometry.indices.draw_range
             offset, size = 6 * offset, 6 * size
         else:
-            self["indexer"] = 3
             offset, size = geometry.indices.draw_range
             offset, size = 3 * offset, 3 * size
 

--- a/tests/renderers/test_reactivity.py
+++ b/tests/renderers/test_reactivity.py
@@ -4,12 +4,12 @@ import numpy as np
 import wgpu
 import pygfx as gfx
 
-from ..testutils import can_use_wgpu_lib
+# from ..testutils import can_use_wgpu_lib
 import pytest
 
 
-if not can_use_wgpu_lib:
-    pytest.skip("Skipping tests that need the wgpu lib", allow_module_level=True)
+# if not can_use_wgpu_lib:
+#     pytest.skip("Skipping tests that need the wgpu lib", allow_module_level=True)
 
 
 render_tex = gfx.Texture(dim=2, size=(10, 10, 1), format=wgpu.TextureFormat.rgba8unorm)


### PR DESCRIPTION
We have no unit-test-builds with lavapipe enabled, so some of the tests are never run. It seems that locally, I mostly run the examples tests, because I only found out today that a few unit tests are actually broken 😢 (and confirmed its not due to the recent changes in wgpu-py)