### PR TITLE
better error message for texture data array shapes that don't make sense

### DIFF
--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -84,7 +84,10 @@ class Texture(Resource):
             if len(shape) == len(collapsed_size) + 1:
                 nchannels = shape[-1]
             else:
-                assert len(shape) == len(collapsed_size)
+                if not len(shape) == len(collapsed_size):
+                    raise ValueError(
+                        "Incompatible data shape for image data, there must be > 1 pixel to draw per channel"
+                    )
                 nchannels = 1
             if not (1 <= nchannels <= 4):
                 raise ValueError(


### PR DESCRIPTION
This just provides an error message for a previous `assert`, I've been wanting to catch this for months and saw that you put in the check recently :smile: 

Catching this is useful in interactive visualizations where the user ends up creating a slice that doesn't make sense. For us it's if you end up with an array of shape `(1, 1)`, i.e. just one pixel in one or all channels so that's why I put that as the "interpretive" error message. Not sure if that's the only case that's covered here but it's what I can think of. 

closes: https://github.com/fastplotlib/fastplotlib/issues/193 

trying to see if cross-repo closing is possible :smile: 