### PR TITLE
Bump version

### DIFF
--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -24,10 +24,10 @@ import pylinalg
 
 del pylinalg
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"
 version_info = tuple(map(int, __version__.split(".")))
 
-__wgpu_version_range__ = "0.10.0", "0.11.0"
+__wgpu_version_range__ = "0.10.0", "0.12.0"
 __pylinalg_version_range__ = "0.4.1", "0.5.0"
 
 


### PR DESCRIPTION
Let's do a release now, against version 0.10.0 and 0.11.0 of wgpu-py. The next version of wgpu-py is likely to have a few API changes.