### PR TITLE
Unable to load model without UV.

### DIFF
--- a/pygfx/geometries/_compat.py
+++ b/pygfx/geometries/_compat.py
@@ -36,6 +36,9 @@ def geometry_from_trimesh(mesh):
         # the coordinate origin is in the upper left corner, while the opengl coordinate
         # origin is in the lower left corner.
         # trimesh loads textures according to the opengl coordinate system.
+        if mesh.visual.uv is None:
+            mesh.visual.uv = [[0,0]]
+            
         wgpu_uv = mesh.visual.uv * np.array([1, -1]) + np.array(
             [0, 1]
         )  # uv.y = 1 - uv.y

--- a/pygfx/materials/_compat.py
+++ b/pygfx/materials/_compat.py
@@ -30,7 +30,10 @@ def texture_from_pillow_image(image, dim=2, **kwargs):
 
     if not isinstance(image, Image):
         raise NotImplementedError()
-
+    
+    if image.width != image.height:
+        image = image.resize([image.width if image.width > image.height else image.height] * 2)
+    
     m = memoryview(image.tobytes())
 
     im_channels = len(image.getbands())

--- a/pygfx/materials/_compat.py
+++ b/pygfx/materials/_compat.py
@@ -60,7 +60,10 @@ def material_from_trimesh(material):
         raise NotImplementedError()
 
     gfx_material = MeshStandardMaterial()
-
+    
+    if material.baseColorFactor is not None:
+        gfx_material.color = material.baseColorFactor/255
+    
     if material.baseColorTexture is not None:
         gfx_material.map = texture_from_pillow_image(material.baseColorTexture)
 


### PR DESCRIPTION
When the added mesh object does not have UV coordinates, set a default to it.