### PR TITLE
add code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,143 @@
+# pygfx code of conduct
+
+# Introduction
+
+This code of conduct applies to all spaces managed by the pygfx project, 
+including all public and private mailing lists, issue trackers, wikis, blogs, 
+Twitter, and any other communication channel used by our community, including 
+any in-person events, whether directly organized by pygfx developers 
+or associated people. 
+
+This code of conduct should be honored by everyone who participates in
+the pygfx community formally or informally, or claims any affiliation with the
+project, in any project-related activities, and, especially, when representing the
+project, in any role.
+
+This code is neither exhaustive nor complete. It serves to distill our common
+understanding of a collaborative, shared environment and goals. Please try to
+follow this code in spirit as much as in letter, to create a friendly and
+productive environment that enriches the surrounding community.
+
+
+# Specific guidelines
+
+We strive to:
+
+1. Be open. We invite anyone to participate in our community. We prefer to use
+   public methods of communication for project-related messages, unless
+   discussing something sensitive. This applies to messages for help or
+   project-related support, too; not only is a public-support request much more
+   likely to result in an answer to a question, it also ensures that any
+   inadvertent mistakes in answering are more easily detected and corrected.
+
+2. Be empathetic, welcoming, friendly, and patient. We work together to resolve
+   conflict, and assume good intentions. We may all experience some frustration
+   from time to time, but we do not allow frustration to turn into a personal
+   attack. A community where people feel uncomfortable or threatened is not a
+   productive one.
+
+3. Be collaborative. Our work will be used by other people, and in turn we will
+   depend on the work of others. When we make something for the benefit of the
+   project, we are willing to explain to others how it works, so that they can
+   build on the work to make it even better. Any decision we make will affect
+   users and colleagues, and we take those consequences seriously when making
+   decisions.
+
+4. Be inquisitive. Nobody knows everything! Asking questions early avoids many
+   problems later, so we encourage questions, although we may direct them to
+   the appropriate forum. We will try hard to be responsive and helpful.
+
+5. Be careful in the words that we choose. We are careful and respectful in
+   our communication and we take responsibility for our own speech. Be kind to
+   others. Do not insult or put down other participants. We will not accept
+   harassment or other exclusionary behavior, such as:
+
+  - Violent threats or language directed against another person.
+  - Sexist, racist, or otherwise discriminatory jokes and language.
+  - Posting sexually explicit or violent material.
+  - Posting (or threatening to post) other people's personally identifying information ("doxing").
+  - Sharing private content, such as emails sent privately or non-publicly,
+    or unlogged forums, such as IRC channel history, without the sender's consent.
+  - Personal insults, especially those using racist or sexist terms.
+  - Unwelcome sexual attention.
+  - Excessive profanity. Please avoid swearwords; people differ greatly in their sensitivity to swearing.
+  - Repeated harassment of others. In general, if someone asks you to stop, then stop.
+  - Advocating for, or encouraging, any of the above behavior.
+
+
+# Diversity statement
+
+The pygfx project welcomes and encourages participation by everyone. We are
+committed to being a community that everyone enjoys being part of. Although
+we may not always be able to accommodate each individual's preferences, we try
+our best to treat everyone kindly.
+
+No matter how you identify yourself or how others perceive you: we welcome you.
+Though no list can hope to be comprehensive, we explicitly honor diversity in:
+age, culture, ethnicity, genotype, gender identity or expression, language,
+national origin, neurotype, phenotype, political beliefs, profession, race,
+religion, sexual orientation, socioeconomic status, subculture and technical
+ability, to the extent that these do not conflict with this code of conduct.
+
+Though we welcome people fluent in all languages, pygfx development is
+conducted in English.
+
+Standards for behavior in the pygfx community are detailed in the Code of
+Conduct above. Participants in our community should uphold these standards
+in all their interactions and help others to do so as well (see next section).
+
+
+# Reporting guidelines
+
+We know that it is painfully common for internet communication to start at or
+devolve into obvious and flagrant abuse. We also recognize that sometimes
+people may have a bad day, or be unaware of some of the guidelines in this Code
+of Conduct. Please keep this in mind when deciding on how to respond to a
+breach of this Code.
+
+For clearly intentional breaches, report those to the Code of Conduct committee
+(see below). For possibly unintentional breaches, you may reply to the person
+and point out this Code of Conduct (either in public or in private, whatever is
+most appropriate). If you would prefer not to do that, please feel free to
+report to the Code of Conduct committee directly, or ask the committee for
+advice, in confidence.
+
+You can report issues to the pygfx core team: 
+
+[Korijn van Golen](https://github.com/Korijn)
+[Almar Klein](https://github.com/almarklein)
+
+If your report involves any members of the pygfx core team, or if they feel they have
+a conflict of interest in handling it, then they will recuse themselves from
+considering your report.
+
+# Incident reporting resolution & Code of Conduct enforcement
+
+We will investigate and respond to all complaints. The pygfx Code of Conduct
+Committee and the pygfx Steering Committee (if involved) will protect the
+identity of the reporter, and treat the content of complaints as confidential
+(unless the reporter agrees otherwise).
+
+In case of severe and obvious breaches, e.g., personal threat or violent, sexist
+or racist language, we will immediately disconnect the originator from pygfx
+communication channels; please see the manual for details.
+
+In cases not involving clear severe and obvious breaches of this code of
+conduct, the process for acting on any received code of conduct violation
+report will be:
+
+1. acknowledgement that the report has been received
+2. reasonable discussion/feedback
+3. mediation (if feedback didn't help, and only if both reporter and reportee agree to this)
+4. enforcement via transparent decision
+
+The committee will respond to any report as soon as possible, and at most
+within 72 hours.
+
+
+# Endnotes
+
+We are thankful to the groups behind the following documents, from which we
+drew content and inspiration:
+
+[SciPy Code of Conduct](https://docs.scipy.org/doc/scipy/dev/conduct/code_of_conduct.html)


### PR DESCRIPTION
Add code of conduct using scipy code of conduct as a template. I can add to wgpu-py as well if this looks fine to you.
