### PR TITLE
Replace pkg_resources with importlib.resources

### DIFF
--- a/pygfx/utils/_dirs.py
+++ b/pygfx/utils/_dirs.py
@@ -3,7 +3,7 @@ import sys
 import atexit
 import shutil
 import tempfile
-from pkg_resources import resource_filename
+import importlib.resources
 
 
 try:
@@ -14,7 +14,15 @@ except Exception:  # Exceptions thrown by home() are not specified...
 
 def get_resources_dir():
     """Get the path to the directory of builtin resources."""
-    return resource_filename("pygfx.data_files", "")
+    if sys.version_info < (3, 9):
+        context = importlib.resources.path("pygfx.data_files", "__init__.py")
+    else:
+        ref = importlib.resources.files("pygfx.data_files") / "__init__.py"
+        context = importlib.resources.as_file(ref)
+    with context as path:
+        pass
+    # Return the dir. We assume that the data files are on a normal dir on the fs.
+    return str(path.parent)
 
 
 def get_cache_dir():


### PR DESCRIPTION
Like we did in https://github.com/pygfx/wgpu-py/pull/421. But in this case we require the data_dir to be on the file system, because we want to search it for font files.