### PR TITLE
Add texture's data to be set

### DIFF
--- a/examples/feature_demo/synced_video.py
+++ b/examples/feature_demo/synced_video.py
@@ -47,7 +47,7 @@ for i in range(3):
 def animate():
     # update with new random image
     for img in images:
-        img.geometry.grid.data[:] = np.random.rand(512, 512).astype(np.float32) * 255
+        img.geometry.grid.data = np.random.rand(512, 512).astype(np.float32) * 255
         img.geometry.grid.update_range((0, 0, 0), img.geometry.grid.size)
 
     renderer.render(scene, camera)

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -126,6 +126,16 @@ class Texture(Resource):
         """
         return self._data
 
+    @data.setter
+    def data(self, data):
+        self._data = data
+        self._mem = memoryview(data)
+        self._store.nbytes = self._mem.nbytes
+        self._store.size = self._size_from_data(self._mem, self.dim, self.size)
+        Resource._rev += 1
+        self._rev = Resource._rev
+        self._gfx_mark_for_sync()
+
     @property
     def mem(self):
         """The data for this buffer as a memoryview. Can be None if


### PR DESCRIPTION
This helps avoid a copy when users overwrite the data.

I'm not sure if this is allowed, but it seems to "work".