### PR TITLE
Make returned arrays of gometric transforms read only

### DIFF
--- a/pygfx/helpers/_axes.py
+++ b/pygfx/helpers/_axes.py
@@ -79,7 +79,12 @@ class AxesHelper(Line):
             arrow_head.local.position = pos
             # offset by half of height since the cones
             # are centered around the origin
-            arrow_head.local.position += arrow_size / 2 * la.vec_normalize(pos)
+            # Do not use +=
+            # see: https://github.com/pygfx/pygfx/issues/651
+            arrow_head.local.position = (
+                arrow_head.local.position +
+                arrow_size / 2 * la.vec_normalize(pos)
+            )
             arrow_head.local.rotation = la.quat_from_vecs(
                 (0, 0, 1), la.vec_normalize(pos)
             )

--- a/pygfx/helpers/_axes.py
+++ b/pygfx/helpers/_axes.py
@@ -82,8 +82,7 @@ class AxesHelper(Line):
             # Do not use +=
             # see: https://github.com/pygfx/pygfx/issues/651
             arrow_head.local.position = (
-                arrow_head.local.position +
-                arrow_size / 2 * la.vec_normalize(pos)
+                arrow_head.local.position + arrow_size / 2 * la.vec_normalize(pos)
             )
             arrow_head.local.rotation = la.quat_from_vecs(
                 (0, 0, 1), la.vec_normalize(pos)

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -157,12 +157,20 @@ class AffineBase:
     @cached
     def _decomposed(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         try:
-            return la.mat_decompose(self.matrix, scaling_signs=self.scaling_signs)
+            decomposed = la.mat_decompose(self.matrix, scaling_signs=self.scaling_signs)
         except ValueError:
             # the matrix has been set manually
             # and so there is no scaling component to preserve
             # any decomposed scaling is acceptable
-            return la.mat_decompose(self.matrix)
+            decomposed = la.mat_decompose(self.matrix)
+
+        # Stop the user from accidentally writing the temporary arrays
+        # that we return from these operations
+        # https://github.com/pygfx/pygfx/issues/651
+        for m in decomposed:
+            m.flags['WRITEABLE'] = False
+
+        return decomposed
 
     @cached
     def _directions(self):

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -168,7 +168,7 @@ class AffineBase:
         # that we return from these operations
         # https://github.com/pygfx/pygfx/issues/651
         for m in decomposed:
-            m.flags['WRITEABLE'] = False
+            m.flags.writeable = False
 
         return decomposed
 
@@ -181,7 +181,12 @@ class AffineBase:
         axes_target = la.vec_transform(axes_source, self.matrix)
         origin_target = la.vec_transform((0, 0, 0), self.matrix)
 
-        return axes_target - origin_target
+        directions = axes_target - origin_target
+        # Stop the user from accidentally writing the temporary arrays
+        # that we return from these operations
+        # https://github.com/pygfx/pygfx/issues/651
+        directions.flags.writeable = False
+        return directions
 
     @cached
     def _direction_components(self):
@@ -189,11 +194,23 @@ class AffineBase:
 
     @cached
     def _rotation_matrix(self):
-        return la.mat_from_quat(self._decomposed[1])
+        rotation = la.mat_from_quat(self._decomposed[1])
+
+        # Stop the user from accidentally writing the temporary arrays
+        # that we return from these operations
+        # https://github.com/pygfx/pygfx/issues/651
+        rotation.flags.writeable = False
+        return rotation
 
     @cached
     def _euler(self):
-        return la.quat_to_euler(self._decomposed[1])
+        euler = la.quat_to_euler(self._decomposed[1])
+
+        # Stop the user from accidentally writing the temporary arrays
+        # that we return from these operations
+        # https://github.com/pygfx/pygfx/issues/651
+        euler.flags.writeable = False
+        return euler
 
     def flag_update(self):
         """Signal that this transform has updated."""
@@ -552,6 +569,9 @@ class AffineTransform(AffineBase):
     @property
     def matrix(self):
         view_array = self.untracked_matrix.view()
+        # Stop the user from accidentally writing the temporary arrays
+        # that we return from these operations
+        # https://github.com/pygfx/pygfx/issues/651
         view_array.flags.writeable = False
         return view_array
 


### PR DESCRIPTION
This should help users accidentally avoid writing to temporary arrays

Closes https://github.com/pygfx/pygfx/issues/651