### PR TITLE
Use wgsl saturate instrinsic when we can.

### DIFF
--- a/pygfx/renderers/wgpu/lineshader.py
+++ b/pygfx/renderers/wgpu/lineshader.py
@@ -457,7 +457,7 @@ class LineShader(WorldObjectShader):
             $$ if aa
                 let aa_width = 1.0;
                 alpha = ((0.5 * varyings.thickness_p) - abs(dist_to_node_p)) / aa_width;
-                alpha = clamp(alpha, 0.0, 1.0);
+                alpha = saturate(alpha);
             $$ endif
 
             $$ if color_mode == 'vertex' or color_mode == 'face'

--- a/pygfx/renderers/wgpu/textshader.py
+++ b/pygfx/renderers/wgpu/textshader.py
@@ -221,7 +221,7 @@ class TextShader(WorldObjectShader):
         return """
 
         fn _sdf_smoothstep( low : f32, high : f32, x : f32 ) -> f32 {
-            let t = clamp( ( x - low ) / ( high - low ), 0.0, 1.0 );
+            let t = saturate( ( x - low ) / ( high - low ));
             return t * t * ( 3.0 - 2.0 * t );
         }
 


### PR DESCRIPTION
I searched for

```
rg "clamp\(.*0\.0, 1\.1 "
```

and it found a few occurances.

Honestly, this might be a micro optimization since the WGSL documentation states that "saturate expands to clamp(x, 0.0, 1.0)" but again, some hardware documentation lists that that the call to "saturate" is free.

I know this is a style thing, so feel free to close.

I did this cleanup in my own codebase so I figured I would oblige.