### PR TITLE
Using the built-in function "smoothstep"

### DIFF
--- a/pygfx/renderers/wgpu/_shaderlib.py
+++ b/pygfx/renderers/wgpu/_shaderlib.py
@@ -22,11 +22,6 @@
 class Shaderlib:
     def light_deps_basic(self):
         return """
-        // TODO smoothstep and saturate probably exists when Naga gets updated
-        fn _smoothstep( low : f32, high : f32, x : f32 ) -> f32 {
-            let t = saturate( ( x - low ) / ( high - low ));
-            return t * t * ( 3.0 - 2.0 * t );
-        }
         fn getDistanceAttenuation(light_distance: f32, cutoff_distance: f32, decay_exponent: f32) -> f32 {
             var distance_falloff: f32 = 1.0 / max( pow( light_distance, decay_exponent ), 0.01 );
             if ( cutoff_distance > 0.0 ) {
@@ -35,7 +30,7 @@ class Shaderlib:
             return distance_falloff;
         }
         fn getSpotAttenuation( cone_cosine: f32, penumbra_cosine: f32, angle_cosine: f32 ) -> f32 {
-            return _smoothstep( cone_cosine, penumbra_cosine, angle_cosine );
+            return smoothstep( cone_cosine, penumbra_cosine, angle_cosine );
         }
         fn getAmbientLightIrradiance( ambientlight_color: vec3<f32> ) -> vec3<f32> {
             let irradiance = ambientlight_color;

--- a/pygfx/renderers/wgpu/textshader.py
+++ b/pygfx/renderers/wgpu/textshader.py
@@ -220,11 +220,6 @@ class TextShader(WorldObjectShader):
     def code_fragment(self):
         return """
 
-        fn _sdf_smoothstep( low : f32, high : f32, x : f32 ) -> f32 {
-            let t = saturate( ( x - low ) / ( high - low ));
-            return t * t * ( 3.0 - 2.0 * t );
-        }
-
         @fragment
         fn fs_main(varyings: Varyings) -> FragmentOutput {
 
@@ -277,13 +272,13 @@ class TextShader(WorldObjectShader):
 
             $$ if aa
                 // We use smoothstep to include alpha blending.
-                let outside_ness = _sdf_smoothstep(cut_off - softness, cut_off + softness, distance);
+                let outside_ness = smoothstep(cut_off - softness, cut_off + softness, distance);
                 aa_alpha = (1.0 - outside_ness);
                 // High softness values also result in lower alpha to prevent artifacts under high angles.
                 soften_alpha = 1.0 - max(softness / max_softness - 0.1, 0.0);
                 // Outline
                 let outline_softness = min(softness, 0.5 * outline_thickness);
-                outline = _sdf_smoothstep(outline_cutoff - outline_softness, outline_cutoff + outline_softness, distance);
+                outline = smoothstep(outline_cutoff - outline_softness, outline_cutoff + outline_softness, distance);
             $$ else
                 // Do a hard transition
                 aa_alpha = select(0.0, 1.0, distance < cut_off);


### PR DESCRIPTION
See: https://github.com/pygfx/pygfx/pull/653#issuecomment-1963179267

When writing these shader codes, there are certain built-in functions in Naga that have not been implemented yet, including some that were later included in the WGPU specification.