### PR TITLE
add zmq example of how to compute data in one process and view it in another process

### DIFF
--- a/examples/feature_demo/multiprocessing_zmq/compute.py
+++ b/examples/feature_demo/multiprocessing_zmq/compute.py
@@ -1,0 +1,27 @@
+"""
+Compute data and send over zmq to be rendered by pygfx in another process
+=========================================================================
+
+Example that demonstrates how to use zmq send data to another process that then uses pygfx to visualize it.
+Use in conjunction with "view.py" in this directory.
+
+First run `view.py`, and then separately run `compute.py`
+"""
+
+# sphinx_gallery_pygfx_render = False
+
+import numpy as np
+import zmq
+
+context = zmq.Context()
+
+# create publisher
+socket = context.socket(zmq.PUB)
+socket.bind("tcp://127.0.0.1:5555")
+
+for i in range(5_000):
+    # make some data, make note of the dtype
+    data = np.random.rand(512, 512).astype(np.float32)
+
+    # sent bytes over the socket
+    socket.send(data.tobytes())

--- a/examples/feature_demo/multiprocessing_zmq/view.py
+++ b/examples/feature_demo/multiprocessing_zmq/view.py
@@ -55,8 +55,7 @@ data = np.random.rand(512, 512).astype(np.float32)
 
 image = pygfx.Image(
     geometry=pygfx.Geometry(grid=pygfx.Texture(data, dim=2)),
-    material=pygfx.ImageBasicMaterial(clim=(0, 1), map=pygfx.cm.plasma)
-
+    material=pygfx.ImageBasicMaterial(clim=(0, 1), map=pygfx.cm.plasma),
 )
 
 scene.add(image)

--- a/examples/feature_demo/multiprocessing_zmq/view.py
+++ b/examples/feature_demo/multiprocessing_zmq/view.py
@@ -1,0 +1,84 @@
+"""
+View data from a zmq publisher
+==============================
+
+Example that demonstrates how to use zmq to receive data from a another process and visualize it.
+Use in conjunction with "compute.py" in this directory.
+
+First run `view.py`, and then separately run `compute.py`
+"""
+
+# sphinx_gallery_pygfx_render = False
+
+
+import numpy as np
+import zmq
+
+import pygfx
+from wgpu.gui.auto import WgpuCanvas, run
+
+context = zmq.Context()
+
+# create subscriber
+sub = context.socket(zmq.SUB)
+sub.setsockopt(zmq.SUBSCRIBE, b"")
+
+# keep only the most recent message
+sub.setsockopt(zmq.CONFLATE, 1)
+
+# publisher address and port
+sub.connect("tcp://127.0.0.1:5555")
+
+
+def get_bytes():
+    """
+    Gets the bytes from the publisher
+    """
+    try:
+        b = sub.recv(zmq.NOBLOCK)
+    except zmq.Again:
+        pass
+    else:
+        return b
+
+    return None
+
+
+canvas = WgpuCanvas()
+renderer = pygfx.WgpuRenderer(canvas)
+
+scene = pygfx.Scene()
+camera = pygfx.OrthographicCamera()
+
+# initialize some data, must be of same dtype and shape as data sent by publisher
+data = np.random.rand(512, 512).astype(np.float32)
+
+image = pygfx.Image(
+    geometry=pygfx.Geometry(grid=pygfx.Texture(data, dim=2)),
+    material=pygfx.ImageBasicMaterial(clim=(0, 1), map=pygfx.cm.plasma)
+
+)
+
+scene.add(image)
+camera.show_object(scene)
+
+
+def update_frame():
+    # receive bytes
+    b = get_bytes()
+
+    if b is not None:
+        # numpy array from bytes, MUST specify dtype and make sure it matches what you sent
+        a = np.frombuffer(b, dtype=np.float32).reshape(512, 512)
+
+        # set image data
+        image.geometry.grid.data[:] = a
+        image.geometry.grid.update_range((0, 0, 0), image.geometry.grid.size)
+
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    canvas.request_draw(update_frame)
+    run()


### PR DESCRIPTION
A simple example that uses `zmq` to send data from a compute process to a separate render process that pygfx uses to render the data. One could do this with python builtin multiprocessing too. ZMQ has the advantage that it works across languages.

related: #572, #667

https://github.com/pygfx/pygfx/assets/9403332/7a5b5cca-b4dc-467e-b42e-9fc39276b0d9
