### PR TITLE
Fix that shader is not recompiled when number of clip planes changes

### DIFF
--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -144,9 +144,15 @@ class Material(Trackable):
         # Apply
         # Note that we can create a null-plane using (0, 0, 0, 0)
         self._set_size_of_uniform_array("clipping_planes", len(planes2))
+        self._store.clipping_plane_count = len(planes2)
         for i in range(len(planes2)):
             self.uniform_buffer.data["clipping_planes"][i] = planes2[i]
         self.uniform_buffer.update_range(0, 1)
+
+    @property
+    def clipping_plane_count(self):
+        """The number of clipping planes (readonly)."""
+        return self._store.clipping_plane_count
 
     @property
     def clipping_mode(self):

--- a/pygfx/renderers/wgpu/_shader.py
+++ b/pygfx/renderers/wgpu/_shader.py
@@ -39,7 +39,7 @@ class WorldObjectShader(BaseShader):
         self.kwargs.setdefault("lighting", "")
 
         # Apply_clip_planes
-        self["n_clipping_planes"] = len(wobject.material.clipping_planes)
+        self["n_clipping_planes"] = wobject.material.clipping_plane_count
         self["clipping_mode"] = wobject.material.clipping_mode
 
     # ----- What subclasses must implement


### PR DESCRIPTION
Fixes #668

By creating a property on `material._store`, the shader will listen to that value changing and invoke a recompile when that happens.