### PR TITLE
Fix minigalleries in docs

### DIFF
--- a/docs/_templates/custom_layout.rst
+++ b/docs/_templates/custom_layout.rst
@@ -1,19 +1,27 @@
-{{ fullname | escape | underline}}
+{{ fullname | escape | underline }}
 
 .. currentmodule:: {{ module }}
 
-{% if objtype == "function" %}
-.. autofunction:: {{ objname }}
-{% elif objtype == "module" %}
-.. automodule:: {{ fullname }}
-{% else %}
-.. autoclass:: {{ objname }}
-   :members:
-   :show-inheritance:
-   :member-order: bysource
+{% if objtype == "module" %}
 
-{% endif %}
-{% if objtype != "module" %}
-   .. rubric:: Examples
-   .. minigallery:: pygfx.{{name}}
+.. automodule:: {{ fullname }}
+
+{% elif objtype == "function" %}
+
+.. autofunction:: {{ objname }}
+
+.. minigallery:: pygfx.{{ objname }}
+    :add-heading: Examples
+    :heading-level: ^
+
+{% else %}
+
+.. autoclass:: {{ objname }}
+    :members:
+    :show-inheritance:
+    :member-order: bysource
+
+.. minigallery:: pygfx.{{ objname }}
+    :add-heading: Examples
+
 {% endif %}

--- a/examples/feature_demo/multiprocessing_zmq/view.py
+++ b/examples/feature_demo/multiprocessing_zmq/view.py
@@ -14,7 +14,7 @@ First run `view.py`, and then separately run `compute.py`
 import numpy as np
 import zmq
 
-import pygfx
+import pygfx as gfx
 from wgpu.gui.auto import WgpuCanvas, run
 
 context = zmq.Context()
@@ -45,17 +45,17 @@ def get_bytes():
 
 
 canvas = WgpuCanvas()
-renderer = pygfx.WgpuRenderer(canvas)
+renderer = gfx.WgpuRenderer(canvas)
 
-scene = pygfx.Scene()
-camera = pygfx.OrthographicCamera()
+scene = gfx.Scene()
+camera = gfx.OrthographicCamera()
 
 # initialize some data, must be of same dtype and shape as data sent by publisher
 data = np.random.rand(512, 512).astype(np.float32)
 
-image = pygfx.Image(
-    geometry=pygfx.Geometry(grid=pygfx.Texture(data, dim=2)),
-    material=pygfx.ImageBasicMaterial(clim=(0, 1), map=pygfx.cm.plasma),
+image = gfx.Image(
+    geometry=gfx.Geometry(grid=gfx.Texture(data, dim=2)),
+    material=gfx.ImageBasicMaterial(clim=(0, 1), map=gfx.cm.plasma),
 )
 
 scene.add(image)

--- a/pygfx/cameras/__init__.py
+++ b/pygfx/cameras/__init__.py
@@ -1,5 +1,7 @@
 """ Objects to view a scene.
 
+.. currentmodule:: pygfx.cameras
+
 .. autosummary::
     :toctree: cameras/
     :template: ../_templates/custom_layout.rst

--- a/pygfx/controllers/__init__.py
+++ b/pygfx/controllers/__init__.py
@@ -1,6 +1,6 @@
-# flake8: noqa
-
 """ Objects to control cameras.
+
+.. currentmodule:: pygfx.controllers
 
 Controllers define how cameras can be interacted with. They are
 independent of any GUI toolkits.
@@ -16,6 +16,8 @@ independent of any GUI toolkits.
     FlyController
 
 """
+
+# flake8: noqa
 
 from ._base import Controller
 from ._panzoom import PanZoomController

--- a/pygfx/helpers/__init__.py
+++ b/pygfx/helpers/__init__.py
@@ -1,10 +1,9 @@
 """Helpers for visual debugging of scenes.
 
+.. currentmodule:: pygfx.helpers
+
 This module contains a collection of WorldObjects that can be useful
 when debugging a scene or to create reference points within a scene.
-
-
-.. currentmodule:: pygfx.helpers
 
 .. autosummary::
     :toctree: helpers/

--- a/pygfx/materials/__init__.py
+++ b/pygfx/materials/__init__.py
@@ -1,13 +1,13 @@
 """
 Containers for Material data.
 
+.. currentmodule:: pygfx.materials
+
 Materials define how a WorldObject is rendered. Many objects support multiple
 different materials, e.g. the materials that can be applied to a Mesh object
 mostly determine how the object is affected by lighs. Further, the materials
 have properties to influence the rendering, like colors, line thickness,
 colormaps, the strength of specular reflections, etc.
-
-.. currentmodule:: pygfx.materials
 
 .. autosummary::
     :toctree: materials/

--- a/pygfx/objects/__init__.py
+++ b/pygfx/objects/__init__.py
@@ -1,5 +1,7 @@
 """ World Objects and Events.
 
+.. currentmodule:: pygfx.objects
+
 .. rubric:: Objects
 .. autosummary::
     :toctree: objects/
@@ -25,8 +27,6 @@
     DirectionalLightShadow
     SpotLightShadow
     PointLightShadow
-
-.. currentmodule:: pygfx.objects
 
 .. rubric:: Events
 .. autosummary::

--- a/pygfx/renderers/wgpu/__init__.py
+++ b/pygfx/renderers/wgpu/__init__.py
@@ -6,6 +6,7 @@ General functions and classes to operate more closely with the wgpu backend.
 
 .. autosummary::
     :toctree: _autosummary/renderers/wgpu
+    :template: ../_templates/custom_layout.rst
 
     WgpuRenderer
     register_wgpu_render_function
@@ -19,6 +20,7 @@ Classes and functions required to implement custom shaders:
 
 .. autosummary::
     :toctree: _autosummary/renderers/wgpu
+    :template: ../_templates/custom_layout.rst
 
     WorldObjectShader
     RenderMask
@@ -33,6 +35,7 @@ Lower level functions that may or may not be needed in custom shaders:
 
 .. autosummary::
     :toctree: _autosummary/renderers/wgpu
+    :template: ../_templates/custom_layout.rst
 
     to_vertex_format
     to_texture_format

--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -1,6 +1,8 @@
 """
 Utility functions for pygfx.
 
+.. currentmodule:: pygfx.utils
+
 .. autosummary::
     :toctree: utils/
     :template: ../_templates/custom_layout.rst


### PR DESCRIPTION
* [x] Fix that no mini gallery was shown in a lot of cases due to a missing ``.. currentmodule::`` directive.
* [x] Put the mini-gallery at the bottom of the page (it was first placed before props&methods).
* [x] Fix that no empty header is shown when there are no examples for the documented object. 