### PR TITLE
Fix update issues related to render_mask

### DIFF
--- a/pygfx/renderers/wgpu/__init__.py
+++ b/pygfx/renderers/wgpu/__init__.py
@@ -37,6 +37,7 @@ Lower level functions that may or may not be needed in custom shaders:
     :toctree: _autosummary/renderers/wgpu
     :template: ../_templates/custom_layout.rst
 
+    nchannels_from_format
     to_vertex_format
     to_texture_format
 
@@ -50,6 +51,7 @@ Lower level functions that may or may not be needed in custom shaders:
 from ...objects._base import RenderMask
 from .engine.utils import (
     register_wgpu_render_function,
+    nchannels_from_format,
     to_vertex_format,
     to_texture_format,
     GfxSampler,

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -621,7 +621,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
         compute_pass = command_encoder.begin_compute_pass()
 
         for compute_pipeline_container in compute_pipeline_containers:
-            compute_pipeline_container.dispatch(compute_pass)
+            compute_pipeline_container.dispatch(compute_pass, environment)
 
         compute_pass.end()
 

--- a/pygfx/renderers/wgpu/engine/utils.py
+++ b/pygfx/renderers/wgpu/engine/utils.py
@@ -32,6 +32,15 @@ def register_wgpu_render_function(wobject_cls, material_cls):
     return _register_wgpu_renderer
 
 
+def nchannels_from_format(format):
+    """Return the number of channels from a buffer format.
+
+    Channels as in elements per item. I.e. will be 1 and 4 for a grayscale and
+    rgba color buffer, respectively.
+    """
+    return int(to_vertex_format(format).partition("x")[2] or "1")
+
+
 def to_vertex_format(format):
     """Convert pygfx' own format to the wgpu format."""
     if format in wgpu.VertexFormat:

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -264,7 +264,6 @@ class LineShader(WorldObjectShader):
             else:
                 raise RuntimeError(f"Unexpected color mode {self['color_mode']}")
 
-        print("line render_mask", render_mask)
         return {
             "indices": (size, 1, offset, 0),
             "render_mask": render_mask,

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -84,14 +84,13 @@ class LineShader(WorldObjectShader):
         # because a lot of logic related joins becomes simpler. However, the miters
         # result in extra fragments that need to be processed, so we'd need to do
         # some benchmarks to be sure.
-        if (
-            self["color_mode"] == "uniform"
-            and not material.is_transparent
-            and not material.color_is_transparent
-            and not self["dashing"]
-        ):
-            pass  # TODO: do benchmarks and enable if it makes things faster
-            # self["line_type"] = "quickline"
+        # if (
+        #     self["color_mode"] == "uniform"
+        #     and not self["dashing"]
+        #     and not material.is_transparent
+        #     and not material.color_is_transparent
+        # ):
+        #     # self["line_type"] = "quickline"
 
         # Handle dashing
         if material.dash_pattern:
@@ -262,6 +261,7 @@ class LineShader(WorldObjectShader):
             else:
                 raise RuntimeError(f"Unexpected color mode {self['color_mode']}")
 
+        print("line render_mask", render_mask)
         return {
             "indices": (size, 1, offset, 0),
             "render_mask": render_mask,

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -23,6 +23,7 @@ from .. import (
     Binding,
     RenderMask,
     load_wgsl,
+    nchannels_from_format,
 )
 
 
@@ -57,13 +58,15 @@ class LineShader(WorldObjectShader):
             self["color_mode"] = "uniform"
             self["color_buffer_channels"] = 0
         elif color_mode == "vertex":
+            nchannels = nchannels_from_format(geometry.colors.format)
             self["color_mode"] = "vertex"
-            self["color_buffer_channels"] = nchannels = geometry.colors.data.shape[1]
+            self["color_buffer_channels"] = nchannels
             if nchannels not in (1, 2, 3, 4):
                 raise ValueError(f"Geometry.colors needs 1-4 columns, not {nchannels}")
         elif color_mode == "face":
+            nchannels = nchannels_from_format(geometry.colors.format)
             self["color_mode"] = "face"
-            self["color_buffer_channels"] = nchannels = geometry.colors.data.shape[1]
+            self["color_buffer_channels"] = nchannels
             if nchannels not in (1, 2, 3, 4):
                 raise ValueError(f"Geometry.colors needs 1-4 columns, not {nchannels}")
         elif color_mode == "vertex_map":

--- a/pygfx/renderers/wgpu/shaders/meshshader.py
+++ b/pygfx/renderers/wgpu/shaders/meshshader.py
@@ -19,6 +19,7 @@ from .. import (
     Binding,
     RenderMask,
     shaderlib,
+    nchannels_from_format,
     to_texture_format,
     GfxSampler,
     GfxTextureView,
@@ -62,15 +63,15 @@ class MeshShader(WorldObjectShader):
             self["color_mode"] = "uniform"
             self["color_buffer_channels"] = 0
         elif color_mode == "vertex":
-            geometry.colors.itemsize  # access so we trigger a recompile when it changes
+            nchannels = nchannels_from_format(geometry.colors.format)
             self["color_mode"] = "vertex"
-            self["color_buffer_channels"] = nchannels = geometry.colors.data.shape[1]
+            self["color_buffer_channels"] = nchannels
             if nchannels not in (1, 2, 3, 4):
                 raise ValueError(f"Geometry.colors needs 1-4 columns, not {nchannels}")
         elif color_mode == "face":
-            geometry.colors.itemsize  # access so we trigger a recompile when it changes
+            nchannels = nchannels_from_format(geometry.colors.format)
             self["color_mode"] = "face"
-            self["color_buffer_channels"] = nchannels = geometry.colors.data.shape[1]
+            self["color_buffer_channels"] = nchannels
             if nchannels not in (1, 2, 3, 4):
                 raise ValueError(f"Geometry.colors needs 1-4 columns, not {nchannels}")
         elif color_mode == "vertex_map":
@@ -701,10 +702,8 @@ class MeshStandardShader(MeshShader):
         # We need uv to use the maps, so if uv not exist, ignore all maps
         if hasattr(geometry, "texcoords") and geometry.texcoords is not None:
             # Texcoords must always be nx2 since it used for all texture maps.
-            if not (
-                geometry.texcoords.data.ndim == 2
-                and geometry.texcoords.data.shape[1] == 2
-            ):
+            nchannels = nchannels_from_format(geometry.texcoords.format)
+            if not (geometry.texcoords.data.ndim == 2 and nchannels == 2):
                 raise ValueError("For standard material, the texcoords must be Nx2")
 
             if material.normal_map is not None:
@@ -844,13 +843,15 @@ class MeshSliceShader(WorldObjectShader):
             self["color_mode"] = "uniform"
             self["color_buffer_channels"] = 0
         elif color_mode == "vertex":
+            nchannels = nchannels_from_format(geometry.colors.format)
             self["color_mode"] = "vertex"
-            self["color_buffer_channels"] = nchannels = geometry.colors.data.shape[1]
+            self["color_buffer_channels"] = nchannels
             if nchannels not in (1, 2, 3, 4):
                 raise ValueError(f"Geometry.colors needs 1-4 columns, not {nchannels}")
         elif color_mode == "face":
+            nchannels = nchannels_from_format(geometry.colors.format)
             self["color_mode"] = "face"
-            self["color_buffer_channels"] = nchannels = geometry.colors.data.shape[1]
+            self["color_buffer_channels"] = nchannels
             if nchannels not in (1, 2, 3, 4):
                 raise ValueError(f"Geometry.colors needs 1-4 columns, not {nchannels}")
         elif color_mode == "vertex_map":

--- a/pygfx/renderers/wgpu/shaders/meshshader.py
+++ b/pygfx/renderers/wgpu/shaders/meshshader.py
@@ -62,11 +62,13 @@ class MeshShader(WorldObjectShader):
             self["color_mode"] = "uniform"
             self["color_buffer_channels"] = 0
         elif color_mode == "vertex":
+            geometry.colors.itemsize  # access so we trigger a recompile when it changes
             self["color_mode"] = "vertex"
             self["color_buffer_channels"] = nchannels = geometry.colors.data.shape[1]
             if nchannels not in (1, 2, 3, 4):
                 raise ValueError(f"Geometry.colors needs 1-4 columns, not {nchannels}")
         elif color_mode == "face":
+            geometry.colors.itemsize  # access so we trigger a recompile when it changes
             self["color_mode"] = "face"
             self["color_buffer_channels"] = nchannels = geometry.colors.data.shape[1]
             if nchannels not in (1, 2, 3, 4):

--- a/pygfx/renderers/wgpu/shaders/pointsshader.py
+++ b/pygfx/renderers/wgpu/shaders/pointsshader.py
@@ -9,6 +9,7 @@ from .. import (
     Binding,
     RenderMask,
     load_wgsl,
+    nchannels_from_format,
 )
 
 
@@ -34,8 +35,9 @@ class PointsShader(WorldObjectShader):
             self["color_mode"] = "uniform"
             self["color_buffer_channels"] = 0
         elif color_mode == "vertex":
+            nchannels = nchannels_from_format(geometry.colors.format)
             self["color_mode"] = "vertex"
-            self["color_buffer_channels"] = nchannels = geometry.colors.data.shape[1]
+            self["color_buffer_channels"] = nchannels
             if nchannels not in (1, 2, 3, 4):
                 raise ValueError(f"Geometry.colors needs 1-4 columns, not {nchannels}")
         elif color_mode == "vertex_map":

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -41,7 +41,7 @@ class Buffer(Resource):
         # To specify the buffer size
         # The actual data (optional)
         self._data = None
-        format = None
+        detected_format = None
         self._gfx_pending_uploads = []  # list of (offset, size) tuples
 
         # Backends-specific attributes for internal use
@@ -56,7 +56,7 @@ class Buffer(Resource):
             if subformat:
                 shape = (mem.shape + (1,)) if len(mem.shape) == 1 else mem.shape
                 if len(shape) == 2:  # if not, the user does something fancy
-                    format = (f"{shape[-1]}x" + subformat).lstrip("1x")
+                    detected_format = (f"{shape[-1]}x" + subformat).lstrip("1x")
             the_nbytes = mem.nbytes
             the_nitems = mem.shape[0] if mem.shape else 1
             if the_nitems:
@@ -73,7 +73,12 @@ class Buffer(Resource):
                 "Buffer must be instantiated with either data or nbytes and nitems."
             )
 
-        self._store.format = str(format)
+        if format is not None:
+            self._store.format = str(format)
+        elif detected_format:
+            self._store.format = detected_format
+        else:
+            self._store.format = None
         self._store.nbytes = the_nbytes
         self._store.nitems = the_nitems
 

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -116,7 +116,7 @@ class Buffer(Resource):
     @property
     def itemsize(self):
         """The number of bytes for a single item."""
-        if self._data is None:
+        if self._data is None or self.nitems > 0:
             # This generic solution fails when nitems is zero
             return self._store.nbytes // self._store.nitems
         else:

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -41,7 +41,7 @@ class Buffer(Resource):
         # To specify the buffer size
         # The actual data (optional)
         self._data = None
-        self._format = None
+        format = None
         self._gfx_pending_uploads = []  # list of (offset, size) tuples
 
         # Backends-specific attributes for internal use
@@ -56,7 +56,7 @@ class Buffer(Resource):
             if subformat:
                 shape = (mem.shape + (1,)) if len(mem.shape) == 1 else mem.shape
                 if len(shape) == 2:  # if not, the user does something fancy
-                    self._format = (f"{shape[-1]}x" + subformat).lstrip("1x")
+                    format = (f"{shape[-1]}x" + subformat).lstrip("1x")
             the_nbytes = mem.nbytes
             the_nitems = mem.shape[0] if mem.shape else 1
             if the_nitems:
@@ -73,9 +73,7 @@ class Buffer(Resource):
                 "Buffer must be instantiated with either data or nbytes and nitems."
             )
 
-        if format is not None:
-            self._format = str(format)
-
+        self._store.format = str(format)
         self._store.nbytes = the_nbytes
         self._store.nitems = the_nitems
 
@@ -106,6 +104,11 @@ class Buffer(Resource):
     @property
     def nbytes(self):
         """The number of bytes in the buffer."""
+        # Note: many properties are stored on ._store, even if they cannot
+        # change. This is done so that whan a buffer is swapped from another, we
+        # can track what properties effectively changed. E.g. to determine
+        # whether the render_mask changes or a shader recompilation is
+        # necessary.
         return self._store.nbytes
 
     @property
@@ -116,15 +119,21 @@ class Buffer(Resource):
     @property
     def itemsize(self):
         """The number of bytes for a single item."""
-        if self._data is None or self.nitems > 0:
-            # This generic solution fails when nitems is zero
-            return self._store.nbytes // self._store.nitems
-        else:
+        # Note: For regular NxM buffers this can also be calculated from the
+        # format, but not when the format is more complex / None, as with
+        # uniform buffers (structured arrays).
+        nbytes = self._store.nbytes  # deliberately touch
+        nitems = self._store.nitems  # deliberately touch
+        if nitems > 0:
+            return nbytes // nitems
+        elif self._data is not None:
             shape = self._mem.shape
             if shape:
                 shape = shape[1:]
-            factor = int(np.prod(shape)) or 1
-            return factor * self._mem.itemsize
+            nelements_per_item = int(np.prod(shape)) or 1
+            return nelements_per_item * self._mem.itemsize
+        else:
+            raise RuntimeError("Cannot determine Buffer.itemsize")
 
     @property
     def format(self):
@@ -134,7 +143,7 @@ class Buffer(Resource):
         or 3xf4 for 3xfloat32), but can also be a overridden to a
         backend-specific format. Can also be None e.g. for uniform buffers.
         """
-        return self._format
+        return self._store.format
 
     @property
     def vertex_byte_range(self):

--- a/tests/usecases/test_wobject_updates.py
+++ b/tests/usecases/test_wobject_updates.py
@@ -1,0 +1,215 @@
+"""
+Tests that updates stuff on the world-object and then verify that pipeline
+mechanics applies changes as expected. Prevent unexpected recompiles
+(expensive), but also make sure changes actually have effect.
+
+The tests in this module are not exhaustive. Let's add tests for cases of
+interests, and regression tests when a bug is fixed.
+
+These tests touch parts of the materials, geometry, buffers, the trackable
+object, and the pipeline update mechanics.
+"""
+
+import numpy as np
+import pygfx as gfx
+from wgpu.gui.offscreen import WgpuCanvas
+from pygfx.renderers.wgpu.engine.pipeline import get_pipeline_container_group
+from pygfx.renderers.wgpu.engine.environment import get_environment
+
+from ..testutils import can_use_wgpu_lib
+import pytest
+
+
+if not can_use_wgpu_lib:
+    pytest.skip("Skipping tests that need the wgpu lib", allow_module_level=True)
+
+
+class PipelineSnapshotter:
+    def __init__(self, renderer, scene, world_object):
+        self.world_object = world_object
+        self.renderer = renderer
+        self.env = get_environment(renderer, scene)
+        self._snapshot()
+
+    def get_shaders_pipelines_bindings(self):
+
+        # Prime the blender
+        self.renderer._blender.ensure_target_size((100, 100))
+
+        # Get the pipeline container. In the call below, the pipeline is updated,
+        # the equivalent what happens during a call. This means we don't need to
+        # perform an actual draw.
+        pipeline_container_group = get_pipeline_container_group(
+            self.world_object, self.env
+        )
+        pipeline_container = pipeline_container_group.render_containers[0]
+
+        # Assume a single environment is in use, get its hash.
+        env_hashes = list(pipeline_container.wgpu_shaders.keys())
+        assert len(env_hashes) == 1
+        env_hash = env_hashes[0]
+
+        # Store shaders
+        shaders = pipeline_container.wgpu_pipelines[env_hash].copy()
+
+        # Store pipelines
+        pipelines = pipeline_container.wgpu_pipelines[env_hash].copy()
+
+        # Store bindings:  bind group -> binding id -> Binding
+        bindings = {k: v.copy() for k, v in pipeline_container.bindings_dicts.items()}
+
+        return shaders, pipelines, bindings
+
+    def _snapshot(self):
+        x = self.get_shaders_pipelines_bindings()
+        self.prev_shaders, self.prev_pipelines, self.prev_bindings = x
+
+    def check(self, *, shaders_same, pipelines_same, bindings_same):
+        shaders, pipelines, bindings = self.get_shaders_pipelines_bindings()
+        prev_shaders, prev_pipelines, prev_bindings = (
+            self.prev_shaders,
+            self.prev_pipelines,
+            self.prev_bindings,
+        )
+
+        if shaders_same:
+            assert shaders == prev_shaders
+        else:
+            assert shaders != prev_shaders
+
+        if pipelines_same:
+            assert pipelines == prev_pipelines
+        else:
+            assert pipelines != prev_pipelines
+
+        if bindings_same:
+            assert bindings == prev_bindings
+        else:
+            assert bindings != prev_bindings
+
+        self._snapshot()
+
+
+def get_pipelines(world_object):
+    pipeline_container_group = world_object._wgpu_pipeline_container_group
+    pipeline_container = pipeline_container_group.render_containers[0]
+    env_hashes = list(pipeline_container.wgpu_shaders.keys())
+    assert len(env_hashes) == 1
+    env_hash = env_hashes[0]
+    return pipeline_container.wgpu_pipelines[env_hash].copy()
+
+
+def get_bindings(world_object):
+    pipeline_container_group = world_object._wgpu_pipeline_container_group
+    pipeline_container = pipeline_container_group.render_containers[0]
+    # bind group -> binding id -> Binding
+    return {k: v.copy() for k, v in pipeline_container.bindings_dicts.items()}
+
+
+def test_updating_image_material_map():
+
+    renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(), blend_mode="ordered2")
+    scene = gfx.Scene()
+
+    # Create an image
+    im = gfx.Image(
+        gfx.Geometry(grid=np.random.uniform(0, 1, size=(24, 24, 1)).astype(np.float32)),
+        gfx.ImageBasicMaterial(map=gfx.cm.plasma),
+    )
+    scene.add(im)
+
+    # Snapshot - change map - compare
+
+    snapshotter = PipelineSnapshotter(renderer, scene, im)
+
+    im.material.map = gfx.cm.viridis
+
+    snapshotter.check(shaders_same=True, pipelines_same=True, bindings_same=False)
+
+
+def test_updating_mesh_material_color():
+
+    renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(), blend_mode="ordered2")
+    scene = gfx.Scene()
+
+    # Create a mesh
+    mesh = gfx.Mesh(
+        gfx.box_geometry(200, 200, 200),
+        gfx.MeshPhongMaterial(color=(1, 0, 0), color_mode="uniform"),
+    )
+    scene.add(mesh)
+
+    snapshotter = PipelineSnapshotter(renderer, scene, mesh)
+
+    # Sanity check
+    snapshotter.check(shaders_same=True, pipelines_same=True, bindings_same=True)
+
+    # Changing to another opaque color does not invoke a change for the pipeline
+    mesh.material.color = (0, 1, 0)
+    snapshotter.check(shaders_same=True, pipelines_same=True, bindings_same=True)
+
+    # Named colours should be opaque too
+    mesh.material.color = "red"
+    snapshotter.check(shaders_same=True, pipelines_same=True, bindings_same=True)
+
+    # Using a transparent color does require a change, bc it needs a shader for the transparency pass
+    mesh.material.color = (1, 1, 0, 0.5)
+    snapshotter.check(shaders_same=False, pipelines_same=False, bindings_same=True)
+
+    # Going back to a transparent color does NOT invoke a change, because the shader's still there
+    mesh.material.color = "red"
+    snapshotter.check(shaders_same=True, pipelines_same=True, bindings_same=True)
+
+
+def test_updating_mesh_material_opacity():
+
+    renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(), blend_mode="ordered2")
+    scene = gfx.Scene()
+
+    # Create a mesh
+    mesh = gfx.Mesh(
+        gfx.box_geometry(200, 200, 200),
+        gfx.MeshPhongMaterial(color=(1, 0, 0), color_mode="uniform"),
+    )
+    scene.add(mesh)
+
+    snapshotter = PipelineSnapshotter(renderer, scene, mesh)
+
+    # Sanity check
+    snapshotter.check(shaders_same=True, pipelines_same=True, bindings_same=True)
+
+    # Making the mesh transparent does require a change, bc it needs a shader for the transparency pass
+    mesh.material.opacity = 0.5
+    snapshotter.check(shaders_same=False, pipelines_same=False, bindings_same=True)
+
+    # Going back to a transparent color does NOT invoke a change, because the shader's still there
+    mesh.material.opacity = 1
+    snapshotter.check(shaders_same=True, pipelines_same=True, bindings_same=True)
+
+
+def test_updating_mesh_geometry_color():
+
+    renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(), blend_mode="ordered2")
+    scene = gfx.Scene()
+
+    # Create a mesh
+    mesh = gfx.Mesh(
+        gfx.box_geometry(200, 200, 200),
+        gfx.MeshPhongMaterial(color_mode="vertex"),
+    )
+    mesh.geometry.colors = gfx.Buffer(np.random.uniform(size=(24, 3)).astype("f4"))
+    scene.add(mesh)
+
+    snapshotter = PipelineSnapshotter(renderer, scene, mesh)
+
+    # Changing to a new set of colors only changes the bindings
+    mesh.geometry.colors = gfx.Buffer(np.random.uniform(size=(24, 3)).astype("f4"))
+    snapshotter.check(shaders_same=True, pipelines_same=True, bindings_same=False)
+
+    # Changing to transparent colors invokes a shader recompile
+    mesh.geometry.colors = gfx.Buffer(np.random.uniform(size=(24, 4)).astype("f4"))
+    snapshotter.check(shaders_same=False, pipelines_same=False, bindings_same=False)
+
+    # This is not because an alpha channel was added; also happens for grayscale
+    mesh.geometry.colors = gfx.Buffer(np.random.uniform(size=(24, 1)).astype("f4"))
+    snapshotter.check(shaders_same=False, pipelines_same=False, bindings_same=False)


### PR DESCRIPTION
Closes #682

* [x] Store value of `buffer.format` at `buffer._store.format`, so its value can be tracked.
* [x] In the shaders, avoid using `buffer.data.shape`, but use (in this case) `buffer.format` instead, so it is tracked.
* [x] Add a `nchannels_from_format` utility function for this purpose. 
* [x] In `pipelines.py`, the update path ends sooner by tracking whether the objects are up-to-date for a specific environment much earlier.
* [x] Also call `environment.register_pipeline_container()` earlier. This puts the environment-handling together, and out of the rest of the logic.
* [x] When an update *does* proceed, it iterates just a bit deeper, checking for each pass whether a shader must be compiled and/or pipeline must be composed. *This is the heart of the fix.*

Consider the scenario where an object goes from fully opaque to fully transparent, i.e. needing only a pipeline for the opaque pass vs only needing a pipeline for the transparent pass. There are two ways to make this work:
* Invalidate the whole set of pipelines (all passes).
* Fill in missing pipelines.

I went with the second option. It may cause having pipeline objects that are not actually used, but it prevents repeated shader compilation when i.e. the transparency of an object is changed to highlight it.