### PR TITLE
Prevent error message about id when passing invalid args to a wobject

### DIFF
--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -62,9 +62,10 @@ class IdProvider:
 
     def release_id(self, wobject, id):
         """Release an id associated with a wobject."""
-        with self._lock:
-            self._ids_in_use.discard(id)
-            self._map.pop(id, None)
+        if id > 0:
+            with self._lock:
+                self._ids_in_use.discard(id)
+                self._map.pop(id, None)
 
     def get_object_from_id(self, id):
         """Return the wobject associated with an id, or None."""
@@ -128,6 +129,8 @@ class WorldObject(EventTarget, RootTrackable):
     """
 
     _FORWARD_IS_MINUS_Z = False  # Default is +Z (lights and cameras use -Z)
+
+    _id = 0
 
     # The uniform type describes the structured info for this object, which represents
     # every "property" that a renderer would need to know in order to visualize it.


### PR DESCRIPTION
I accidentally wrote:
```py
line = gfx.Line(gfx.box_geometry(300, 300, 300), gfx.LineMaterial(aa=False), map=gfx.cm.viridis)
```
And got:

```
>>> (executing cell "" (line 32 of "tmp.py"))
Exception ignored in: <function WorldObject.__del__ at 0x107276b60>
Traceback (most recent call last):
  File "/Users/almar/dev/py/pygfx/pygfx/objects/_base.py", line 202, in __del__
    id_provider.release_id(self, self.id)
                                 ^^^^^^^
  File "/Users/almar/dev/py/pygfx/pygfx/objects/_base.py", line 229, in id
    return self._id
           ^^^^^^^^
AttributeError: 'Line' object has no attribute '_id'
Traceback (most recent call last):
  File "/Users/almar/dev/py/tmp.py", line 57, in <module>
    line = gfx.Line(gfx.box_geometry(300, 300, 300), gfx.LineMaterial(aa=False), map=gfx.cm.viridis)
TypeError: WorldObject.__init__() got an unexpected keyword argument 'map'
```

The actual error is obfuscated by a weird error about `self._id` not existing. This PR fixes that.