### PR TITLE
Update image_plus_points to demostrate variable point sizes

### DIFF
--- a/examples/feature_demo/image_plus_points.py
+++ b/examples/feature_demo/image_plus_points.py
@@ -11,6 +11,7 @@ Show an image with points overlaid.
 import imageio.v3 as iio
 from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
+import numpy as np
 
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -30,10 +31,19 @@ scene.add(image)
 
 xx = [182, 180, 161, 153, 191, 237, 293, 300, 272, 267, 254]
 yy = [145, 131, 112, 59, 29, 14, 48, 91, 136, 137, 172]
+sizes = np.arange(1, len(xx) + 1, dtype=np.float32)
 
 points = gfx.Points(
-    gfx.Geometry(positions=[(x, y, 1) for x, y in zip(xx, yy)]),
-    gfx.PointsMaterial(color=(0, 1, 1, 1), size=10),
+    gfx.Geometry(
+        positions=[(x, y, 1) for x, y in zip(xx, yy)],
+        sizes=sizes,
+    ),
+    gfx.PointsMaterial(
+        color=(0, 1, 1, 1),
+        size=10,
+        size_space="world",
+        size_mode="vertex",
+    ),
 )
 scene.add(points)
 


### PR DESCRIPTION
In doing this I also noticed a bug in the shader where as you zoom in (alot) the points start to "shake".

I tried to screen capture.

Play the example, then zoom into an edge of the point.

[Screencast from 2024-03-28 09-28-11.webm](https://github.com/pygfx/pygfx/assets/90008/c1cc489f-0b76-4dc3-a696-3c67caa4db79)

<details><summary>setup info</summary>

```

################ system:

             platform:  Linux-6.5.0-26-generic-x86_64-with-glibc2.38
python_implementation:  CPython
               python:  3.10.13

################ versions:

    wgpu:  0.15.0
    cffi:  1.16.0
 PySide6:  6.6.2
   numpy:  1.26.4
   pygfx:  0.1.18
pylinalg:  0.4.1

################ wgpu_native_info:

expected_version:  0.19.3.1
     lib_version:  0.19.3.1
        lib_path:  libwgpu_native.so

################ object_counts:

                      count  resource_mem

            Adapter:      1
          BindGroup:      0
    BindGroupLayout:      0
             Buffer:      2            40
      CanvasContext:      1
      CommandBuffer:      0
     CommandEncoder:      0
 ComputePassEncoder:      0
    ComputePipeline:      0
             Device:      1
     PipelineLayout:      0
           QuerySet:      0
              Queue:      1
       RenderBundle:      0
RenderBundleEncoder:      0
  RenderPassEncoder:      0
     RenderPipeline:      0
            Sampler:      0
       ShaderModule:      0
            Texture:      0
        TextureView:      0

              total:      6            40

################ wgpu_native_counts:

                  count    mem  backend   a  k  r  e  el_size

        Adapter:      1  1.98K   vulkan:  1  1  0  0    1.98K
      BindGroup:      0      0   vulkan:  0  0  0  0      368
BindGroupLayout:      0      0   vulkan:  0  0  0  0      320
         Buffer:      2    592   vulkan:  2  2  0  0      296
  CanvasContext:      1    160            1  1  0  0      160
  CommandBuffer:      0      0   vulkan:  0  0  0  0    1.28K
ComputePipeline:      0      0   vulkan:  0  0  0  0      288
         Device:      1  11.9K   vulkan:  1  1  0  0    11.9K
 PipelineLayout:      0      0   vulkan:  0  0  0  0      200
       QuerySet:      0      0   vulkan:  0  0  0  0       80
          Queue:      1    184   vulkan:  1  1  0  0      184
   RenderBundle:      0      0   vulkan:  0  0  0  0      848
 RenderPipeline:      0      0   vulkan:  0  0  0  0      560
        Sampler:      0      0   vulkan:  0  0  0  0       80
   ShaderModule:      0      0   vulkan:  0  0  0  0      800
        Texture:      0      0   vulkan:  0  0  0  0      824
    TextureView:      0      0   vulkan:  0  0  0  0      248

          total:      6  14.8K

    * The a, k, r, e are allocated, kept, released, and error, respectively.
    * Reported memory does not include buffer/texture data.

################ pygfx_adapter_info:

      vendor:  Intel open-source Mesa driver
architecture:
      device:  Intel(R) Xe Graphics (TGL GT2)
 description:  Mesa 23.2.1-1ubuntu3.1
adapter_type:  IntegratedGPU
backend_type:  Vulkan

################ pygfx_features:

                                       adapter  device

                  bgra8unorm-storage:        ✓       -
               depth32float-stencil8:        ✓       -
                  depth-clip-control:        ✓       -
                  float32-filterable:        ✓       ✓
             indirect-first-instance:        ✓       -
            rg11b10ufloat-renderable:        ✓       -
                          shader-f16:        ✓       -
            texture-compression-astc:        ✓       -
              texture-compression-bc:        ✓       -
            texture-compression-etc2:        ✓       -
                     timestamp-query:        ✓       -
                   MultiDrawIndirect:        ✓       -
              MultiDrawIndirectCount:        ✓       -
                       PushConstants:        ✓       -
TextureAdapterSpecificFormatFeatures:        ✓       -
               VertexWritableStorage:        ✓       -

################ pygfx_limits:

                                                  adapter  device

                                max_bind_groups:        8       8
            max_bind_groups_plus_vertex_buffers:        0       0
                    max_bindings_per_bind_group:    1.00K   1.00K
                                max_buffer_size:    2.14G   2.14G
          max_color_attachment_bytes_per_sample:        0       0
                          max_color_attachments:        0       0
          max_compute_invocations_per_workgroup:    1.02K   1.02K
                   max_compute_workgroup_size_x:    1.02K   1.02K
                   max_compute_workgroup_size_y:    1.02K   1.02K
                   max_compute_workgroup_size_z:    1.02K   1.02K
             max_compute_workgroup_storage_size:    65.5K   65.5K
           max_compute_workgroups_per_dimension:    65.5K   65.5K
max_dynamic_storage_buffers_per_pipeline_layout:        8       8
max_dynamic_uniform_buffers_per_pipeline_layout:        8       8
              max_inter_stage_shader_components:      116     116
               max_inter_stage_shader_variables:        0       0
          max_sampled_textures_per_shader_stage:    65.5K   65.5K
                  max_samplers_per_shader_stage:    65.5K   65.5K
                max_storage_buffer_binding_size:    2.14G   2.14G
           max_storage_buffers_per_shader_stage:    65.5K   65.5K
          max_storage_textures_per_shader_stage:    65.5K   65.5K
                       max_texture_array_layers:    2.04K   2.04K
                        max_texture_dimension1d:    16.3K   16.3K
                        max_texture_dimension2d:    16.3K   16.3K
                        max_texture_dimension3d:    2.04K   2.04K
                max_uniform_buffer_binding_size:    1.07G   1.07G
           max_uniform_buffers_per_shader_stage:       64      64
                          max_vertex_attributes:       29      29
                 max_vertex_buffer_array_stride:    4.09K   4.09K
                             max_vertex_buffers:       16      16
            min_storage_buffer_offset_alignment:       32      32
            min_uniform_buffer_offset_alignment:       64      64

################ pygfx_caches:

                    count  hits  misses

full_quad_objects:      0     0       0
 mipmap_pipelines:      0     0       0
          layouts:      0     0       0
         bindings:      0     0       0
   shader_modules:      0     0       0
        pipelines:      0     0       0
 shadow_pipelines:      0     0       0

################ pygfx_resources:

Texture:  6
 Buffer:  39

```
</details>