### PR TITLE
Updated wx rotating cube example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ venv.bak/
 
 glTF-Sample-Models
 reactive_rendering_state.pkl
+
+# jetbrains idea
+.idea/

--- a/examples/other/cube_wx.py
+++ b/examples/other/cube_wx.py
@@ -8,11 +8,11 @@ Example showing a single geometric cube.
 # sphinx_gallery_pygfx_docs = 'code'
 # sphinx_gallery_pygfx_test = 'off'
 
-import pygfx as gfx
-
+import pylinalg as la
 import wx
 from wgpu.gui.wx import WgpuCanvas
 
+import pygfx as gfx
 
 app = wx.App()
 
@@ -27,15 +27,18 @@ cube = gfx.Mesh(
 scene.add(cube)
 
 scene.add(gfx.AmbientLight())
-scene.add(gfx.DirectionalLight(position=(0, 0, 1)))
+
+directional_light = gfx.DirectionalLight()
+directional_light.world.position = (0, 0, 1)
+scene.add(directional_light)
 
 camera = gfx.PerspectiveCamera(70, 16 / 9)
-camera.position.z = 400
+camera.world.position = (0, 0, 400)
 
 
 def animate():
-    rot = gfx.linalg.Quaternion().set_from_euler(gfx.linalg.Euler(0.005, 0.01))
-    cube.rotation.multiply(rot)
+    rot = la.quat_from_euler((0.005, 0.01), order="XY")
+    cube.local.rotation = la.quat_mul(rot, cube.local.rotation)
 
     renderer.render(scene, camera)
     canvas.request_draw()


### PR DESCRIPTION
This PR updates the [cube_wx.py](https://github.com/pygfx/pygfx/blob/main/examples/other/cube_wx.py) example to be compatible with the most recent version of pygfx (world / local position, readonly vectors and so on). To be able to test it, I had to include the wgpu package, where the following PR has been applied: https://github.com/pygfx/wgpu-py/pull/486

Now everything works as expected (currently tested on MacOS):

<img width="637" alt="image" src="https://github.com/pygfx/pygfx/assets/5220162/03b2bb32-dee3-447d-9b68-b5b43e971bfd">
