### PR TITLE
Improve trimesh conversion

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -122,6 +122,7 @@ Currently this includes the following classes, which comprise the public API:
     ~pygfx.utils.color.Color
     ~pygfx.utils.load.load_mesh
     ~pygfx.utils.load.load_meshes
+    ~pygfx.utils.load.load_scene
     ~pygfx.utils.show.show
     ~pygfx.utils.show.Display
     ~pygfx.utils.viewport.Viewport

--- a/examples/feature_demo/aomap.py
+++ b/examples/feature_demo/aomap.py
@@ -41,7 +41,7 @@ import pygfx as gfx
 canvas = WgpuCanvas(size=(1200, 400), title="aomap")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
-meshes = gfx.load_meshes(model_dir / "lightmap" / "scene.gltf")
+meshes = gfx.load_mesh(model_dir / "lightmap" / "scene.gltf")
 
 ao_map = iio.imread(model_dir / "lightmap" / "lightmap-ao-shadow.png")
 ao_map_tex = gfx.Texture(ao_map, dim=2)

--- a/examples/feature_demo/lightmap.py
+++ b/examples/feature_demo/lightmap.py
@@ -40,7 +40,7 @@ import pygfx as gfx
 canvas = WgpuCanvas(size=(1200, 400), title="lightmap")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
-meshes = gfx.load_meshes(model_dir / "lightmap" / "scene.gltf")
+meshes = gfx.load_mesh(model_dir / "lightmap" / "scene.gltf")
 
 light_map = iio.imread(model_dir / "lightmap" / "lightmap-ao-shadow.png")
 light_map_tex = gfx.Texture(light_map, dim=2)

--- a/examples/feature_demo/pbr.py
+++ b/examples/feature_demo/pbr.py
@@ -58,7 +58,7 @@ scene.add(background)
 # Load meshes, and apply env map
 # Note that this lights the helmet already
 gltf_path = model_dir / "DamagedHelmet" / "glTF" / "DamagedHelmet.gltf"
-meshes = gfx.load_meshes(gltf_path)
+meshes = gfx.load_mesh(gltf_path)
 scene.add(*meshes)
 m = meshes[0]  # this example has just one mesh
 m.geometry.texcoords1 = m.geometry.texcoords  # use second set of texcoords for ao map

--- a/examples/feature_demo/show_stl.py
+++ b/examples/feature_demo/show_stl.py
@@ -33,8 +33,8 @@ except NameError:
 import pygfx as gfx
 
 
-mesh = gfx.load_mesh(model_dir / "teapot.stl")
+meshes = gfx.load_mesh(model_dir / "teapot.stl")
 
 if __name__ == "__main__":
     disp = gfx.Display()
-    disp.show(mesh, up=(0, 0, 1))
+    disp.show(meshes[0], up=(0, 0, 1))

--- a/examples/other/sponza_scene.py
+++ b/examples/other/sponza_scene.py
@@ -55,7 +55,7 @@ def configure(obj):
 
 
 # Load scene
-scene.add(*gfx.load_meshes(gltf_path.as_posix()))
+scene.add(*gfx.load_mesh(gltf_path.as_posix()))
 scene.traverse(configure)
 
 # Add ambient light

--- a/pygfx/geometries/_compat.py
+++ b/pygfx/geometries/_compat.py
@@ -43,6 +43,8 @@ def geometry_from_trimesh(mesh):
         kwargs["texcoords"] = np.ascontiguousarray(wgpu_uv, dtype="f4")
     elif mesh.visual.kind == "vertex":
         kwargs["colors"] = np.ascontiguousarray(mesh.visual.vertex_colors, dtype="f4")
+    elif mesh.visual.kind == "face":
+        kwargs["colors"] = np.ascontiguousarray(mesh.visual.face_colors, dtype="f4")
 
     # todo: support vertex attribute 'tangent'
 

--- a/pygfx/geometries/_compat.py
+++ b/pygfx/geometries/_compat.py
@@ -30,7 +30,8 @@ def geometry_from_trimesh(mesh):
         indices=np.ascontiguousarray(mesh.faces, dtype="i4"),
         normals=np.ascontiguousarray(mesh.vertex_normals, dtype="f4"),
     )
-    if mesh.visual.kind == "texture":
+    # Note: some trimesh visuals have type texture but no UV coordinates
+    if mesh.visual.kind == "texture" and getattr(mesh.visual, "uv", None) is not None:
         # convert the uv coordinates from opengl to wgpu conventions.
         # wgpu uses the D3D and Metal coordinate systems.
         # the coordinate origin is in the upper left corner, while the opengl coordinate

--- a/pygfx/materials/_compat.py
+++ b/pygfx/materials/_compat.py
@@ -131,15 +131,15 @@ def material_from_trimesh(x):
         # also be undefined in which case it's just a default material
         gfx_material = MeshPhongMaterial(color=x.main_color / 255)
 
-        gfx_material.shininess = x.defaults['material_shine']
-        gfx_material.specular = Color(*(x.defaults['material_specular'] / 255))
+        gfx_material.shininess = x.defaults["material_shine"]
+        gfx_material.specular = Color(*(x.defaults["material_specular"] / 255))
 
         gfx_material.side = "FRONT"
 
-        if x.kind == 'vertex':
-            gfx_material.color_mode = 'vertex'
-        elif x.kind == 'face':
-            gfx_material.color_mode = 'face'
+        if x.kind == "vertex":
+            gfx_material.color_mode = "vertex"
+        elif x.kind == "face":
+            gfx_material.color_mode = "face"
     else:
         raise NotImplementedError(f"Conversion of {type(x)} is not supported.")
 

--- a/pygfx/materials/_compat.py
+++ b/pygfx/materials/_compat.py
@@ -121,7 +121,8 @@ def material_from_trimesh(x):
         gfx_material.shininess = material.glossiness
         gfx_material.specular = Color(*(material.specular / 255))
 
-        if hasattr(material, "image"):
+        # Note: `material.image` can exist but be None
+        if getattr(material, "image", None):
             gfx_material.map = texture_from_pillow_image(material.image)
 
         gfx_material.side = "FRONT"

--- a/pygfx/materials/_compat.py
+++ b/pygfx/materials/_compat.py
@@ -31,6 +31,10 @@ def texture_from_pillow_image(image, dim=2, **kwargs):
     if not isinstance(image, Image):
         raise NotImplementedError()
 
+    # If this is a palette image, convert it to RGBA
+    if getattr(image, "mode", None) == "P":
+        image = image.convert("RGBA")
+
     m = memoryview(image.tobytes())
 
     im_channels = len(image.getbands())

--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -10,6 +10,7 @@ Utility functions for pygfx.
     Color
     load.load_mesh
     load.load_meshes
+    load.load_scene
     show.show
     show.Display
     viewport.Viewport

--- a/pygfx/utils/load.py
+++ b/pygfx/utils/load.py
@@ -11,12 +11,14 @@ from importlib.util import find_spec
 def load_meshes(path, remote_ok=False):
     """Load meshes from a file.
 
+    Deprecated: use load_mesh() instead.
+
     Parameters
     ----------
     path : str
         The location where the mesh is stored.
     remote_ok : bool
-        Whether to allow loading meshes from URLs, by default False.
+        Whether to allow loading meshes from URLs. Default is False.
 
     Returns
     -------
@@ -38,7 +40,7 @@ def load_mesh(path, remote_ok=False):
         The location where the mesh or scene is stored.
         Can be a local file path or a URL.
     remote_ok : bool
-        Whether to allow loading meshes from URLs, by default False.
+        Whether to allow loading meshes from URLs. Default is False.
 
     Returns
     -------
@@ -102,13 +104,13 @@ def load_scene(
         The filepath. Can be a local file or a URL.
     flatten : bool
         If True, will ignore any hierarchical structure in the scene graph and
-        instead import as a flat list of objects.
+        instead import as a flat list of objects. Default is False.
     meshes : bool
-        Whether to load meshes.
+        Whether to load meshes. Default is True.
     materials : bool
-        Whether to load materials.
+        Whether to load materials. Default is True.
     volumes : bool
-        Whether to load 3D image volumes.
+        Whether to load 3D image volumes. Default is True.
     lights :  "auto" | "file" | "none"
         Whether to import lights. "auto" (default) will always add lights to the scene
         even if the file does not contain any; "file" will import only lights defined in
@@ -118,7 +120,7 @@ def load_scene(
         even if the file does not contain any; "file" will import only cameras defined in
         the file; "none" will not add any cameras to the scene.
     remote_ok : bool
-        Whether to allow loading files from URLs, by default False.
+        Whether to allow loading files from URLs. Default is False.
 
     Returns
     -------
@@ -180,9 +182,9 @@ def meshes_from_trimesh(scene, materials=True, apply_transforms=True):
     scene : trimesh.Scene
         The scene to convert.
     materials : bool
-        Whether to import materials. If False, a default material will be created.
+        Whether to import materials. If False, a standard material will be created. Default is True.
     apply_transforms : bool
-        Whether to apply the scene graph transforms directly to the meshes, by default True.
+        Whether to apply the scene graph transforms directly to the meshes. Default is True.
 
     Returns
     -------
@@ -294,13 +296,13 @@ def scene_from_trimesh(
         A trimesh Scene.
     flatten : bool
         If True, will ignore any hierarchical structure in the scene graph and
-        instead import as a flat list of objects.
+        instead import as a flat list of objects. Default is False.
     meshes : bool
-        Whether to import meshes.
+        Whether to import meshes. Default is True.
     materials : bool
-        Whether to import materials.
+        Whether to import materials. Default is True.
     volumes : bool
-        Whether to load 3D image volumes.
+        Whether to load 3D image volumes. Default is True.
     lights :  "auto" | "file" | "none"
         Whether to import lights. "auto" (default) will always add lights to the scene
         even if the file does not contain any; "file" will import only lights defined in
@@ -311,7 +313,7 @@ def scene_from_trimesh(
         the file; "none" will not add any cameras to the scene.
     background : bool
         Trimesh scenes typically have a white background. If True, we will add a white background
-        to the pygfx scene. If False, no background will be added.
+        to the pygfx scene. If False, no background will be added. Default is True.
 
     Returns
     -------
@@ -507,10 +509,6 @@ def _volume_from_voxelgrid(vxl, cmap=None, clim="data"):
     ----------
     vxl : trimesh.voxels.VoxelGrid
         The voxel grid to convert.
-    camera : bool
-        Whether to add camera to the scene.
-    lights : "bool
-        Whether to add lights to the scene.
     cmap : pygfx.Texture, optional
         The colormap to use. If None, this will default to `pygfx.cm.viridis`.
     clim : "data" | "dtype" | tuple | None

--- a/pygfx/utils/load.py
+++ b/pygfx/utils/load.py
@@ -287,10 +287,8 @@ def scene_from_trimesh(
     # while lights and cameras are stored separate from 'world'.
     if meshes:
         if not flatten:
-            # By convention, we expect the "world" objects to be the root of the scene graph
+            # Use the graph representation of the scene - easier to handle
             G = tm_scene.graph.to_networkx()
-            if "world" not in G.nodes:
-                raise ValueError("No 'world' node found in scene graph")
 
             # Load the geometries and materials
             gfx_geometries, gfx_materials = objects_from_trimesh(
@@ -346,8 +344,9 @@ def scene_from_trimesh(
                             node_group.add(mesh)
 
             # Recursively build the scene graph
-            gfx_scene.local.matrix = tm_scene.graph["world"][0]
-            _build_graph_bfs("world", gfx_scene)  # start at the root node
+            world = tm_scene.graph.base_frame
+            gfx_scene.local.matrix = tm_scene.graph[world][0]
+            _build_graph_bfs(world, gfx_scene)  # start at the root node
         # Just add the flat meshes
         else:
             # If we're flattening the scene graph, we'll just

--- a/pygfx/utils/load.py
+++ b/pygfx/utils/load.py
@@ -41,6 +41,7 @@ def load_meshes(path):
     ----------
     path : str
         The location where the mesh or scene is stored.
+        Can be a local file path or a URL.
 
     Returns
     -------
@@ -48,29 +49,52 @@ def load_meshes(path):
         A list of loaded meshes.
 
     """
-
     import trimesh  # noqa
 
-    scene = trimesh.load(path)
+    # Trimesh's load() performs a similar check and refers
+    # loading from URLs to load_remote()
+    if "https://" in str(path) or "http://" in str(path):
+        scene = trimesh.load_remote(path)
+    else:
+        scene = trimesh.load(path)
+
+    # If this is a single object we can just convert and return it
     if isinstance(scene, trimesh.Trimesh):
         m = gfx.Mesh(
             gfx.geometry_from_trimesh(scene),
             gfx.MeshPhongMaterial(),
         )
         return [m]
-
+    # If this is a scene, we need to properly parse it
     elif isinstance(scene, trimesh.Scene):
+        # Scene consists of geometries (which in trimesh contain both
+        # the vertices/faces as well as the mateiral) and a scene graph.
+        # Each node in the graph consists of a geometry and a transform
+        # A geometry can be used by more than one node in the graph.
+        # Here we will convert each node in the graph to a pygfx.Mesh
+        # but in the future it might be better to use pygfx.InstancedMesh.
+        gfx_geometries = {}
+        gfx_materials = {}
+        meshes = []
         for node_name in scene.graph.nodes_geometry:
             transform, geometry_name = scene.graph[node_name]
-            current = scene.geometry[geometry_name]
-            current.apply_transform(transform)
 
-        return [
-            gfx.Mesh(
-                gfx.geometry_from_trimesh(m),
-                gfx.material_from_trimesh(m.visual.material),
-            )
-            for m in scene.geometry.values()
-        ]
+            # Convert each geometry only once
+            if geometry_name not in gfx_geometries:
+                m = scene.geometry[geometry_name]
+                gfx_geometries[geometry_name] = gfx.geometry_from_trimesh(m)
+                if hasattr(m.visual, "material"):
+                    gfx_materials[geometry_name] = gfx.material_from_trimesh(
+                        m.visual.material
+                    )
+                else:
+                    gfx_materials[geometry_name] = gfx.MeshStandardMaterial()
+
+            # Generate a visual for each node
+            mesh = gfx.Mesh(gfx_geometries[geometry_name], gfx_materials[geometry_name])
+            mesh.local.matrix = transform  # set the node's transform
+
+            meshes.append(mesh)
+        return meshes
     else:
         raise ValueError(f"Unexpected trimesh data: {scene.__class__.__name__}")

--- a/pygfx/utils/load.py
+++ b/pygfx/utils/load.py
@@ -5,26 +5,23 @@ Utilities to load scenes from files, using trimesh.
 import pygfx as gfx
 
 
-def load_scene(path):
-    raise DeprecationWarning(
-        "The load_scene() function is replaced with load_meshes()."
-    )
-
-
-def load_mesh(path):
+def load_mesh(path, remote_ok=False):
     """Load a mesh from a file.
 
     Parameters
     ----------
     path : str
         The location where the mesh is stored.
+    remote_ok : bool
+        Whether to allow loading meshes from URLs, by default False.
 
     Returns
     -------
     mesh : Mesh
         A pygfx Mesh object. If the file does not contain exactly one mesh, an error is raised.
+
     """
-    meshes = load_meshes(path)
+    meshes = load_meshes(path, remote_ok=remote_ok)
     if len(meshes) != 1:
         raise ValueError(
             f"Found {len(meshes)} meshes instead of 1 in '{path}'. Use `load_meshes()` instead. "
@@ -50,6 +47,11 @@ def load_meshes(path, remote_ok=False):
     meshes : list
         A list of loaded meshes.
 
+    See Also
+    --------
+    load_scene
+        Loads the entire scene (lights, graph, etc.) from a file.
+
     """
     import trimesh  # noqa
 
@@ -65,11 +67,73 @@ def load_meshes(path, remote_ok=False):
     else:
         scene = trimesh.load(path)
 
+    return meshes_from_trimesh(scene, apply_transforms=True)
+
+
+def load_scene(path, remote_ok=False):
+    """Load file into a scene.
+
+    This function requires the trimesh library.
+
+    Parameters
+    ----------
+    path : str
+        The location where the mesh or scene is stored.
+        Can be a local file path or a URL.
+    remote_ok : bool
+        Whether to allow loading files from URLs, by default False.
+
+    Returns
+    -------
+    scene : pygfx.Scene
+        The loaded scene.
+
+    See Also
+    --------
+    load_meshes
+        Returns the flat meshes contained in a file.
+
+    """
+    import trimesh  # noqa
+
+    # Trimesh's load() performs a similar check and refers
+    # loading from URLs to load_remote()
+    if "https://" in str(path) or "http://" in str(path):
+        if not remote_ok:
+            raise ValueError(
+                "Loading scenes from URLs is disabled. "
+                "Set remote_ok=True to allow loading from URLs."
+            )
+        tm_scene = trimesh.load_remote(path)
+    else:
+        tm_scene = trimesh.load(path)
+
+    return scene_from_trimesh(tm_scene)
+
+
+def meshes_from_trimesh(scene, apply_transforms=True):
+    """Converts a trimesh scene into a flat list of pygfx Mesh objects.
+
+    Parameters
+    ----------
+    scene : trimesh.Scene
+        The scene to convert.
+    apply_transforms : bool
+        Whether to apply the scene graph transforms directly to the meshes, by default True.
+
+    Returns
+    -------
+    meshes : list
+        A list of loaded meshes.
+
+    """
+    import trimesh  # noqa
+
     # If this is a single object we can just convert and return it
     if isinstance(scene, trimesh.Trimesh):
         m = gfx.Mesh(
             gfx.geometry_from_trimesh(scene),
-            gfx.MeshPhongMaterial(),
+            gfx.material_from_trimesh(scene.visual.material),
         )
         return [m]
     # If this is a scene, we need to properly parse it
@@ -80,28 +144,193 @@ def load_meshes(path, remote_ok=False):
         # A geometry can be used by more than one node in the graph.
         # Here we will convert each node in the graph to a pygfx.Mesh
         # but in the future it might be better to use pygfx.InstancedMesh.
-        gfx_geometries = {}
-        gfx_materials = {}
+
+        # Extract the geometries and materials
+        gfx_geometries, gfx_materials = objects_from_trimesh(scene)
+
+        # Generate a visual for each node
         meshes = []
         for node_name in scene.graph.nodes_geometry:
             transform, geometry_name = scene.graph[node_name]
 
-            # Convert each geometry only once
-            if geometry_name not in gfx_geometries:
-                m = scene.geometry[geometry_name]
-                gfx_geometries[geometry_name] = gfx.geometry_from_trimesh(m)
-                if hasattr(m.visual, "material"):
-                    gfx_materials[geometry_name] = gfx.material_from_trimesh(
-                        m.visual.material
-                    )
-                else:
-                    gfx_materials[geometry_name] = gfx.MeshStandardMaterial()
-
-            # Generate a visual for each node
             mesh = gfx.Mesh(gfx_geometries[geometry_name], gfx_materials[geometry_name])
-            mesh.local.matrix = transform  # set the node's transform
+
+            if apply_transforms:
+                mesh.local.matrix = transform  # set the node's transform
 
             meshes.append(mesh)
         return meshes
     else:
         raise ValueError(f"Unexpected trimesh data: {scene.__class__.__name__}")
+
+
+def objects_from_trimesh(scene):
+    """Extract geometries and materials from a trimesh scene.
+
+    Parameters
+    ----------
+    scene : trimesh.Scene
+        The scene to convert.
+
+    Returns
+    -------
+    gfx_geometries : dict
+        A dictionary of geometry objects. Keys are the names of the geometries.
+    gfx_materials : dict
+        A dictionary of material objects. Keys are the names of the geometries.
+
+    """
+    gfx_geometries = {}
+    gfx_materials = {}
+    for name, mesh in scene.geometry.items():
+        gfx_geometries[name] = gfx.geometry_from_trimesh(mesh)
+        # If mesh has a material, convert it
+        if hasattr(mesh.visual, "material"):
+            gfx_materials[name] = gfx.material_from_trimesh(mesh.visual.material)
+        # If not, create a default material
+        else:
+            gfx_materials[name] = gfx.MeshStandardMaterial()
+
+    return gfx_geometries, gfx_materials
+
+
+def scene_from_trimesh(tm_scene):
+    """Convert a trimesh scene into a pygfx scene.
+
+    Parameters
+    ----------
+    tm_scene : trimesh.Scene
+        A trimesh Scene.
+
+    Returns
+    -------
+    scene : pygfx.Scene
+        The scene converted to pygfx.
+
+    """
+    import trimesh  # noqa
+
+    # Basic scene setup
+    gfx_scene = gfx.Scene()
+    camera = gfx.PerspectiveCamera()
+    gfx_scene.add(camera)
+
+    # This will be populated later
+    gfx_lights = []
+
+    if isinstance(tm_scene, trimesh.Trimesh):
+        gfx_scene.add(*meshes_from_trimesh(tm_scene))
+        camera.show_object(gfx_scene)
+    elif isinstance(tm_scene, trimesh.Scene):
+        # By convention, we expect the "world" objects to be the root of the scene graph
+        G = tm_scene.graph.to_networkx()
+        if "world" not in G.nodes:
+            raise ValueError("No 'world' node found in scene graph")
+
+        # Load the geometries and materials
+        gfx_geometries, gfx_materials = objects_from_trimesh(tm_scene)
+
+        def _build_graph_bfs(node, node_group):
+            """Recursively parse scene graph into pygfx.Groups."""
+            # Note: not sure if that will ever happen in practice but
+            # in theory, this implementation could run into the recursion
+            # depth limit (3000 on my machine). If that turns out to be
+            # a problem we need to switch the implementation
+
+            # Go over this node's children
+            for child in tm_scene.graph.transforms.children.get(node, []):
+                # Generate a new graph for this child
+                child_group = gfx.Group()
+
+                # Set the child's transform
+                child_group.local.matrix = G.edges[(node, child)]["matrix"]
+
+                # See if this child has a geometry
+                geometry_name = G.edges[(node, child)].get("geometry", None)
+                if geometry_name is not None:
+                    # Add the geometry to the child
+                    child_group.add(
+                        gfx.Mesh(
+                            gfx_geometries[geometry_name], gfx_materials[geometry_name]
+                        )
+                    )
+
+                # Connect the child to the parent
+                node_group.add(child_group)
+
+                # Recurse ot this child's children
+                _build_graph_bfs(child, child_group)
+
+        # Recursively build the scene graph
+        gfx_scene.local.matrix = tm_scene.graph["world"][0]
+        _build_graph_bfs("world", gfx_scene)  # start at the root node
+
+        # Accessing the .camera attribute directly will create
+        # a camera if it doesn't exist, hence we check the
+        # `.has_camera` attribute.
+        # Also note that we're currently only using the
+        # camera's transform but not e.g. FOV or resolution
+        if tm_scene.has_camera:
+            camera.local.matrix = tm_scene.camera_transform
+        else:
+            # If not camera, make sure the camera actually looks
+            # at the objects in the scene
+            camera.show_object(gfx_scene)
+
+        # Parse lights. Similar to the camera, trimesh will create
+        # lights automatically if we access the `.lights` attribute
+        # directly.
+        if hasattr(tm_scene, "_lights"):
+            for light in tm_scene.lights:
+                if isinstance(light, trimesh.scene.lighting.PointLight):
+                    gfx_lights.append(gfx.PointLight())
+                    gfx_lights[-1].distance = light.radius
+                elif isinstance(light, trimesh.scene.lighting.DirectionalLight):
+                    gfx_lights.append(gfx.DirectionalLight())
+                elif isinstance(light, trimesh.scene.lighting.SpotLight):
+                    gfx_lights.append(gfx.SpotLight())
+                    gfx_lights[-1].distance = light.radius
+                    gfx_lights[-1].angle = light.outerConeAngle
+                else:
+                    # Skip unknown light types
+                    continue
+
+                # These properties are common to all light types
+                gfx_lights[-1].color = light.color / 255
+                gfx_lights[-1].intensity = light.intensity
+                gfx_lights[-1].local.matrix = tm_scene.graph[light.name][0]
+
+            gfx_scene.add(*gfx_lights)
+    else:
+        raise ValueError(f"Unexpected trimesh data: {type(tm_scene)}")
+
+    # If no lights (either because we loaded only a single Trimesh or because
+    # the scene didn't contain lights), make sure things are actually visible
+    if not gfx_lights:
+        # Add an ambient light
+        gfx_scene.add(gfx.AmbientLight())
+
+        # Get the scene bounding box
+        bbox = gfx_scene.get_bounding_box()
+
+        # Calculate extend (if no geometries, bbox will be None)
+        if bbox is not None:
+            extend = bbox[1] - bbox[0]
+
+            # Padd the bounding box
+            bbox[0, :] -= extend
+            bbox[1, :] += extend
+
+            # Add point lights at the corners of the (padded) bounding box
+            # This is ~ what trimesh does
+            # If we don't pad, things look odd if the mesh(es) are boxy or flat
+            for x, y, z in bbox:
+                light = gfx.PointLight()
+                (light.local.x, light.local.y, light.local.z) = (x, y, z)
+                gfx_scene.add(light)
+
+    # By default trimesh scenes have a white background
+    # while gfx.show() uses a black background
+    gfx_scene.add(gfx.Background(None, gfx.BackgroundMaterial((1, 1, 1))))
+
+    return gfx_scene

--- a/pygfx/utils/load.py
+++ b/pygfx/utils/load.py
@@ -32,7 +32,7 @@ def load_mesh(path):
     return meshes[0]
 
 
-def load_meshes(path):
+def load_meshes(path, remote_ok=False):
     """Load meshes from a file.
 
     This function requires the trimesh library.
@@ -42,6 +42,8 @@ def load_meshes(path):
     path : str
         The location where the mesh or scene is stored.
         Can be a local file path or a URL.
+    remote_ok : bool
+        Whether to allow loading meshes from URLs, by default False.
 
     Returns
     -------
@@ -54,6 +56,11 @@ def load_meshes(path):
     # Trimesh's load() performs a similar check and refers
     # loading from URLs to load_remote()
     if "https://" in str(path) or "http://" in str(path):
+        if not remote_ok:
+            raise ValueError(
+                "Loading meshes from URLs is disabled. "
+                "Set remote_ok=True to allow loading from URLs."
+            )
         scene = trimesh.load_remote(path)
     else:
         scene = trimesh.load(path)

--- a/pygfx/utils/load.py
+++ b/pygfx/utils/load.py
@@ -5,8 +5,8 @@ Utilities to load scenes from files, using trimesh.
 import pygfx as gfx
 
 
-def load_mesh(path, remote_ok=False):
-    """Load a mesh from a file.
+def load_meshes(path, remote_ok=False):
+    """Load meshes from a file.
 
     Parameters
     ----------
@@ -17,20 +17,15 @@ def load_mesh(path, remote_ok=False):
 
     Returns
     -------
-    mesh : Mesh
-        A pygfx Mesh object. If the file does not contain exactly one mesh, an error is raised.
+    meshes : list
+        A list of loaded meshes.
 
     """
-    meshes = load_meshes(path, remote_ok=remote_ok)
-    if len(meshes) != 1:
-        raise ValueError(
-            f"Found {len(meshes)} meshes instead of 1 in '{path}'. Use `load_meshes()` instead. "
-        )
-    return meshes[0]
+    raise DeprecationWarning("The load_meshes() function is replaced with load_mesh().")
 
 
-def load_meshes(path, remote_ok=False):
-    """Load meshes from a file.
+def load_mesh(path, remote_ok=False):
+    """Load mesh(es) from a file.
 
     This function requires the trimesh library.
 
@@ -45,7 +40,7 @@ def load_meshes(path, remote_ok=False):
     Returns
     -------
     meshes : list
-        A list of loaded meshes.
+        A list of pygfx.Meshes.
 
     See Also
     --------

--- a/pygfx/utils/load.py
+++ b/pygfx/utils/load.py
@@ -165,7 +165,7 @@ def meshes_from_trimesh(scene, materials=True, apply_transforms=True):
     if isinstance(scene, trimesh.Trimesh):
         m = gfx.Mesh(
             gfx.geometry_from_trimesh(scene),
-            gfx.material_from_trimesh(scene.visual.material),
+            gfx.material_from_trimesh(scene),
         )
         return [m]
     # If this is a scene, we need to properly parse it

--- a/pygfx/utils/load.py
+++ b/pygfx/utils/load.py
@@ -5,6 +5,8 @@ Utilities to load scenes from files, using trimesh.
 import pygfx as gfx
 import numpy as np
 
+from importlib.util import find_spec
+
 
 def load_meshes(path, remote_ok=False):
     """Load meshes from a file.
@@ -49,6 +51,11 @@ def load_mesh(path, remote_ok=False):
         Loads the entire scene (lights, graph, etc.) from a file.
 
     """
+    if not find_spec("trimesh"):
+        raise ImportError(
+            "The `trimesh` library is required to load meshes: pip install trimesh"
+        )
+
     import trimesh  # noqa
 
     # Trimesh's load() performs a similar check and refers
@@ -58,6 +65,10 @@ def load_mesh(path, remote_ok=False):
             raise ValueError(
                 "Loading meshes from URLs is disabled. "
                 "Set remote_ok=True to allow loading from URLs."
+            )
+        if not find_spec("httpx"):
+            raise ImportError(
+                "The `httpx` library is required to load meshes from URLs: pip install httpx"
             )
         scene = trimesh.load_remote(path)
     else:
@@ -120,6 +131,11 @@ def load_scene(
         Returns the flat meshes contained in a file.
 
     """
+    if not find_spec("trimesh"):
+        raise ImportError(
+            "The `trimesh` library is required to load scenes: pip install trimesh"
+        )
+
     if lights not in ("auto", "file", "none"):
         raise ValueError(f"Invalid value for `lights`: {lights}")
 
@@ -135,6 +151,11 @@ def load_scene(
             raise ValueError(
                 "Loading scenes from URLs is disabled. "
                 "Set remote_ok=True to allow loading from URLs."
+            )
+
+        if not find_spec("httpx"):
+            raise ImportError(
+                "The `httpx` library is required to load meshes from URLs: pip install httpx"
             )
         tm_scene = trimesh.load_remote(path)
     else:
@@ -298,6 +319,11 @@ def scene_from_trimesh(
         The scene converted to pygfx.
 
     """
+    if not find_spec("trimesh"):
+        raise ImportError(
+            "The `trimesh` library is required to load scenes: pip install trimesh"
+        )
+
     if lights not in ("auto", "file", "none"):
         raise ValueError(f"Invalid value for `lights`: {lights}")
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ extras_require = {
         "imageio",
         "psutil",
         "pyinstaller>=4",
+        "trimesh"
     ],
     "examples": [
         "pytest",

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ extras_require = {
         "psutil",
         "pyinstaller>=4",
         "trimesh",
-        "httpx",
-        "networkx"
+        "httpx"
     ],
     "examples": [
         "pytest",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ extras_require = {
         "psutil",
         "pyinstaller>=4",
         "trimesh",
-        "httpx"
+        "httpx",
+        "networkx"
     ],
     "examples": [
         "pytest",

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ extras_require = {
         "psutil",
         "pyinstaller>=4",
         "trimesh",
-        "httpx"
+        "httpx",
     ],
     "examples": [
         "pytest",

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ extras_require = {
         "imageio",
         "psutil",
         "pyinstaller>=4",
-        "trimesh"
+        "trimesh",
+        "httpx"
     ],
     "examples": [
         "pytest",

--- a/tests/utils/test_load.py
+++ b/tests/utils/test_load.py
@@ -9,7 +9,7 @@ FILES_TO_TEST = [
     "CesiumMilkTruck.glb",
     "nested.glb",
     "cube_blender_uv.ply",
-    "chair_model.binvox"
+    "chair_model.binvox",
 ]
 URLS = [f"{BASE_URL}/{file}" for file in FILES_TO_TEST]
 
@@ -32,7 +32,10 @@ def test_load_meshes(url):
 
 @pytest.mark.parametrize("url", URLS)
 @pytest.mark.parametrize("flatten", (True, False))
-def test_load_scenes(url, flatten, ):
+def test_load_scenes(
+    url,
+    flatten,
+):
     # Test loading scenes via trimesh
     mesh = gfx.load_scene(url, flatten=flatten, remote_ok=True)
 

--- a/tests/utils/test_load.py
+++ b/tests/utils/test_load.py
@@ -9,12 +9,20 @@ FILES_TO_TEST = [
     "CesiumMilkTruck.glb",
     "nested.glb",
     "cube_blender_uv.ply",
+    "chair_model.binvox"
 ]
 URLS = [f"{BASE_URL}/{file}" for file in FILES_TO_TEST]
 
 
 @pytest.mark.parametrize("url", URLS)
 def test_load_meshes(url):
+    # The .binvox format is expected to fail because trimesh
+    # loads it as VoxelGrid, not as a mesh
+    if url.endswith(".binvox"):
+        with pytest.raises(ValueError):
+            mesh = gfx.load_mesh(url, remote_ok=True)
+        return
+
     # Test loading meshes via trimesh
     mesh = gfx.load_mesh(url, remote_ok=True)
 

--- a/tests/utils/test_load.py
+++ b/tests/utils/test_load.py
@@ -5,10 +5,10 @@ import pygfx as gfx
 
 BASE_URL = "https://github.com/mikedh/trimesh/raw/main/models"
 FILES_TO_TEST = [
-            "wallhole.obj",
-            "CesiumMilkTruck.glb",
-            "nested.glb",
-            "cube_blender_uv.ply"
+    "wallhole.obj",
+    "CesiumMilkTruck.glb",
+    "nested.glb",
+    "cube_blender_uv.ply",
 ]
 URLS = [f"{BASE_URL}/{file}" for file in FILES_TO_TEST]
 
@@ -16,15 +16,16 @@ URLS = [f"{BASE_URL}/{file}" for file in FILES_TO_TEST]
 @pytest.mark.parametrize("url", URLS)
 def test_load_meshes(url):
     # Test loading meshes via trimesh
-    mesh = gfx.load_meshes(url, remote_ok=True)
+    mesh = gfx.load_mesh(url, remote_ok=True)
 
     assert isinstance(mesh, list)
     assert all([isinstance(m, gfx.Mesh) for m in mesh])
 
 
 @pytest.mark.parametrize("url", URLS)
-def test_load_scenes(url):
+@pytest.mark.parametrize("flatten", (True, False))
+def test_load_scenes(url, flatten, ):
     # Test loading scenes via trimesh
-    mesh = gfx.load_scene(url, remote_ok=True)
+    mesh = gfx.load_scene(url, flatten=flatten, remote_ok=True)
 
     assert isinstance(mesh, gfx.Scene)

--- a/tests/utils/test_load.py
+++ b/tests/utils/test_load.py
@@ -1,0 +1,30 @@
+import pytest
+
+import pygfx as gfx
+
+
+BASE_URL = "https://github.com/mikedh/trimesh/raw/main/models"
+FILES_TO_TEST = [
+            "wallhole.obj",
+            "CesiumMilkTruck.glb",
+            "nested.glb",
+            "cube_blender_uv.ply"
+]
+URLS = [f"{BASE_URL}/{file}" for file in FILES_TO_TEST]
+
+
+@pytest.mark.parametrize("url", URLS)
+def test_load_meshes(url):
+    # Test loading meshes via trimesh
+    mesh = gfx.load_meshes(url, remote_ok=True)
+
+    assert isinstance(mesh, list)
+    assert all([isinstance(m, gfx.Mesh) for m in mesh])
+
+
+@pytest.mark.parametrize("url", URLS)
+def test_load_scenes(url):
+    # Test loading scenes via trimesh
+    mesh = gfx.load_scene(url, remote_ok=True)
+
+    assert isinstance(mesh, gfx.Scene)


### PR DESCRIPTION
The purpose of this PR is to make the conversion from trimesh objects into pygfx Meshes more robust:
1. Trimesh scenes where geometries are used by multiple nodes are now correctly converted 
2. `material_from_trimesh` now also converts trimesh's `SimpleMaterials` 
3. `pygfx.load_meshes` now also works for remote sources (simply wrapping `trimesh.load_remote`)
4. Fixed a couple corner cases where the conversion would break before 

With these changes you can now do this:

```python
>>> import pygfx as gfx
>>> meshes = gfx.load_meshes("https://github.com/mikedh/trimesh/raw/main/models/CesiumMilkTruck.glb")
>>> scene = gfx.Scene()
>>> scene.add(*meshes)
>>> scene.add(*[gfx.AmbientLight(), gfx.PointLight()])
>>> gfx.show(scene)
```
<img width="752" alt="Screenshot 2024-04-03 at 16 45 03" src="https://github.com/pygfx/pygfx/assets/7161148/26172086-c4ed-4023-88ec-27aa956df394">

I have tried this with a couple of the [trimesh models](https://github.com/mikedh/trimesh/tree/main/models) and it seems to work across the board.

Two questions from my side:
1. Would you like to add tests for this?
2. Is there appetite for functionality to load the entire trimesh scene, i.e. including lights, camera, background, etc?
