### PR TITLE
Use the render_mask to control when the background shader is displayed

### DIFF
--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -55,10 +55,10 @@ class Background(WorldObject):
 
     """
 
-    def __init__(self, geometry=None, material=None, **kwargs):
+    def __init__(self, geometry=None, material=None, render_mask="opaque", **kwargs):
         if geometry is not None and material is None:
             raise TypeError("You need to instantiate using Background(None, material)")
-        super().__init__(None, material, **kwargs)
+        super().__init__(None, material, render_mask=render_mask, **kwargs)
 
 
 class Line(WorldObject):

--- a/pygfx/renderers/wgpu/shaders/backgroundshader.py
+++ b/pygfx/renderers/wgpu/shaders/backgroundshader.py
@@ -161,10 +161,6 @@ class BackgroundShader(WorldObjectShader):
             // We can apply clipping planes, but maybe a background should not be clipped?
             // apply_clipping_planes(in.world_pos);
 
-            $$ if not write_pick
-                if (true) { discard; }
-            $$ endif
-
             // This is the opaque pass.
             // A fragment of the background could be transparent, but it should still be
             // written in the opaque pass in order for it to really be background.


### PR DESCRIPTION
This was found in https://github.com/pygfx/pygfx/pull/704

It seems that write_pick was previously used a sentinel to detect the type of pass that was getting used.

It is currently defined as true when:

* BasePass
* OpaquePass
* FullOpaquePass
* SimpleSinglePass
* FrontmostTransparencyPass