### PR TITLE
Force lavapipe on local testing system when multiple GPUs are present

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -30,3 +30,15 @@ def numerical_exceptions():
     Preferably using local `with np.errstate(...)` constructs
     """
     np.seterr(all="raise")
+
+
+@pytest.fixture(autouse=True, scope="session")
+def force_llvm_adapter():
+    import wgpu
+    import pygfx as gfx
+    adapters = wgpu.gpu.enumerate_adapters()
+    adapters_llvm = [a for a in adapters if "llvmpipe" in a.summary.lower()]
+    if adapters_llvm:
+        gfx.renderers.wgpu.select_adapter(adapters_llvm[0])
+    else:
+        pytest.skip(reason="No LLVMpipe adapter found")

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -19,8 +19,6 @@ import numpy as np
 import pytest
 
 from examples.tests.testutils import (
-    wgpu_backend,
-    is_lavapipe,
     find_examples,
     ROOT,
     screenshots_dir,
@@ -49,13 +47,7 @@ logging.getLogger().addHandler(log_handler)
 
 
 # Initialize the device, to avoid Rust warnings from showing in the first example
-gfx.renderers.wgpu.get_shared()
-
-
-def test_that_we_are_on_lavapipe():
-    print(wgpu_backend)
-    if os.getenv("PYGFX_EXPECT_LAVAPIPE"):
-        assert is_lavapipe
+# gfx.renderers.wgpu.get_shared()
 
 
 def test_examples_meta():
@@ -104,7 +96,7 @@ def test_examples_run(module, force_offscreen):
 
 
 @pytest.mark.parametrize("module", examples_to_compare, ids=lambda x: x.stem)
-def test_examples_compare(module, pytestconfig, force_offscreen, mock_time, request):
+def test_examples_compare(module, pytestconfig, force_offscreen, mock_time, request, force_llvm_adapter):
     """Run every example marked to compare its result against a reference screenshot."""
 
     # (relative) module name from project root
@@ -124,15 +116,6 @@ def test_examples_compare(module, pytestconfig, force_offscreen, mock_time, requ
 
     # check if _something_ was rendered
     assert img is not None and img.size > 0
-
-    # we skip the rest of the test if you are not using lavapipe
-    # images come out subtly differently when using different wgpu adapters
-    # so for now we only compare screenshots generated with the same adapter (lavapipe)
-    # a benefit of using pytest.skip is that you are still running
-    # the first part of the test everywhere else; ensuring that examples
-    # can at least import, run and render something
-    if not is_lavapipe:
-        pytest.skip("screenshot comparisons are only done when using lavapipe")
 
     # regenerate screenshot if requested
     screenshot_path = screenshots_dir / f"{module.stem}.png"
@@ -208,5 +191,4 @@ if __name__ == "__main__":
     # Enable tweaking in an IDE by running in an interactive session.
     os.environ["WGPU_FORCE_OFFSCREEN"] = "true"
     pytest.getoption = lambda x: False
-    is_lavapipe = True  # noqa: F811
     test_examples_compare("validate_volume", pytest, None, None)

--- a/examples/tests/testutils.py
+++ b/examples/tests/testutils.py
@@ -36,10 +36,6 @@ def get_wgpu_backend():
     return err if "traceback" in err.lower() else out
 
 
-wgpu_backend = get_wgpu_backend()
-is_lavapipe = wgpu_backend.lower() == "cpu vulkan"
-
-
 def find_examples():
     """Return a list of (filename, fname, config)."""
     examples = []


### PR DESCRIPTION
This is my attempt to force lavapipe to generate the screenshots, but I had alot of trouble generating screenshots for
https://github.com/pygfx/pygfx/pull/712

My strategy was:
1. SSH into a linux machine that doesn't have a GPU.
2. Regenerate from that machine.

But given the progress in https://github.com/pygfx/pygfx/pull/709 it seems that we should be able to create a fixture to force pytest to use the `lavapipe` based GPU.

Locally, on Ubuntu 23.10  (and likely a few other mods) I get failures on the following tests
```
examples/tests/test_examples.py::test_examples_compare[validate_text_anchor] FAILED [ 77%]
examples/tests/test_examples.py::test_examples_compare[validate_culling] FAILED [ 88%]
examples/tests/test_examples.py::test_examples_compare[validate_transparency] FAILED [ 94%]
examples/tests/test_examples.py::test_examples_compare[validate_text_size] FAILED [ 95%]
```

The errors seem to be associated with the edge of the text. On Ubuntu 22.04 it seems fine. I have seen many font differences between Ubuntu 20.04, 22.04 and 23.10 in terms of font support so I would like to attribute it to that.

xref: https://github.com/pygfx/pygfx/issues/684