### PR TITLE
Fix that pick_write is not dynamic

### DIFF
--- a/pygfx/renderers/wgpu/engine/pipeline.py
+++ b/pygfx/renderers/wgpu/engine/pipeline.py
@@ -530,8 +530,8 @@ class PipelineContainer:
     def update_shader_data(self, wobject, changed):
         """Update the info that applies to all passes and environments."""
 
-        if "create" in changed:
-            with wobject.tracker.track_usage("create"):
+        if "create" in changed or "reset" in changed:
+            with wobject.tracker.track_usage("reset"):
                 self.wobject_info["pick_write"] = wobject.material.pick_write
             changed.update(("bindings", "pipeline_info", "render_info"))
 


### PR DESCRIPTION
Closes #720

The problem was (obviously) that the `material.pick_write` was not used under a tracking context. The fact that we had methods passing around a wobject (or its material) was a flag that information was used that was not tracked. In this case this also includes `depth_test`.

So I removed the passing around of the world object. Instead any info that is used from the world object must be put into a little dict (`self.wobject_info`) in a way that this is tracked

So this *also* fixes the same problem for `depth_test`, and avoids similar bugs in the future.