### PR TITLE
Set the children property of the `WorldObject` class to be read-only.

### DIFF
--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -1,7 +1,7 @@
 import random
 import weakref
 import threading
-from typing import List
+from typing import List, Tuple
 import pylinalg as la
 
 import numpy as np
@@ -329,7 +329,7 @@ class WorldObject(EventTarget, RootTrackable):
             return self._parent()
 
     @property
-    def children(self) -> tuple["WorldObject"]:
+    def children(self) -> Tuple["WorldObject"]:
         """tuple of children of this object. (read-only)"""
         return tuple(self._children)
 

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -329,8 +329,8 @@ class WorldObject(EventTarget, RootTrackable):
             return self._parent()
 
     @property
-    def children(self) -> List["WorldObject"]:
-        """List of children of this object. (read-only)"""
+    def children(self) -> tuple["WorldObject"]:
+        """tuple of children of this object. (read-only)"""
         return tuple(self._children)
 
     def add(self, *objects, before=None, keep_world_matrix=False) -> "WorldObject":


### PR DESCRIPTION
I think that when accessing the `children` property of a `WorldObject`, it should return a read-only property. 

Allowing users to modify the `children` property can lead to some potential issues.