### PR TITLE
Fix render_mask logic for points

### DIFF
--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -81,7 +81,7 @@ class PointsMaterial(Material):
         color = Color(color)
         self.uniform_buffer.data["color"] = color
         self.uniform_buffer.update_range(0, 1)
-        self._store.color_is_transparent = color.a < 1
+        self._store.color_is_transparent = 0 < color.a < 1
 
     @property
     def color_is_transparent(self):
@@ -125,6 +125,10 @@ class PointsMaterial(Material):
         if value not in ColorMode:
             raise ValueError(
                 f"PointsMaterial.color_mode must be a string in {ColorMode}, not {repr(value)}"
+            )
+        if value in ["face", "face_map"]:
+            raise ValueError(
+                f"PointsMaterial.color_mode does not support {repr(value)}"
             )
         self._store.color_mode = value
 
@@ -256,6 +260,12 @@ class PointsMarkerMaterial(PointsMaterial):
         edge_color = Color(edge_color)
         self.uniform_buffer.data["edge_color"] = edge_color
         self.uniform_buffer.update_range(0, 1)
+        self._store.edge_color_is_transparent = 0 < edge_color.a < 1
+
+    @property
+    def edge_color_is_transparent(self):
+        """Whether the edge_color is (semi) transparent (i.e. not fully opaque)."""
+        return self._store.edge_color_is_transparent
 
     @property
     def edge_width(self):

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -81,7 +81,7 @@ class PointsMaterial(Material):
         color = Color(color)
         self.uniform_buffer.data["color"] = color
         self.uniform_buffer.update_range(0, 1)
-        self._store.color_is_transparent = 0 < color.a < 1
+        self._store.color_is_transparent = color.a < 1
 
     @property
     def color_is_transparent(self):
@@ -260,7 +260,7 @@ class PointsMarkerMaterial(PointsMaterial):
         edge_color = Color(edge_color)
         self.uniform_buffer.data["edge_color"] = edge_color
         self.uniform_buffer.update_range(0, 1)
-        self._store.edge_color_is_transparent = 0 < edge_color.a < 1
+        self._store.edge_color_is_transparent = edge_color.a < 1
 
     @property
     def edge_color_is_transparent(self):


### PR DESCRIPTION
Addendum to #708

Updates/fixes ender_mask logic for all render modes, sprites, markers. In practice, when `aa` is on, the erroneous logic would not have surfaced (because with aa the render_mask includes the transparency pass).