### PR TITLE
Align and fix rendermask usage

### DIFF
--- a/pygfx/materials/_text.py
+++ b/pygfx/materials/_text.py
@@ -92,7 +92,7 @@ class TextMaterial(Material):
         color = Color(color)
         self.uniform_buffer.data["color"] = color
         self.uniform_buffer.update_range(0, 1)
-        self._store.color_is_transparent = color < 1
+        self._store.color_is_transparent = color.a < 1
 
     @property
     def color_is_transparent(self):
@@ -121,7 +121,7 @@ class TextMaterial(Material):
         outline_color = Color(outline_color)
         self.uniform_buffer.data["outline_color"] = outline_color
         self.uniform_buffer.update_range(0, 1)
-        self._store.outline_color_is_transparent = outline_color < 1
+        self._store.outline_color_is_transparent = outline_color.a < 1
 
     @property
     def outline_color_is_transparent(self):

--- a/pygfx/materials/_text.py
+++ b/pygfx/materials/_text.py
@@ -92,11 +92,7 @@ class TextMaterial(Material):
         color = Color(color)
         self.uniform_buffer.data["color"] = color
         self.uniform_buffer.update_range(0, 1)
-        self._check_color_is_transparent()
-
-    def _check_color_is_transparent(self):
-        max_a = max(self.color.a, self.outline_color.a)
-        self._store.color_is_transparent = max_a < 0
+        self._store.color_is_transparent = color < 1
 
     @property
     def color_is_transparent(self):
@@ -121,11 +117,16 @@ class TextMaterial(Material):
         return Color(self.uniform_buffer.data["outline_color"])
 
     @outline_color.setter
-    def outline_color(self, color):
-        color = Color(color)
-        self.uniform_buffer.data["outline_color"] = color
+    def outline_color(self, outline_color):
+        outline_color = Color(outline_color)
+        self.uniform_buffer.data["outline_color"] = outline_color
         self.uniform_buffer.update_range(0, 1)
-        self._check_color_is_transparent()
+        self._store.outline_color_is_transparent = outline_color < 1
+
+    @property
+    def outline_color_is_transparent(self):
+        """Whether the outline_color is (semi) transparent (i.e. not fully opaque)."""
+        return self._store.outline_color_is_transparent
 
     @property
     def weight_offset(self):

--- a/pygfx/renderers/wgpu/shaders/imageshader.py
+++ b/pygfx/renderers/wgpu/shaders/imageshader.py
@@ -173,17 +173,23 @@ class ImageShader(BaseImageShader):
     def get_render_info(self, wobject, shared):
         material = wobject.material
 
-        render_mask = wobject.render_mask
-        if not render_mask:
-            render_mask = RenderMask.all
-            if material.is_transparent:
-                render_mask = RenderMask.transparent
-            elif material.map is not None:
+        render_mask = 0
+        if wobject.render_mask:
+            render_mask = wobject.render_mask
+        elif material.is_transparent:
+            render_mask = RenderMask.transparent
+        else:
+            # Determine what passes are needed
+            if material.map is not None:
                 if self["colormap_nchannels"] in (1, 3):
-                    render_mask = RenderMask.opaque
+                    render_mask |= RenderMask.opaque
+                else:
+                    render_mask |= RenderMask.all
             else:
                 if self["img_nchannels"] in (1, 3):
-                    render_mask = RenderMask.opaque
+                    render_mask |= RenderMask.opaque
+                else:
+                    render_mask |= RenderMask.all
 
         return {
             "indices": (4, 1),

--- a/pygfx/renderers/wgpu/shaders/meshshader.py
+++ b/pygfx/renderers/wgpu/shaders/meshshader.py
@@ -923,26 +923,28 @@ class MeshSliceShader(WorldObjectShader):
         offset, size = geometry.indices.draw_range
         offset, size = offset * 6, size * 6
 
-        # As long as we don't use alpha for aa in the frag shader, we can use a render_mask of 1 or 2.
-        render_mask = wobject.render_mask
-        if not render_mask:
-            if material.is_transparent:
-                render_mask = RenderMask.transparent
-            elif self["color_mode"] == "uniform":
+        render_mask = 0
+        if wobject.render_mask:
+            render_mask = wobject.render_mask
+        elif material.is_transparent:
+            render_mask = RenderMask.transparent
+        else:
+            # Get what passes are needed for the color
+            if self["color_mode"] == "uniform":
                 if material.color_is_transparent:
-                    render_mask = RenderMask.transparent
+                    render_mask |= RenderMask.transparent
                 else:
-                    render_mask = RenderMask.opaque
+                    render_mask |= RenderMask.opaque
             elif self["color_mode"] in ("vertex", "face"):
                 if self["color_buffer_channels"] in (1, 3):
-                    render_mask = RenderMask.opaque
+                    render_mask |= RenderMask.opaque
                 else:
-                    render_mask = RenderMask.all
+                    render_mask |= RenderMask.all
             elif self["color_mode"] in ("vertex_map", "face_map"):
                 if self["colormap_nchannels"] in (1, 3):
-                    render_mask = RenderMask.opaque
+                    render_mask |= RenderMask.opaque
                 else:
-                    render_mask = RenderMask.all
+                    render_mask |= RenderMask.all
             else:
                 raise RuntimeError(f"Unexpected color mode {self['color_mode']}")
 

--- a/pygfx/renderers/wgpu/shaders/pointsshader.py
+++ b/pygfx/renderers/wgpu/shaders/pointsshader.py
@@ -138,41 +138,44 @@ class PointsShader(WorldObjectShader):
         offset, size = wobject.geometry.positions.draw_range
         offset, size = offset * 6, size * 6
 
-        render_mask = wobject.render_mask
-        if not render_mask:
-            # Establish render_mask from color
+        render_mask = 0
+        if wobject.render_mask:
+            render_mask = wobject.render_mask
+        elif material.is_transparent:
+            render_mask = RenderMask.transparent
+        else:
+            # Get what passes are needed for the color
             if self["color_mode"] == "uniform":
                 if material.color_is_transparent:
-                    render_mask = RenderMask.transparent
-                elif material.aa:
-                    render_mask = RenderMask.all
+                    render_mask |= RenderMask.transparent
                 else:
-                    render_mask = RenderMask.opaque
+                    render_mask |= RenderMask.opaque
             elif self["color_mode"] == "vertex":
                 if self["color_buffer_channels"] in (2, 4):
-                    render_mask = RenderMask.all
-                elif material.aa:
-                    render_mask = RenderMask.all
+                    render_mask |= RenderMask.all
                 else:
-                    render_mask = RenderMask.opaque
+                    render_mask |= RenderMask.opaque
             elif self["color_mode"] == "vertex_map":
                 if self["colormap_nchannels"] in (2, 4):
-                    render_mask = RenderMask.all
-                elif material.aa:
-                    render_mask = RenderMask.all
+                    render_mask |= RenderMask.all
                 else:
-                    render_mask = RenderMask.opaque
+                    render_mask |= RenderMask.opaque
             else:
                 raise RuntimeError(f"Unexpected color mode {self['color_mode']}")
-            # Then overload / combine
-            if material.is_transparent:
-                render_mask = RenderMask.transparent
-            elif self["is_sprite"]:
+            # Need transparency for aa
+            if material.aa:
+                render_mask |= RenderMask.transparent
+            # More cases
+            elif isinstance(material, PointsSpriteMaterial):
                 if self["sprite_nchannels"] in [2, 4]:
                     render_mask |= RenderMask.transparent
+                else:
+                    pass  # mixed with color, so no need to OR with opaque
             elif isinstance(material, PointsMarkerMaterial):
                 if material.edge_color_is_transparent:
                     render_mask |= RenderMask.transparent
+                else:
+                    render_mask |= RenderMask.opaque
 
         return {
             "indices": (size, 1, offset, 0),

--- a/pygfx/renderers/wgpu/shaders/textshader.py
+++ b/pygfx/renderers/wgpu/shaders/textshader.py
@@ -68,21 +68,25 @@ class TextShader(WorldObjectShader):
     def get_render_info(self, wobject, shared):
         material = wobject.material
         n = wobject.geometry.positions.nitems * 6
-        render_mask = wobject.render_mask
-        if not render_mask:
-            if material.is_transparent:
-                render_mask = RenderMask.transparent
+
+        render_mask = 0
+        if wobject.render_mask:
+            render_mask = wobject.render_mask
+        elif material.is_transparent:
+            render_mask = RenderMask.transparent
+        else:
+            # Determine needed passes
+            if material.color_is_transparent:
+                render_mask |= RenderMask.transparent
             else:
-                if material.color_is_transparent:
-                    render_mask |= RenderMask.transparent
-                else:
-                    render_mask |= RenderMask.opaque
-                if material.outline_color_is_transparent:
-                    render_mask |= RenderMask.transparent
-                else:
-                    render_mask |= RenderMask.opaque
-                if material.aa:
-                    render_mask |= RenderMask.transparent
+                render_mask |= RenderMask.opaque
+            if material.outline_color_is_transparent:
+                render_mask |= RenderMask.transparent
+            else:
+                render_mask |= RenderMask.opaque
+            if material.aa:
+                render_mask |= RenderMask.transparent
+
         return {
             "indices": (n, 1),
             "render_mask": render_mask,

--- a/pygfx/renderers/wgpu/shaders/textshader.py
+++ b/pygfx/renderers/wgpu/shaders/textshader.py
@@ -72,10 +72,17 @@ class TextShader(WorldObjectShader):
         if not render_mask:
             if material.is_transparent:
                 render_mask = RenderMask.transparent
-            elif material.color_is_transparent:
-                render_mask = RenderMask.transparent
             else:
-                render_mask = RenderMask.all
+                if material.color_is_transparent:
+                    render_mask |= RenderMask.transparent
+                else:
+                    render_mask |= RenderMask.opaque
+                if material.outline_color_is_transparent:
+                    render_mask |= RenderMask.transparent
+                else:
+                    render_mask |= RenderMask.opaque
+                if material.aa:
+                    render_mask |= RenderMask.transparent
         return {
             "indices": (n, 1),
             "render_mask": render_mask,

--- a/pygfx/renderers/wgpu/shaders/volumeshader.py
+++ b/pygfx/renderers/wgpu/shaders/volumeshader.py
@@ -149,14 +149,23 @@ class VolumeSliceShader(BaseVolumeShader):
     def get_render_info(self, wobject, shared):
         material = wobject.material
 
-        render_mask = wobject.render_mask
-        if not render_mask:
-            if material.is_transparent:
-                render_mask = RenderMask.transparent
-            elif self["img_nchannels"] in (1, 3):
-                render_mask = RenderMask.opaque
+        render_mask = 0
+        if wobject.render_mask:
+            render_mask = wobject.render_mask
+        elif material.is_transparent:
+            render_mask = RenderMask.transparent
+        else:
+            # Determine what passes are needed
+            if material.map is not None:
+                if self["colormap_nchannels"] in (1, 3):
+                    render_mask |= RenderMask.opaque
+                else:
+                    render_mask |= RenderMask.all
             else:
-                render_mask = RenderMask.all
+                if self["img_nchannels"] in (1, 3):
+                    render_mask |= RenderMask.opaque
+                else:
+                    render_mask |= RenderMask.all
 
         return {
             "indices": (12, 1),


### PR DESCRIPTION
Make all render magic calculations follow this pattern:
```py
        render_mask = 0
        if wobject.render_mask:
            render_mask = wobject.render_mask
        elif material.is_transparent:
            render_mask = RenderMask.transparent
        else:
            # Determine what passes are needed
            if material.something:
                render_mask |= xx
            else:
                render_mask |= yy
            if ... etc  
```

This makes these triages easier to follow, in part because we OR what passes are needed, and also because each shader follows the same pattern.

Fixes some cases for text and volume.