### PR TITLE
Add Background.from_color

### DIFF
--- a/examples/feature_demo/fly_controller.py
+++ b/examples/feature_demo/fly_controller.py
@@ -18,6 +18,7 @@ import numpy as np
 canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
+scene.add(gfx.Background.from_color("#000"))
 
 # Create a bunch of points
 n = 1000

--- a/examples/feature_demo/map_click_events_to_world.py
+++ b/examples/feature_demo/map_click_events_to_world.py
@@ -38,7 +38,7 @@ for i in range(4):
     scene = gfx.Scene()
     scenes.append(scene)
 
-    bg = gfx.Background(None, gfx.BackgroundMaterial(bg_colors[i]))
+    bg = gfx.Background.from_color(bg_colors[i])
     scene.add(bg)
 
     # create camera, set default position, add to list

--- a/examples/feature_demo/multi_slice1.py
+++ b/examples/feature_demo/multi_slice1.py
@@ -25,7 +25,7 @@ scene = gfx.Scene()
 
 dark_gray = np.array((169, 167, 168, 255)) / 255
 light_gray = np.array((100, 100, 100, 255)) / 255
-background = gfx.Background(None, gfx.BackgroundMaterial(light_gray, dark_gray))
+background = gfx.Background.from_color(light_gray, dark_gray)
 scene.add(background)
 
 scene.add(gfx.AxesHelper(size=50))

--- a/examples/feature_demo/multi_slice2.py
+++ b/examples/feature_demo/multi_slice2.py
@@ -27,7 +27,7 @@ scene = gfx.Scene()
 
 dark_gray = np.array((169, 167, 168, 255)) / 255
 light_gray = np.array((100, 100, 100, 255)) / 255
-background = gfx.Background(None, gfx.BackgroundMaterial(light_gray, dark_gray))
+background = gfx.Background.from_color(light_gray, dark_gray)
 scene.add(background)
 
 scene.add(gfx.AxesHelper(size=50))

--- a/examples/feature_demo/paint_to_texture.py
+++ b/examples/feature_demo/paint_to_texture.py
@@ -19,7 +19,7 @@ import numpy as np
 renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
 scene = gfx.Scene()
 
-scene.add(gfx.Background(None, gfx.BackgroundMaterial("#cde")))
+scene.add(gfx.Background.from_color("#cde"))
 
 data = np.zeros((100, 500), np.uint8)
 tex = gfx.Texture(data, dim=2)

--- a/examples/feature_demo/panzoom_camera.py
+++ b/examples/feature_demo/panzoom_camera.py
@@ -26,7 +26,7 @@ scene.add(axes)
 
 dark_gray = np.array((169, 167, 168, 255)) / 255
 light_gray = np.array((100, 100, 100, 255)) / 255
-background = gfx.Background(None, gfx.BackgroundMaterial(light_gray, dark_gray))
+background = gfx.Background.from_color(light_gray, dark_gray)
 scene.add(background)
 
 im = iio.imread("imageio:astronaut.png")

--- a/examples/feature_demo/picking_color.py
+++ b/examples/feature_demo/picking_color.py
@@ -22,7 +22,7 @@ scene = gfx.Scene()
 
 dark_gray = np.array((169, 167, 168, 255)) / 255
 light_gray = np.array((100, 100, 100, 255)) / 255
-background = gfx.Background(None, gfx.BackgroundMaterial(light_gray, dark_gray))
+background = gfx.Background.from_color(light_gray, dark_gray)
 scene.add(background)
 
 im = iio.imread("imageio:astronaut.png").astype(np.float32) / 255

--- a/examples/feature_demo/picking_mesh.py
+++ b/examples/feature_demo/picking_mesh.py
@@ -27,7 +27,7 @@ renderer = gfx.renderers.WgpuRenderer(canvas)
 renderer.blend_mode = "weighted_plus"
 scene = gfx.Scene()
 
-scene.add(gfx.Background(None, gfx.BackgroundMaterial("#446")))
+scene.add(gfx.Background.from_color("#446"))
 
 im = iio.imread("imageio:astronaut.png").astype(np.float32) / 255
 tex = gfx.Texture(im, dim=2)

--- a/examples/feature_demo/quad_mesh.py
+++ b/examples/feature_demo/quad_mesh.py
@@ -75,7 +75,7 @@ light.local.position = (0, 0, 1)
 
 # Create a contrasting background
 clr = [i / 255 for i in [87, 188, 200, 255]]
-background = gfx.Background(None, gfx.BackgroundMaterial(clr))
+background = gfx.Background.from_color(clr)
 scene.add(background)
 
 

--- a/examples/feature_demo/scene_in_a_scene.py
+++ b/examples/feature_demo/scene_in_a_scene.py
@@ -29,7 +29,7 @@ texture1 = gfx.Texture(dim=2, size=(200, 200, 1), format="rgba8unorm")
 renderer1 = gfx.renderers.WgpuRenderer(texture1)
 scene1 = gfx.Scene()
 
-background1 = gfx.Background(None, gfx.BackgroundMaterial((0, 0.5, 0, 1)))
+background1 = gfx.Background.from_color((0, 0.5, 0, 1))
 scene1.add(background1)
 
 im = iio.imread("imageio:bricks.jpg").astype(np.float32) / 255

--- a/examples/feature_demo/scene_subplots2.py
+++ b/examples/feature_demo/scene_subplots2.py
@@ -18,7 +18,7 @@ renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
 
 # Create a scene to display multiple times. It contains three points clouds.
 scene = gfx.Scene()
-scene.add(gfx.Background.from_color(("#ddd"))
+scene.add(gfx.Background.from_color("#ddd"))
 
 for clr, offset in [
     ("red", (-3, -1, 0)),

--- a/examples/feature_demo/scene_subplots2.py
+++ b/examples/feature_demo/scene_subplots2.py
@@ -18,7 +18,7 @@ renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
 
 # Create a scene to display multiple times. It contains three points clouds.
 scene = gfx.Scene()
-scene.add(gfx.Background(None, gfx.BackgroundMaterial("#ddd")))
+scene.add(gfx.Background.from_color(("#ddd"))
 
 for clr, offset in [
     ("red", (-3, -1, 0)),
@@ -39,7 +39,7 @@ for clr, offset in [
 # Background
 viewport0 = gfx.Viewport(renderer)
 camera0 = gfx.NDCCamera()
-scene0 = gfx.Background(None, gfx.BackgroundMaterial("#fff"))
+scene0 = gfx.Background.from_color("#fff")
 
 # Create view 1 - xy
 viewport1 = gfx.Viewport(renderer)

--- a/examples/feature_demo/text_align.py
+++ b/examples/feature_demo/text_align.py
@@ -21,7 +21,7 @@ import pygfx as gfx
 scene = gfx.Scene()
 
 
-scene.add(gfx.Background(None, gfx.BackgroundMaterial("#fff", "#000")))
+scene.add(gfx.Background.from_color("#fff", "#000"))
 
 if "PYTEST_CURRENT_TEST" not in os.environ:
     import argparse

--- a/examples/feature_demo/text_contrast.py
+++ b/examples/feature_demo/text_contrast.py
@@ -23,7 +23,7 @@ import pygfx as gfx
 scene = gfx.Scene()
 
 
-scene.add(gfx.Background(None, gfx.BackgroundMaterial("#fff", "#000")))
+scene.add(gfx.Background.from_color("#fff", "#000"))
 
 geo = gfx.TextGeometry(text="Lorem ipsum", font_size=40, screen_space=True)
 

--- a/examples/feature_demo/text_waterfall.py
+++ b/examples/feature_demo/text_waterfall.py
@@ -21,7 +21,7 @@ glyph_atlas = gfx.utils.text.glyph_atlas
 glyph_atlas.clear_free_regions = True  # So we can see regions being freed
 
 # Add background
-background = gfx.Background(None, gfx.BackgroundMaterial("#dde", "#fff"))
+background = gfx.Background.from_color("#dde", "#fff")
 scene.add(background)
 
 # Add an image that shows the glyph atlas

--- a/examples/feature_demo/transparency1.py
+++ b/examples/feature_demo/transparency1.py
@@ -18,7 +18,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-background = gfx.Background(None, gfx.BackgroundMaterial("#000"))
+background = gfx.Background.from_color("#000")
 
 geometry = gfx.plane_geometry(50, 50)
 plane1 = gfx.Mesh(geometry, gfx.MeshBasicMaterial(color=(1, 0, 0, 0.4)))

--- a/examples/feature_demo/transparency2.py
+++ b/examples/feature_demo/transparency2.py
@@ -18,7 +18,7 @@ canvas = WgpuCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
-background = gfx.Background(None, gfx.BackgroundMaterial("#000"))
+background = gfx.Background.from_color("#000")
 
 sphere = gfx.Mesh(gfx.sphere_geometry(10), gfx.MeshPhongMaterial())
 

--- a/examples/introductory/orbit_camera.py
+++ b/examples/introductory/orbit_camera.py
@@ -36,7 +36,7 @@ for i, cube in enumerate(cubes):
 
 dark_gray = np.array((169, 167, 168, 255)) / 255
 light_gray = np.array((100, 100, 100, 255)) / 255
-background = gfx.Background(None, gfx.BackgroundMaterial(light_gray, dark_gray))
+background = gfx.Background.from_color(light_gray, dark_gray)
 scene.add(background)
 
 camera = gfx.PerspectiveCamera(70, 16 / 9)

--- a/examples/introductory/points_basic.py
+++ b/examples/introductory/points_basic.py
@@ -29,9 +29,7 @@ material = gfx.PointsMaterial(color_mode="vertex", size_mode="vertex")
 points = gfx.Points(geometry, material)
 scene.add(points)
 
-scene.add(
-    gfx.Background(None, gfx.BackgroundMaterial((0.2, 0.0, 0, 1), (0, 0.0, 0.2, 1)))
-)
+scene.add(gfx.Background.from_color((0.2, 0.0, 0, 1), (0, 0.0, 0.2, 1)))
 
 camera = gfx.NDCCamera()
 

--- a/examples/validation/validate_points_markers.py
+++ b/examples/validation/validate_points_markers.py
@@ -36,7 +36,7 @@ geometry = gfx.Geometry(positions=positions, colors=colors)
 
 
 scene = gfx.Scene()
-scene.add(gfx.Background(None, gfx.BackgroundMaterial("#bbb", "#777")))
+scene.add(gfx.Background.from_color("#bbb", "#777"))
 
 y = 0
 for marker in gfx.MarkerShape:

--- a/examples/validation/validate_text_align.py
+++ b/examples/validation/validate_text_align.py
@@ -19,7 +19,7 @@ import pygfx as gfx
 scene = gfx.Scene()
 
 
-scene.add(gfx.Background(None, gfx.BackgroundMaterial("#fff", "#000")))
+scene.add(gfx.Background.from_color("#fff", "#000"))
 text = (
     " \n  \n\n"  # Some newlines and spaces before the text starts.
     "  Lorem ipsum\n"  # Some space at the very beginning of the line

--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -3,6 +3,11 @@ import pylinalg as la
 from ._base import WorldObject
 from ..utils import unpack_bitfield
 from ..utils.transform import AffineBase, callback
+from ..materials import (
+    BackgroundMaterial,
+    # BackgroundImageMaterial,
+    # BackgroundSkyboxMaterial,
+)
 
 
 class Group(WorldObject):
@@ -59,6 +64,13 @@ class Background(WorldObject):
         if geometry is not None and material is None:
             raise TypeError("You need to instantiate using Background(None, material)")
         super().__init__(None, material, render_mask=render_mask, **kwargs)
+
+    @classmethod
+    def from_color(cls, *colors):
+        """Create a background with a :class:`.BackgroundMaterial`,
+        using 1 uniform color, 2 colors for a vertical gradient, or 4 colors (one for each corner).
+        """
+        return cls(None, BackgroundMaterial(*colors))
 
 
 class Line(WorldObject):

--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -3,11 +3,7 @@ import pylinalg as la
 from ._base import WorldObject
 from ..utils import unpack_bitfield
 from ..utils.transform import AffineBase, callback
-from ..materials import (
-    BackgroundMaterial,
-    # BackgroundImageMaterial,
-    # BackgroundSkyboxMaterial,
-)
+from ..materials import BackgroundMaterial
 
 
 class Group(WorldObject):

--- a/pygfx/renderers/wgpu/engine/flusher.py
+++ b/pygfx/renderers/wgpu/engine/flusher.py
@@ -268,6 +268,11 @@ class RenderFlusher:
             }
             let gamma3 = vec3<f32>(u_render.gamma);
             out.color = vec4<f32>(pow(val.rgb / weight, gamma3), val.a / weight);
+
+            // Note that the final opacity is not necessarily one. This means that
+            // the framebuffer can be blended with the background, or one can render
+            // images that can be better combined with other content in a document.
+            // It also means that most examples benefit from a gfx.Background.
         """
 
         binding_layout = [


### PR DESCRIPTION
## Intro

To avoid blending issues (as in #724) it should be recommended to use a background in most use-cases. But creating a simple uniform background is currently a bit verbose:
```py
scene.add(gfx.Background(None, gfx.BackgroundMaterial("#000")))
```
This is because the `Background` has the same geometry+material args as all world objects (except `Scene` and `Group`). I value that consistency, but it's also annoying to write out.

## Alternative options
One option could be to drop the `Geomety` arg. But that's still pretty long. And it creates a problem when at some point we get a new kind of background that *does* need geometry.
```py
scene.add(gfx.Background(gfx.BackgroundMaterial("#000")))
```

Another option is to allow something like this. I like the brevity, but documenting this is a bit awkward, I don't think this level of dynamic arguments works well here. Also what about a gradient?
```py
scene.add(gfx.Background("#000"))
```

So what I came up with is this. A bit longer than the previous, but in return its explicit and unambiguous.
```py
scene.add(gfx.Background.from_color("#000"))
```

## Tasks

* [x] Agreement on this proposal.
* [x] Update examples that currenly use a color background.


