### PR TITLE
Suppress sphinx warning about caching gallery_conf

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -55,6 +55,10 @@ exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 # Force offscreen rendering
 os.environ["WGPU_FORCE_OFFSCREEN"] = "true"
 
+# Suppress "cannot cache unpickable configuration value" for sphinx_gallery_conf
+# See https://github.com/sphinx-doc/sphinx/issues/12300
+suppress_warnings = ["config.cache"]
+
 # The gallery conf. See https://sphinx-gallery.github.io/stable/configuration.html
 sphinx_gallery_conf = {
     "gallery_dirs": "_gallery",


### PR DESCRIPTION
The warning that causes the doc build to fail:
```
pickling environment... WARNING: cannot cache unpickable configuration value: 'sphinx_gallery_conf'
```

It is raised from Sphinx here: https://github.com/sphinx-doc/sphinx/blob/da4c6a783066f0eb711f109461275415f99e3568/sphinx/config.py#L455-L485

From what I can find, by the time the code gets here, the `sphinx_gallery_conf` has been populated with more fields, some of which are regexps. Maybe there are funcs too. 