### PR TITLE
Color Conversion in PBR Example

### DIFF
--- a/examples/feature_demo/pbr2.py
+++ b/examples/feature_demo/pbr2.py
@@ -11,10 +11,8 @@ metalness and roughness. Every second sphere has an IBL environment map on it.
 
 import math
 from time import perf_counter
-from colorsys import hls_to_rgb
 
 import imageio.v3 as iio
-import numpy as np
 from wgpu.gui.auto import WgpuCanvas, run
 
 import pygfx as gfx
@@ -65,7 +63,7 @@ while alpha <= 1.0:
         gamma = 0.0
         while gamma <= 1.0:
             material = gfx.MeshStandardMaterial(
-                color=hls_to_rgb(alpha, 0.5, gamma * 0.5 + 0.1),
+                color=gfx.Color.from_hsl(alpha, 0.5, gamma * 0.5 + 0.1),
                 metalness=beta,
                 roughness=1.0 - alpha,
             )
@@ -99,10 +97,12 @@ t0 = perf_counter()
 def animate():
     t = perf_counter() - t0
 
+    t = t * 0.25
+
     point_light.local.position = (
-        math.sin(t / 30 * (2 * np.pi)) * 300,
-        math.cos(t * 2 / 30 * (2 * np.pi)) * 400,
-        math.cos(t / 30 * (2 * np.pi)) * 300,
+        math.sin(t * 7) * 300,
+        math.cos(t * 5) * 400,
+        math.cos(t * 3) * 300,
     )
 
     renderer.render(scene, camera)

--- a/examples/feature_demo/pbr2.py
+++ b/examples/feature_demo/pbr2.py
@@ -63,7 +63,9 @@ while alpha <= 1.0:
         gamma = 0.0
         while gamma <= 1.0:
             material = gfx.MeshStandardMaterial(
-                color=gfx.Color.from_hsl(alpha, 0.5, gamma * 0.5 + 0.1),
+                color=gfx.Color.from_physical(
+                    *gfx.Color.from_hsl(alpha, 0.5, gamma * 0.5 + 0.1)
+                ),
                 metalness=beta,
                 roughness=1.0 - alpha,
             )

--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -319,11 +319,11 @@ class Color:
         meaning the primary color. The value/brightness indicates goes
         from 0 (black) to 1 (white).
         """
-        return Color(colorsys.hsv_to_rgb(hue, saturation, value))
+        return Color.from_physical(*colorsys.hsv_to_rgb(hue, saturation, value))
 
     def to_hsv(self):
         """Get the color represented in the HSV colorspace, as 3 floats."""
-        return colorsys.rgb_to_hsv(*self.rgb)
+        return colorsys.rgb_to_hsv(*self.to_physical())
 
     @classmethod
     def from_hsl(cls, hue, saturation, lightness):
@@ -334,11 +334,11 @@ class Color:
         color differently, e.g. a lightness of 1 always represents full
         white.
         """
-        return Color(colorsys.hls_to_rgb(hue, lightness, saturation))
+        return Color.from_physical(*colorsys.hls_to_rgb(hue, lightness, saturation))
 
     def to_hsl(self):
         """Get the color represented in the HSL colorspace, as 3 floats."""
-        hue, lightness, saturation = colorsys.rgb_to_hls(*self.rgb)
+        hue, lightness, saturation = colorsys.rgb_to_hls(*self.to_physical())
         return hue, saturation, lightness
 
 

--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -319,11 +319,11 @@ class Color:
         meaning the primary color. The value/brightness indicates goes
         from 0 (black) to 1 (white).
         """
-        return Color.from_physical(*colorsys.hsv_to_rgb(hue, saturation, value))
+        return Color(colorsys.hsv_to_rgb(hue, saturation, value))
 
     def to_hsv(self):
         """Get the color represented in the HSV colorspace, as 3 floats."""
-        return colorsys.rgb_to_hsv(*self.to_physical())
+        return colorsys.rgb_to_hsv(*self.rgb)
 
     @classmethod
     def from_hsl(cls, hue, saturation, lightness):
@@ -334,11 +334,11 @@ class Color:
         color differently, e.g. a lightness of 1 always represents full
         white.
         """
-        return Color.from_physical(*colorsys.hls_to_rgb(hue, lightness, saturation))
+        return Color(colorsys.hls_to_rgb(hue, lightness, saturation))
 
     def to_hsl(self):
         """Get the color represented in the HSL colorspace, as 3 floats."""
-        hue, lightness, saturation = colorsys.rgb_to_hls(*self.to_physical())
+        hue, lightness, saturation = colorsys.rgb_to_hls(*self.rgb)
         return hue, saturation, lightness
 
 


### PR DESCRIPTION
I noticed that currently in the pygfx library, the values of Color are treated as being in the srgb color-space. When converting to the HSL or HSV color-spaces, the values need to be first converted to the linear-srgb space.