### PR TITLE
Use np.linalg.pinv instead of .inv

### DIFF
--- a/examples/feature_demo/line_basic.py
+++ b/examples/feature_demo/line_basic.py
@@ -90,7 +90,7 @@ def set_last_node(event):
     if 3 in event.buttons or event.button == 3:
         w, h = canvas.get_logical_size()
         ndcx, ndcy = 2 * event.x / w - 1, 1 - 2 * event.y / h
-        pos = la.vec_transform((ndcx, ndcy, 0), np.linalg.inv(camera.camera_matrix))
+        pos = la.vec_transform((ndcx, ndcy, 0), np.linalg.pinv(camera.camera_matrix))
         line.geometry.positions.data[-1, :2] = pos[0], pos[1]
         line.geometry.positions.update_range(len(positions) - 1, 1)
         renderer.request_draw()

--- a/pygfx/cameras/_base.py
+++ b/pygfx/cameras/_base.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from ..objects._base import WorldObject
+from ..utils.transform import mat_inv
 
 
 class Camera(WorldObject):
@@ -90,4 +91,4 @@ class ScreenCoordsCamera(Camera):
         m = sx, 0, 0, dx, 0, sy, 0, dy, 0, 0, sz, dz, 0, 0, 0, 1
         proj_view = self.projection_matrix.ravel()
         proj_view[:] = m
-        self.projection_matrix_inverse = np.linalg.pinv(self.projection_matrix)
+        self.projection_matrix_inverse = mat_inv(self.projection_matrix)

--- a/pygfx/cameras/_base.py
+++ b/pygfx/cameras/_base.py
@@ -90,4 +90,4 @@ class ScreenCoordsCamera(Camera):
         m = sx, 0, 0, dx, 0, sy, 0, dy, 0, 0, sz, dz, 0, 0, 0, 1
         proj_view = self.projection_matrix.ravel()
         proj_view[:] = m
-        self.projection_matrix_inverse = np.linalg.inv(self.projection_matrix)
+        self.projection_matrix_inverse = np.linalg.pinv(self.projection_matrix)

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -271,7 +271,7 @@ class PerspectiveCamera(Camera):
             self.projection_matrix = la.mat_perspective(
                 left, right, top, bottom, near, far, depth_range=(0, 1)
             )
-            self.projection_matrix_inverse = np.linalg.inv(self.projection_matrix)
+            self.projection_matrix_inverse = np.linalg.pinv(self.projection_matrix)
 
         else:
             # The reference view plane is scaled with the zoom factor
@@ -294,7 +294,7 @@ class PerspectiveCamera(Camera):
             proj = la.mat_orthographic(
                 left, right, top, bottom, near, far, depth_range=(0, 1)
             )
-            proj_i = np.linalg.inv(proj)
+            proj_i = np.linalg.pinv(proj)
             self.projection_matrix = proj
             self.projection_matrix_inverse = proj_i
 

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -4,6 +4,7 @@ import numpy as np
 import pylinalg as la
 
 from ..objects._base import WorldObject
+from ..utils.transform import mat_inv
 from ._base import Camera
 
 
@@ -271,7 +272,7 @@ class PerspectiveCamera(Camera):
             self.projection_matrix = la.mat_perspective(
                 left, right, top, bottom, near, far, depth_range=(0, 1)
             )
-            self.projection_matrix_inverse = np.linalg.pinv(self.projection_matrix)
+            self.projection_matrix_inverse = mat_inv(self.projection_matrix)
 
         else:
             # The reference view plane is scaled with the zoom factor
@@ -294,7 +295,7 @@ class PerspectiveCamera(Camera):
             proj = la.mat_orthographic(
                 left, right, top, bottom, near, far, depth_range=(0, 1)
             )
-            proj_i = np.linalg.pinv(proj)
+            proj_i = mat_inv(proj)
             self.projection_matrix = proj
             self.projection_matrix_inverse = proj_i
 

--- a/pygfx/helpers/_gizmo.py
+++ b/pygfx/helpers/_gizmo.py
@@ -10,7 +10,7 @@ from ..geometries import Geometry, sphere_geometry, cone_geometry, box_geometry
 from ..materials import MeshBasicMaterial, LineMaterial
 from ..objects import WorldObject
 from ..utils.viewport import Viewport
-from ..utils.transform import AffineTransform
+from ..utils.transform import AffineTransform, mat_inv
 
 
 # Colors in hsluv space - https://www.hsluv.org/
@@ -633,7 +633,7 @@ class TransformGizmo(WorldObject):
         """Translate action, either using a translate1 or translate2 handle."""
 
         world_to_screen = self._ndc_to_screen @ self._camera.camera_matrix
-        screen_to_world = np.linalg.pinv(world_to_screen)
+        screen_to_world = mat_inv(world_to_screen)
 
         if isinstance(self._ref["dim"], int):
             travel_directions = (self._ref["dim"],)
@@ -654,7 +654,7 @@ class TransformGizmo(WorldObject):
             units_traveled = get_scale_factor(screen_directions[..., :2], screen_travel)
         else:
             # translate 2D: change basis from screen to gizmo axes
-            screen_to_axes = np.linalg.pinv(screen_directions[..., :2].T)
+            screen_to_axes = mat_inv(screen_directions[..., :2].T)
             units_traveled = screen_to_axes @ screen_travel
 
         # pixel units to world units

--- a/pygfx/helpers/_gizmo.py
+++ b/pygfx/helpers/_gizmo.py
@@ -633,7 +633,7 @@ class TransformGizmo(WorldObject):
         """Translate action, either using a translate1 or translate2 handle."""
 
         world_to_screen = self._ndc_to_screen @ self._camera.camera_matrix
-        screen_to_world = np.linalg.inv(world_to_screen)
+        screen_to_world = np.linalg.pinv(world_to_screen)
 
         if isinstance(self._ref["dim"], int):
             travel_directions = (self._ref["dim"],)
@@ -654,7 +654,7 @@ class TransformGizmo(WorldObject):
             units_traveled = get_scale_factor(screen_directions[..., :2], screen_travel)
         else:
             # translate 2D: change basis from screen to gizmo axes
-            screen_to_axes = np.linalg.inv(screen_directions[..., :2].T)
+            screen_to_axes = np.linalg.pinv(screen_directions[..., :2].T)
             units_traveled = screen_to_axes @ screen_travel
 
         # pixel units to world units

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -668,7 +668,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
         stdinfo_data["cam_transform_inv"] = camera.world.matrix.T
         stdinfo_data["projection_transform"] = camera.projection_matrix.T
         stdinfo_data["projection_transform_inv"] = camera.projection_matrix_inverse.T
-        # stdinfo_data["ndc_to_world"].flat = np.linalg.inv(stdinfo_data["cam_transform"] @ stdinfo_data["projection_transform"])
+        # stdinfo_data["ndc_to_world"].flat = np.linalg.pinv(stdinfo_data["cam_transform"] @ stdinfo_data["projection_transform"])
         stdinfo_data["physical_size"] = physical_size
         stdinfo_data["logical_size"] = logical_size
         # Upload to GPU

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -23,6 +23,7 @@ from ....cameras import Camera
 from ....resources import Texture
 from ....resources._base import resource_update_registry
 from ....utils import Color
+from ....utils.transform import mat_inv  # noqa
 
 from ... import Renderer
 from . import blender as blender_module
@@ -668,7 +669,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
         stdinfo_data["cam_transform_inv"] = camera.world.matrix.T
         stdinfo_data["projection_transform"] = camera.projection_matrix.T
         stdinfo_data["projection_transform_inv"] = camera.projection_matrix_inverse.T
-        # stdinfo_data["ndc_to_world"].flat = np.linalg.pinv(stdinfo_data["cam_transform"] @ stdinfo_data["projection_transform"])
+        # stdinfo_data["ndc_to_world"].flat = mat_inv(stdinfo_data["cam_transform"] @ stdinfo_data["projection_transform"])
         stdinfo_data["physical_size"] = physical_size
         stdinfo_data["logical_size"] = logical_size
         # Upload to GPU

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -6,7 +6,15 @@ import functools
 
 from typing import Tuple, Union
 
+
 PRECISION_EPSILON = 1e-7
+
+
+if int(np.__version__.split(".")[0]) >= 2:
+    mat_inv = np.linalg.inv
+else:
+    # Avoid cpu's spinning at 300%, see issue #763
+    mat_inv = np.linalg.pinv
 
 
 class cached:  # noqa: N801
@@ -150,7 +158,7 @@ class AffineBase:
 
     @cached
     def _inverse_matrix(self) -> np.ndarray:
-        return np.linalg.pinv(self.matrix)
+        return mat_inv(self.matrix)
 
     @property
     def scaling_signs(self):

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -150,7 +150,7 @@ class AffineBase:
 
     @cached
     def _inverse_matrix(self) -> np.ndarray:
-        return np.linalg.inv(self.matrix)
+        return np.linalg.pinv(self.matrix)
 
     @property
     def scaling_signs(self):


### PR DESCRIPTION
Closes #763

This avoids the heavy CPU usage (300%) for simple visualizations. The CPU usage is due to `np.linalg.inv`, via Blas, is using a thread pool, and somehow these threads stay active for a while. The `pinv()` function does not have this problem. 

The `pinv` is about 3x slower than `inv` though, so let's only use for numpy 1.