### PR TITLE
Measure gpu time for all render passes

### DIFF
--- a/pygfx/renderers/wgpu/engine/flusher.py
+++ b/pygfx/renderers/wgpu/engine/flusher.py
@@ -143,6 +143,7 @@ class RenderFlusher:
         dst_color_tex,
         gamma=1.0,
         filter_strength=1.0,
+        time_measurer=None,
     ):
         """Render the (internal) result of the renderer to a texture view."""
 
@@ -166,7 +167,7 @@ class RenderFlusher:
 
         # Ready to go!
         self._update_uniforms(src_color_tex, dst_color_tex, gamma, filter_strength)
-        return self._render(dst_color_tex)
+        return self._render(dst_color_tex, time_measurer)
 
     def _update_uniforms(self, src_color_tex, dst_color_tex, gamma, filter_strength):
         # Get factor between texture sizes
@@ -199,8 +200,13 @@ class RenderFlusher:
             self._uniform_buffer, 0, self._uniform_data, 0, self._uniform_data.nbytes
         )
 
-    def _render(self, dst_color_tex):
+    def _render(self, dst_color_tex, time_measurer):
         command_encoder = self._device.create_command_encoder()
+
+        timestamp_writes = None
+        if time_measurer:
+            time_group = time_measurer.create_group(self._device, "flush", 1)
+            timestamp_writes = time_group.get_timestamp_writes(0)
 
         render_pass = command_encoder.begin_render_pass(
             color_attachments=[
@@ -213,11 +219,15 @@ class RenderFlusher:
                 }
             ],
             depth_stencil_attachment=None,
+            timestamp_writes=timestamp_writes,
         )
         render_pass.set_pipeline(self._render_pipeline)
         render_pass.set_bind_group(0, self._bind_group, [], 0, 99)
         render_pass.draw(4, 1)
         render_pass.end()
+
+        if time_measurer:
+            time_group.resolve(command_encoder)
 
         return [command_encoder.finish()]
 

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -34,7 +34,7 @@ from .shared import get_shared
 from .environment import get_environment
 from .shadowutil import render_shadow_maps
 from .mipmapsutil import generate_texture_mipmaps
-from .utils import GfxTextureView
+from .utils import GfxTextureView, GpuTimeMeasurer
 
 
 def _get_sort_function(camera: Camera):
@@ -182,6 +182,14 @@ class WgpuRenderer(RootEventHandler, Renderer):
             usage=wgpu.BufferUsage.COPY_DST | wgpu.BufferUsage.MAP_READ,
         )
 
+        # Statistics about frame times etc.
+        self._stats = {"cpu_time": 0}
+
+        # Whether to measure timestamps. Note: requires "timestamp-query" in self._device.features.
+        # For now this is an undocument feature that we use in our benchmarks. We could make this
+        # more public eventually, but for now consider it experimental.
+        self.measure_gpu_time = False
+
         # Init fps measurements
         self._show_fps = bool(show_fps)
         now = time.perf_counter()
@@ -189,6 +197,11 @@ class WgpuRenderer(RootEventHandler, Renderer):
 
         if enable_events:
             self.enable_events()
+
+    @property
+    def stats(self):
+        """Statistics for this renderer. Experimental."""
+        return self._stats
 
     @property
     def device(self):
@@ -526,6 +539,10 @@ class WgpuRenderer(RootEventHandler, Renderer):
         # If we do get this to work, we should trigger a new recording
         # when the wobject's children, visible, render_order, or render_pass changes.
 
+        time_measurer = None
+        if self.measure_gpu_time:
+            time_measurer = GpuTimeMeasurer()
+
         # Record the rendering of all world objects, or re-use previous recording
         command_buffers = []
         command_buffers += self._render_recording(
@@ -535,19 +552,28 @@ class WgpuRenderer(RootEventHandler, Renderer):
             render_pipeline_containers,
             physical_viewport,
             clear_color,
+            time_measurer,
         )
-        command_buffers += self._blender.perform_combine_pass()
+        command_buffers += self._blender.perform_combine_pass(time_measurer)
 
         # Collect commands and submit
         self._device.queue.submit(command_buffers)
 
+        # Flush to screen
         if flush:
-            self.flush()
+            self.flush(None, _time_measurer=time_measurer)
 
-    def flush(self, target=None):
+        # Store elapsed time
+        if time_measurer:
+            self._stats["gpu_times"] = time_measurer.get_times()
+        else:
+            self._stats.pop("gpu_times", None)
+
+    def flush(self, target=None, *, _time_measurer=None):
         """Render the result into the target. This method is called
         automatically unless you use ``.render(..., flush=False)``.
         """
+        time_measurer = _time_measurer
 
         # Print FPS
         now = time.perf_counter()  # noqa
@@ -592,6 +618,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
             wgpu_tex_view,
             self._gamma_correction * self._gamma_correction_srgb,
             self._pixel_filter,
+            time_measurer,
         )
         self._device.queue.submit(command_buffers)
 
@@ -606,6 +633,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
         render_pipeline_containers,
         physical_viewport,
         clear_color,
+        time_measurer,
     ):
         # You might think that this is slow for large number of world
         # object. But it is actually pretty good. It does iterate over
@@ -637,7 +665,12 @@ class WgpuRenderer(RootEventHandler, Renderer):
             + environment.lights["spot_lights"]
             + environment.lights["directional_lights"]
         )
-        render_shadow_maps(lights, wobject_list, command_encoder)
+        render_shadow_maps(lights, wobject_list, command_encoder, time_measurer)
+
+        if time_measurer:
+            time_group = time_measurer.create_group(
+                self._device, "pass#", self._blender.get_pass_count()
+            )
 
         for pass_index in range(blender.get_pass_count()):
             color_attachments = blender.get_color_attachments(pass_index)
@@ -646,9 +679,14 @@ class WgpuRenderer(RootEventHandler, Renderer):
             if not color_attachments:
                 continue
 
+            timestamp_writes = None
+            if time_measurer:
+                timestamp_writes = time_group.get_timestamp_writes(pass_index)
+
             render_pass = command_encoder.begin_render_pass(
                 color_attachments=color_attachments,
                 depth_stencil_attachment=depth_attachment,
+                timestamp_writes=timestamp_writes,
                 occlusion_query_set=None,
             )
             render_pass.set_viewport(*physical_viewport)
@@ -659,6 +697,9 @@ class WgpuRenderer(RootEventHandler, Renderer):
                 )
 
             render_pass.end()
+
+        if time_measurer:
+            time_group.resolve(command_encoder)
 
         return [command_encoder.finish()]
 

--- a/pygfx/renderers/wgpu/engine/shadowutil.py
+++ b/pygfx/renderers/wgpu/engine/shadowutil.py
@@ -60,7 +60,7 @@ bind_group_layout_entry = {
 global_bind_group_layout = None
 
 
-def render_shadow_maps(lights, wobjects, command_encoder):
+def render_shadow_maps(lights, wobjects, command_encoder, time_measurer):
     """Render the wobjects into the shadow maps for the given lights."""
 
     global global_bind_group_layout
@@ -75,6 +75,17 @@ def render_shadow_maps(lights, wobjects, command_encoder):
     # Filter shadow-able objects once beforehand.
     wobjects = [w for w in wobjects if w.cast_shadow and w.geometry is not None]
 
+    time_group = None
+    if time_measurer:
+        pass_count = 0
+        for light in lights:
+            if light.cast_shadow:
+                light_has_6_sides = isinstance(light, objects.PointLight)
+                pass_count += 6 if light_has_6_sides else 1
+        if pass_count > 0:
+            time_group = time_measurer.create_group(device, "shadow", pass_count)
+
+    pass_index = -1
     for light in lights:
         if not light.cast_shadow:
             continue
@@ -89,6 +100,7 @@ def render_shadow_maps(lights, wobjects, command_encoder):
             shadow_maps = light.shadow._wgpu_tex_view
             shadow_buffers = light.shadow._gfx_matrix_buffer
             for i in range(6):
+                pass_index += 1
                 render_shadow_map(
                     device,
                     light,
@@ -96,18 +108,35 @@ def render_shadow_maps(lights, wobjects, command_encoder):
                     shadow_buffers[i],
                     wobjects,
                     command_encoder,
+                    time_group.get_timestamp_writes(pass_index) if time_group else None,
                 )
         else:
             # Render this one shadow map
+            pass_index += 1
             shadow_map = light.shadow._wgpu_tex_view
             shadow_buffer = light.shadow._gfx_matrix_buffer
             render_shadow_map(
-                device, light, shadow_map, shadow_buffer, wobjects, command_encoder
+                device,
+                light,
+                shadow_map,
+                shadow_buffer,
+                wobjects,
+                command_encoder,
+                time_group.get_timestamp_writes(pass_index) if time_group else None,
             )
+
+    if time_group:
+        time_group.resolve(command_encoder)
 
 
 def render_shadow_map(
-    device, light, shadow_map, shadow_buffer, wobjects, command_encoder
+    device,
+    light,
+    shadow_map,
+    shadow_buffer,
+    wobjects,
+    command_encoder,
+    timestamp_writes,
 ):
     """Render the wobjects into the given shadow map."""
 
@@ -123,6 +152,7 @@ def render_shadow_map(
             "stencil_load_op": wgpu.LoadOp.clear,
             "stencil_store_op": wgpu.StoreOp.discard,
         },
+        timestamp_writes=timestamp_writes,
     )
 
     light_bind_group = get_shadow_bind_group(device, shadow_buffer)


### PR DESCRIPTION
This adds support to measure the GPU time for the different render passes, which can be useful in benchmarks to see how much strain each pass in the rendering process puts on the GPU, and how certain choices affect the GPU usage. This feature is opt-in, one must set `renderer.measure_gpu_times = True`. This flag is undocumented/experimental for now.

Note1: This relies on https://github.com/pygfx/wgpu-py/pull/505, which is not yet released. But IMO that's ok, since for now this feature is undocumented and only used by ourselves (meaning devs who checkout the `main`of wgpu-py).

Note2: Using this feature requires `gfx.renderers.wgpu.enable_wgpu_features("timestamp-query")`.

This PR:
* [x] Adds a `GpuTimeMeasurer` to abstract away the details, so that the rendering code has minimal extra stuff to do the measurements.
* [x] The renderer creates an instance for each `render()` call, and uses it to measure the render passes, blender combine pass (if applicable), flush pass, and shadow passes.
* [x] The renderer then publishes the result in a new `stats` prop at `renderer.stats["gpu_times"]`.  

An example output from the benchmark code I'm working on. You can see how the number of measurements changes depending on the presence of shadows and used blend mode.
```      
       weighthed_plus blending - cpu:  6.0  bcombine:  0.5  flush:  1.6  pass1:  0.2  pass2:  0.3  pass3:  0.3
                        shadow - cpu:  7.6  flush:  1.4  pass1:  0.2  pass2:  0.2  shadow:  0.4
```