### PR TITLE
Showing how a little bit of partial opacity can be disastrous

### DIFF
--- a/examples/feature_demo/image_click_events.py
+++ b/examples/feature_demo/image_click_events.py
@@ -14,7 +14,7 @@ import pygfx as gfx
 import numpy as np
 
 canvas = WgpuCanvas()
-renderer = gfx.renderers.WgpuRenderer(canvas)
+renderer = gfx.renderers.WgpuRenderer(canvas, blend_mode="ordered2")
 scene = gfx.Scene()
 
 # add image
@@ -24,7 +24,11 @@ im = iio.imread("imageio:astronaut.png")
 
 image = gfx.Image(
     gfx.Geometry(grid=gfx.Texture(im, dim=2)),
-    gfx.ImageBasicMaterial(clim=(0, 255), pick_write=True),
+    gfx.ImageBasicMaterial(
+        clim=(0, 255),
+        pick_write=True,
+        opacity=0.99
+    ),
 )
 scene.add(image)
 

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -63,6 +63,11 @@ class WgpuRenderer(RootEventHandler, Renderer):
           fragments and then blends transparent fragments (using alpha blending)
           with depth-write disabled. The visual results are usually better than
           ordered1, but still depend on the drawing order.
+        * "ordered2wp": two-pass approach that first processes all opaque
+          fragments and then blends transparent fragments (using alpha blending)
+          with depth-write disabled. The visual results should be identical to
+          "ordered2", but this mode also allows for picking from the transparency
+          pass.
         * "weighted": two-pass approach for order independent transparency based
           on alpha weights.
         * "weighted_depth": two-pass approach for order independent transparency
@@ -320,6 +325,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
             "opaque": blender_module.OpaqueFragmentBlender,
             "ordered1": blender_module.Ordered1FragmentBlender,
             "ordered2": blender_module.Ordered2FragmentBlender,
+            "ordered2wp": blender_module.Ordered2FragmentBlenderWithPick,
             "weighted": blender_module.WeightedFragmentBlender,
             "weighted_depth": blender_module.WeightedDepthFragmentBlender,
             "weighted_plus": blender_module.WeightedPlusFragmentBlender,


### PR DESCRIPTION
The image plus points demo "breaks" when the image is only rendered in the SimpleTransparencyPass where the pick info is ignored

This code is mostly to demonstrate the challenges of #780.

ordered1 show the successful interaction.