### PR TITLE
Move most builds from 3.9 to 3.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.12
     - name: Install dev dependencies
       run: |
         python -m pip install --upgrade pip
@@ -42,10 +42,10 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.12
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
@@ -78,6 +78,9 @@ jobs:
           - name: Test py311
             os: ubuntu-latest
             pyversion: '3.11'
+          - name: Test py312
+            os: ubuntu-latest
+            pyversion: '3.12'
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.pyversion }}
@@ -103,10 +106,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.12
     - name: Install package and dev dependencies
       run: |
         python -m pip install --upgrade pip
@@ -116,16 +119,22 @@ jobs:
         pytest -v pygfx/__pyinstaller
 
   test-examples-build:
-    name: Test examples
-    runs-on: ubuntu-latest
+    name: Test examples ${{ matrix.pyversion }}
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            pyversion: '3.10'
+          - os: ubuntu-latest
+            pyversion: '3.12'
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: 3.12
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq
@@ -155,10 +164,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.9
+      - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: 3.12
       - name: Install dev dependencies
         run: |
           python -m pip install --upgrade pip wheel setuptools twine
@@ -194,10 +203,10 @@ jobs:
     if: success() && startsWith(github.ref, 'refs/tags/v')
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: 3.12
     - name: Download assets
       uses: actions/download-artifact@v3
       with:

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: 'ubuntu-latest'
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python 3.9
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: 3.12
     - name: Install llvmpipe and lavapipe for offscreen canvas
       run: |
         sudo apt-get update -y -qq

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -6,7 +6,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.12"
   apt_packages:
     - libegl1-mesa
     - libgl1-mesa-dri

--- a/pygfx/renderers/wgpu/engine/environment.py
+++ b/pygfx/renderers/wgpu/engine/environment.py
@@ -280,13 +280,13 @@ class Environment(Trackable):
             elif binding.type.startswith("shadow_texture/"):
                 dim = binding.type.split("/")[-1].replace("-", "_")
                 code = f"""
-                @group({ bind_group_index }) @binding({slot})
+                @group({bind_group_index}) @binding({slot})
                 var {binding.name}: texture_depth_{dim};
                 """.rstrip()
                 codes.append(code)
             elif binding.type.startswith("shadow_sampler/"):
                 code = f"""
-                @group({ bind_group_index }) @binding({slot})
+                @group({bind_group_index}) @binding({slot})
                 var {binding.name}: sampler_comparison;
                 """.rstrip()
                 codes.append(code)


### PR DESCRIPTION
* [x] Move most builds from 3.9 to 3.12
  * This fixes the compatibility issue between skimage and numpy.
* [x] Also do screenshot tests on two Python versions. 
  * For now 3.10 to avoid the numpy2/skimage issue. Can drop that to 3.9 soon.
* [x] Add 3.12 build to unit tests.
* [x] Fix a small flake issue that is only observed with flake8 on 3.12  