### PR TITLE
Add filter_fn to traverse

### DIFF
--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -431,7 +431,7 @@ class WorldObject(EventTarget, RootTrackable):
         are included.
         """
 
-        for child in self.iter(skip_invisible=skip_invisible, filter_fn=None):
+        for child in self.iter(skip_invisible=skip_invisible, filter_fn=filter_fn):
             callback(child)
 
     def iter(self, filter_fn=None, skip_invisible=False):

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -426,7 +426,7 @@ class WorldObject(EventTarget, RootTrackable):
         ``visible`` property is False - and their children - are
         skipped. Note that modifying the scene graph inside the callback
         is discouraged.
-        
+
         If ``filter_fn`` is given, only objects for which it returns ``True``
         are included.
         """

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -419,20 +419,29 @@ class WorldObject(EventTarget, RootTrackable):
         if keep_world_matrix:
             self.world.matrix = transform_matrix
 
-    def traverse(self, callback, skip_invisible=False):
+    def traverse(self, callback, skip_invisible=False, filter_fn=None):
         """Executes the callback on this object and all descendants.
 
         If ``skip_invisible`` is given and True, objects whose
         ``visible`` property is False - and their children - are
         skipped. Note that modifying the scene graph inside the callback
         is discouraged.
+        
+        If ``filter_fn`` is given, only objects for which it returns ``True``
+        are included.
         """
 
-        for child in self.iter(skip_invisible=skip_invisible):
+        for child in self.iter(skip_invisible=skip_invisible, filter_fn=None):
             callback(child)
 
     def iter(self, filter_fn=None, skip_invisible=False):
         """Create a generator that iterates over this objects and its children.
+
+        If ``skip_invisible`` is given and True, objects whose
+        ``visible`` property is False - and their children - are
+        skipped. Note that modifying the scene graph inside the iteration
+        is discouraged.
+
         If ``filter_fn`` is given, only objects for which it returns ``True``
         are included.
         """


### PR DESCRIPTION
I am trying to implement frustum culling and I'm finding a few small inconsistencies like this along the way.

One challenge here is that the order of `filter_fn` and `skip_invisible` is flipped between `iter` and `traverse`.

Having used this function for 1 hour (so don't take my suggestions as meaning too much), I feel that `skip_invisible` should likely be removed.

To my knowledge it is used in the renderer, but the render could also simply define its own filter_fn too

https://github.com/pygfx/pygfx/blob/cba5dd1d0c017c414c92497a6efd8b7d2f9a9fec/pygfx/renderers/wgpu/engine/renderer.py#L490