### PR TITLE
Question: Demonstrate edge cases in line dashing

### DIFF
--- a/examples/validation/validate_line_dash.py
+++ b/examples/validation/validate_line_dash.py
@@ -15,8 +15,11 @@ from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(1000, 1000))
+pixel_ratio = 2.
+canvas = WgpuCanvas(size=(1000, 1000), title=f"Dashing {pixel_ratio=:}")
 renderer = gfx.WgpuRenderer(canvas)
+# Setting the pixel ratio to 1 seems to invoke some kind of edge case
+renderer.pixel_ratio = pixel_ratio
 
 x = np.linspace(0, 4 * np.pi, 1000)
 y = np.sin(x)
@@ -25,6 +28,16 @@ y = np.sin(x)
 positions = np.array([x * 100, y * 100, np.zeros_like(x)], np.float32).T.copy()
 
 geometry = gfx.Geometry(positions=positions)
+
+line0 = gfx.Line(
+    geometry,
+    gfx.LineMaterial(
+        thickness=1.,
+        dash_pattern=(5, 5),
+        color=(0.0, 1.0, 1.0, 0.4),
+        dash_offset=0,
+    ),
+)
 
 line1 = gfx.Line(
     geometry,
@@ -65,16 +78,17 @@ line4 = gfx.Line(
     ),
 )
 
-for line in (line1, line2, line3, line4):
+for line in (line0, line1, line2, line3, line4):
     line.material.thickness_space = "screen"
 
+line0.local.position = 0, 500, 0
 line1.local.position = 0, 0, 0
 line2.local.position = 0, -500, 0
 line3.local.position = 0, -1000, 0
 line4.local.position = 0, -1500, 0
 
 scene = gfx.Scene()
-scene.add(line1, line2, line3, line4)
+scene.add(line0, line1, line2, line3, line4)
 
 camera = gfx.OrthographicCamera()
 camera.show_object(scene)


### PR DESCRIPTION
It seems that if you use a pixel_ratio of 1, and a line thickness of 1 the dashing miraculously disappears???

I haven't spent too much time investigating this, but I was curious as to why my dashing went away when I set the pixel_ratio to 1 (was trying to see if I could speedup my application that way)

is this a bug or expected behavior?

![Screenshot from 2024-07-07 16-22-54](https://github.com/pygfx/pygfx/assets/90008/e5db273c-6268-4aec-9f3d-7d15cdba8f84)
