### PR TITLE
Make hte resources path more resilient to changing python environment

### DIFF
--- a/examples/feature_demo/multiple_fonts.py
+++ b/examples/feature_demo/multiple_fonts.py
@@ -1,0 +1,63 @@
+"""
+Multiple Fonts
+==============
+
+Example demonstrating the capabilities of text to be rendered in
+multiple different fonts.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+
+from datetime import datetime
+
+now = datetime.now()
+text = now.strftime("%H:%M:%S")
+
+text_noto = gfx.Text(
+    gfx.TextGeometry(
+        text="Noto Sans: " + text,
+        # family="Noto Sans",
+    ),
+    gfx.TextMaterial(color="#B4F8C8", outline_color="#000", outline_thickness=0.15),
+)
+text_noto.local.position = (0, -40, 0)
+
+text_humor = gfx.Text(
+    gfx.TextGeometry(
+        text="Humor Sans: " + text,
+        family="Humor Sans",
+    ),
+    gfx.TextMaterial(color="#B4F8C8", outline_color="#000", outline_thickness=0.15),
+)
+text_humor.local.position = (0, 0, 0)
+
+text_instructions = gfx.Text(
+    gfx.TextGeometry(
+        text="Click to update the clock",
+    ),
+    gfx.TextMaterial(color="#B4F8C8", outline_color="#000", outline_thickness=0.15),
+)
+text_instructions.local.position = (0, 40, 0)
+
+scene = gfx.Scene()
+scene.add(text_noto, text_humor, text_instructions)
+camera = gfx.OrthographicCamera(400, 300)
+renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(800, 600)))
+
+
+@renderer.add_event_handler("pointer_down")
+def change_text(event):
+    now = datetime.now()
+    text = now.strftime("%H:%M:%S")
+    text_noto.geometry.set_text("Noto Sans: " + text)
+    text_humor.geometry.set_text("Humor Sans: " + text, family="Humor Sans")
+    renderer.request_draw()
+
+
+renderer.request_draw(lambda: renderer.render(scene, camera))
+if __name__ == "__main__":
+    run()

--- a/pygfx/utils/_dirs.py
+++ b/pygfx/utils/_dirs.py
@@ -1,9 +1,9 @@
 import os
 import sys
 import atexit
+from pathlib import Path
 import shutil
 import tempfile
-import importlib.resources
 
 
 try:
@@ -14,15 +14,7 @@ except Exception:  # Exceptions thrown by home() are not specified...
 
 def get_resources_dir():
     """Get the path to the directory of builtin resources."""
-    if sys.version_info < (3, 9):
-        context = importlib.resources.path("pygfx.data_files", "__init__.py")
-    else:
-        ref = importlib.resources.files("pygfx.data_files") / "__init__.py"
-        context = importlib.resources.as_file(ref)
-    with context as path:
-        pass
-    # Return the dir. We assume that the data files are on a normal dir on the fs.
-    return str(path.parent)
+    return str(Path(__file__).parent.parent / "data_files")
 
 
 def get_cache_dir():


### PR DESCRIPTION
Ok this is quite an edge case but consider this:

1. An early adopter developer trying to test your code.
2. They install some supported version.
3. They need to test some example on the main branch. (such as your cool new ruler)
4. They run `pip install -e . -vv` to using the main branch in editable mode
5. The font caching engine then tries to re-open a a Noto-font file but can't resolve the resource correctly.

I feel like using `__file__` is likely easy enough but maybe it isn't comptaible with some pyinstaller stuff?

Trying to test on the CIs.