### PR TITLE
Update internal usage of buffers and textures

### DIFF
--- a/examples/feature_demo/custom_object2.py
+++ b/examples/feature_demo/custom_object2.py
@@ -55,7 +55,7 @@ class TriangleMaterial(gfx.Material):
     @color.setter
     def color(self, color):
         self.uniform_buffer.data["color"] = gfx.Color(color)
-        self.uniform_buffer.update_range(0, 99999)
+        self.uniform_buffer.update_full()
 
 
 @register_wgpu_render_function(Triangle, TriangleMaterial)

--- a/examples/feature_demo/custom_object3.py
+++ b/examples/feature_demo/custom_object3.py
@@ -58,7 +58,7 @@ class TriangleMaterial(gfx.Material):
     def color(self, color):
         color = gfx.Color(color)
         self.uniform_buffer.data["color"] = color
-        self.uniform_buffer.update_range(0, 99999)
+        self.uniform_buffer.update_full()
         self._store.color_is_transparent = color.a < 1
 
     @property

--- a/examples/feature_demo/geometry_plane.py
+++ b/examples/feature_demo/geometry_plane.py
@@ -40,7 +40,7 @@ scene.add(gfx.AmbientLight(), gfx.DirectionalLight())
 def animate():
     # Read next frame, rewind if we reach the end
     tex.data[:] = next(frame_generator)
-    tex.update_range((0, 0, 0), tex.size)
+    tex.update_full()
 
     renderer.render(scene, camera)
     canvas.request_draw()

--- a/examples/feature_demo/multi_slice1.py
+++ b/examples/feature_demo/multi_slice1.py
@@ -74,7 +74,7 @@ def animate():
     plane = planes[2]
     plane.local.z = t * vol.shape[0] * 0.5
     plane.geometry.texcoords.data[:, 2] = (t + 1) / 2
-    plane.geometry.texcoords.update_range(0, plane.geometry.texcoords.nitems)
+    plane.geometry.texcoords.update_full()
 
     renderer.render(scene, camera)
     canvas.request_draw()

--- a/examples/feature_demo/multiprocessing_zmq/view.py
+++ b/examples/feature_demo/multiprocessing_zmq/view.py
@@ -73,7 +73,7 @@ def update_frame():
 
         # set image data
         image.geometry.grid.data[:] = a
-        image.geometry.grid.update_range((0, 0, 0), image.geometry.grid.size)
+        image.geometry.grid.update_full()
 
     renderer.render(scene, camera)
     canvas.request_draw()

--- a/examples/feature_demo/paint_to_texture.py
+++ b/examples/feature_demo/paint_to_texture.py
@@ -21,8 +21,9 @@ scene = gfx.Scene()
 
 scene.add(gfx.Background.from_color("#cde"))
 
+# Create texture to draw to. We set the force_contiguous flag because we will sync the texture regularly
 data = np.zeros((100, 500), np.uint8)
-tex = gfx.Texture(data, dim=2)
+tex = gfx.Texture(data, dim=2, force_contiguous=True)
 
 image = gfx.Image(
     gfx.Geometry(grid=tex),
@@ -47,7 +48,7 @@ def pick(event):
                 tex.data[y, x] = min(200, tex.data[y, x] + 50)
             else:
                 tex.data[y, x] = max(0, tex.data[y, x] - 50)
-            tex.update_range((x, y, 0), (1, 1, 1))
+            tex.update_indices(x, y, 0)
             renderer.request_draw()
 
 

--- a/examples/feature_demo/scene_subplots_video.py
+++ b/examples/feature_demo/scene_subplots_video.py
@@ -82,7 +82,7 @@ def animate():
     for img in images:
         # create new image data
         img.geometry.grid.data[:] = np.random.rand(*dims).astype(np.float32) * 255
-        img.geometry.grid.update_range((0, 0, 0), img.geometry.grid.size)
+        img.geometry.grid.update_full()
 
     # render the viewports
     for viewport, s, c in zip(viewports, scenes, cameras):

--- a/examples/feature_demo/volume_slice1.py
+++ b/examples/feature_demo/volume_slice1.py
@@ -40,7 +40,7 @@ def handle_event(event):
     index = max(0, min(nslices - 1, index))
     im = vol[index]
     tex.data[:] = im
-    tex.update_range((0, 0, 0), tex.size)
+    tex.update_full()
     canvas.request_draw()
 
 

--- a/examples/feature_demo/volume_slice2.py
+++ b/examples/feature_demo/volume_slice2.py
@@ -42,7 +42,7 @@ def handle_event(event):
     index = index + event.dy / 90
     index = max(0, min(nslices - 1, index))
     geometry.texcoords.data[:, 2] = index / nslices
-    geometry.texcoords.update_range(0, geometry.texcoords.nitems)
+    geometry.texcoords.update_full()
     canvas.request_draw()
 
 

--- a/examples/feature_demo/wireframe_material.py
+++ b/examples/feature_demo/wireframe_material.py
@@ -36,7 +36,7 @@ class WireframeMaterial(gfx.Material):
     @thickness.setter
     def thickness(self, thickness):
         self.uniform_buffer.data["thickness"] = thickness
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
 
 @register_wgpu_render_function(gfx.WorldObject, WireframeMaterial)

--- a/examples/other/integration_pytorch.py
+++ b/examples/other/integration_pytorch.py
@@ -551,7 +551,7 @@ class SceneHandler:
             else:
                 c_pred = SceneHandler._get_vertex_colors_from_k(k=mesh_data.pred_k)
                 SceneHandler._scene_state.pred_mesh.geometry.colors.data[:] = c_pred
-                SceneHandler._scene_state.pred_mesh.geometry.colors.update_range()
+                SceneHandler._scene_state.pred_mesh.geometry.colors.update_full()
         except queue.Empty:
             pass
 

--- a/examples/other/post_processing1.py
+++ b/examples/other/post_processing1.py
@@ -58,7 +58,7 @@ class NoiseMaterial(gfx.materials.Material):
 
     def tick(self):
         self.uniform_buffer.data["time"] = time.time() % 1
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
 
 shader_source = """

--- a/pygfx/helpers/_axes.py
+++ b/pygfx/helpers/_axes.py
@@ -120,7 +120,7 @@ class AxesHelper(Line):
         self._geometry.colors.data[3] = y
         self._geometry.colors.data[4] = z
         self._geometry.colors.data[5] = z
-        self._geometry.colors.update_range(0, self._geometry.colors.nitems)
+        self._geometry.colors.update_full()
         # update arrow heads
         for arrow, color in zip(self.children, [x, y, z]):
             arrow.material.color = color

--- a/pygfx/materials/_background.py
+++ b/pygfx/materials/_background.py
@@ -75,7 +75,7 @@ class BackgroundMaterial(Material):
     @color_bottom_left.setter
     def color_bottom_left(self, color):
         self.uniform_buffer.data["color_bottom_left"] = Color(color)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def color_bottom_right(self):
@@ -85,7 +85,7 @@ class BackgroundMaterial(Material):
     @color_bottom_right.setter
     def color_bottom_right(self, color):
         self.uniform_buffer.data["color_bottom_right"] = Color(color)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def color_top_left(self):
@@ -95,7 +95,7 @@ class BackgroundMaterial(Material):
     @color_top_left.setter
     def color_top_left(self, color):
         self.uniform_buffer.data["color_top_left"] = Color(color)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def color_top_right(self):
@@ -105,7 +105,7 @@ class BackgroundMaterial(Material):
     @color_top_right.setter
     def color_top_right(self, color):
         self.uniform_buffer.data["color_top_right"] = Color(color)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
 
 class BackgroundImageMaterial(BackgroundMaterial):

--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -50,7 +50,9 @@ class Material(Trackable):
     ):
         super().__init__()
 
-        self._store.uniform_buffer = Buffer(array_from_shadertype(self.uniform_type))
+        self._store.uniform_buffer = Buffer(
+            array_from_shadertype(self.uniform_type), force_contiguous=True
+        )
 
         self.opacity = opacity
         self.clipping_planes = clipping_planes or []
@@ -81,7 +83,9 @@ class Material(Trackable):
         self.uniform_type[key] = f"{new_length}*{subtype}"
         # Recreate buffer
         data = self.uniform_buffer.data
-        self._store.uniform_buffer = Buffer(array_from_shadertype(self.uniform_type))
+        self._store.uniform_buffer = Buffer(
+            array_from_shadertype(self.uniform_type), force_contiguous=True
+        )
         # Copy data
         for k in data.dtype.names:
             if k != key:

--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -117,7 +117,7 @@ class Material(Trackable):
     def opacity(self, value):
         value = min(max(float(value), 0), 1)
         self.uniform_buffer.data["opacity"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
         self._store.is_transparent = value < 1
 
     @property
@@ -164,7 +164,7 @@ class Material(Trackable):
         self._store.clipping_plane_count = len(planes2)
         for i in range(len(planes2)):
             self.uniform_buffer.data["clipping_planes"][i] = planes2[i]
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def clipping_plane_count(self):

--- a/pygfx/materials/_grid.py
+++ b/pygfx/materials/_grid.py
@@ -118,7 +118,7 @@ class GridMaterial(Material):
                 f"major_step must be tuple or float, not {step.__class__.__name__}"
             )
         self.uniform_buffer.data["major_step"] = step
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
         self._set_draw_major()
 
     @property
@@ -138,7 +138,7 @@ class GridMaterial(Material):
                 f"minor_step must be tuple or float, not {step.__class__.__name__}"
             )
         self.uniform_buffer.data["minor_step"] = step
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
         self._set_draw_minor()
 
     @property
@@ -149,7 +149,7 @@ class GridMaterial(Material):
     @axis_thickness.setter
     def axis_thickness(self, thickness):
         self.uniform_buffer.data["axis_thickness"] = max(0.0, float(thickness))
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
         self._set_draw_axis()
 
     @property
@@ -160,7 +160,7 @@ class GridMaterial(Material):
     @major_thickness.setter
     def major_thickness(self, thickness):
         self.uniform_buffer.data["major_thickness"] = max(0.0, float(thickness))
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
         self._set_draw_major()
 
     @property
@@ -171,7 +171,7 @@ class GridMaterial(Material):
     @minor_thickness.setter
     def minor_thickness(self, thickness):
         self.uniform_buffer.data["minor_thickness"] = max(0.0, float(thickness))
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
         self._set_draw_minor()
 
     @property
@@ -203,7 +203,7 @@ class GridMaterial(Material):
     @axis_color.setter
     def axis_color(self, color):
         self.uniform_buffer.data["axis_color"] = Color(color)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def major_color(self):
@@ -213,7 +213,7 @@ class GridMaterial(Material):
     @major_color.setter
     def major_color(self, color):
         self.uniform_buffer.data["major_color"] = Color(color)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def minor_color(self):
@@ -223,7 +223,7 @@ class GridMaterial(Material):
     @minor_color.setter
     def minor_color(self, color):
         self.uniform_buffer.data["minor_color"] = Color(color)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def infinite(self):

--- a/pygfx/materials/_image.py
+++ b/pygfx/materials/_image.py
@@ -68,7 +68,7 @@ class ImageBasicMaterial(Material):
         clim = float(clim[0]), float(clim[1])
         # Update uniform data
         self.uniform_buffer.data["clim"] = clim
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def interpolation(self):

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -81,7 +81,7 @@ class LineMaterial(Material):
     def color(self, color):
         color = Color(color)
         self.uniform_buffer.data["color"] = color
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
         self._store.color_is_transparent = color.a < 1
 
     @property
@@ -151,7 +151,7 @@ class LineMaterial(Material):
     @thickness.setter
     def thickness(self, thickness):
         self.uniform_buffer.data["thickness"] = max(0.0, float(thickness))
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def thickness_space(self):
@@ -232,7 +232,7 @@ class LineMaterial(Material):
     @dash_offset.setter
     def dash_offset(self, value):
         self.uniform_buffer.data["dash_offset"] = float(value)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
 
 class LineDebugMaterial(LineMaterial):

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -75,7 +75,7 @@ class MeshAbstractMaterial(Material):
     def color(self, color):
         color = Color(color)
         self.uniform_buffer.data["color"] = color
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
         self._store.color_is_transparent = color.a < 1
 
     @property
@@ -256,7 +256,7 @@ class MeshBasicMaterial(MeshAbstractMaterial):
             self.uniform_buffer.data["wireframe"] = thickness
         else:
             self.uniform_buffer.data["wireframe"] = -thickness
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def wireframe_thickness(self):
@@ -270,7 +270,7 @@ class MeshBasicMaterial(MeshAbstractMaterial):
             self.uniform_buffer.data["wireframe"] = value
         else:
             self.uniform_buffer.data["wireframe"] = -value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def flat_shading(self):
@@ -298,7 +298,7 @@ class MeshBasicMaterial(MeshAbstractMaterial):
     @reflectivity.setter
     def reflectivity(self, value):
         self.uniform_buffer.data["reflectivity"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def refraction_ratio(self):
@@ -310,7 +310,7 @@ class MeshBasicMaterial(MeshAbstractMaterial):
     @refraction_ratio.setter
     def refraction_ratio(self, value):
         self.uniform_buffer.data["refraction_ratio"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def env_combine_mode(self):
@@ -368,7 +368,7 @@ class MeshBasicMaterial(MeshAbstractMaterial):
     @light_map_intensity.setter
     def light_map_intensity(self, value):
         self.uniform_buffer.data["light_map_intensity"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def ao_map(self):
@@ -390,7 +390,7 @@ class MeshBasicMaterial(MeshAbstractMaterial):
     @ao_map_intensity.setter
     def ao_map_intensity(self, value):
         self.uniform_buffer.data["ao_map_intensity"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
 
 class MeshPhongMaterial(MeshBasicMaterial):
@@ -477,7 +477,7 @@ class MeshPhongMaterial(MeshBasicMaterial):
     def emissive(self, color):
         color = Color(color)
         self.uniform_buffer.data["emissive_color"] = color
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def specular(self):
@@ -489,7 +489,7 @@ class MeshPhongMaterial(MeshBasicMaterial):
     def specular(self, color):
         color = Color(color)
         self.uniform_buffer.data["specular_color"] = color
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def shininess(self):
@@ -501,7 +501,7 @@ class MeshPhongMaterial(MeshBasicMaterial):
     @shininess.setter
     def shininess(self, value):
         self.uniform_buffer.data["shininess"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     # TODO: more advanced mproperties, Unified with "MeshStandardMaterial".
 
@@ -559,7 +559,7 @@ class MeshNormalLinesMaterial(MeshAbstractMaterial):
     @line_length.setter
     def line_length(self, value):
         self.uniform_buffer.data["line_length"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
 
 class MeshSliceMaterial(MeshAbstractMaterial):
@@ -602,7 +602,7 @@ class MeshSliceMaterial(MeshAbstractMaterial):
     @plane.setter
     def plane(self, plane):
         self.uniform_buffer.data["plane"] = plane
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def thickness(self):
@@ -612,7 +612,7 @@ class MeshSliceMaterial(MeshAbstractMaterial):
     @thickness.setter
     def thickness(self, thickness):
         self.uniform_buffer.data["thickness"] = thickness
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
 
 class MeshStandardMaterial(MeshBasicMaterial):
@@ -699,7 +699,7 @@ class MeshStandardMaterial(MeshBasicMaterial):
     def emissive(self, color):
         color = Color(color)
         self.uniform_buffer.data["emissive_color"] = color
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def emissive_map(self):
@@ -731,7 +731,7 @@ class MeshStandardMaterial(MeshBasicMaterial):
     @emissive_intensity.setter
     def emissive_intensity(self, value):
         self.uniform_buffer.data["emissive_intensity"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def metalness(self):
@@ -746,7 +746,7 @@ class MeshStandardMaterial(MeshBasicMaterial):
     @metalness.setter
     def metalness(self, value):
         self.uniform_buffer.data["metalness"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def metalness_map(self):
@@ -769,7 +769,7 @@ class MeshStandardMaterial(MeshBasicMaterial):
     @roughness.setter
     def roughness(self, value):
         self.uniform_buffer.data["roughness"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def roughness_map(self):
@@ -792,7 +792,7 @@ class MeshStandardMaterial(MeshBasicMaterial):
     @normal_scale.setter
     def normal_scale(self, value):
         self.uniform_buffer.data["normal_scale"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def normal_map(self):
@@ -836,7 +836,7 @@ class MeshStandardMaterial(MeshBasicMaterial):
             width, height, _ = map.size
             max_level = math.floor(math.log2(max(width, height))) + 1
             self.uniform_buffer.data["env_map_max_mip_level"] = float(max_level)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def env_map_intensity(self):
@@ -848,4 +848,4 @@ class MeshStandardMaterial(MeshBasicMaterial):
     @env_map_intensity.setter
     def env_map_intensity(self, value):
         self.uniform_buffer.data["env_map_intensity"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -80,7 +80,7 @@ class PointsMaterial(Material):
     def color(self, color):
         color = Color(color)
         self.uniform_buffer.data["color"] = color
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
         self._store.color_is_transparent = color.a < 1
 
     @property
@@ -150,7 +150,7 @@ class PointsMaterial(Material):
     @size.setter
     def size(self, size):
         self.uniform_buffer.data["size"] = size
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def size_space(self):
@@ -268,7 +268,7 @@ class PointsMarkerMaterial(PointsMaterial):
     def edge_color(self, edge_color):
         edge_color = Color(edge_color)
         self.uniform_buffer.data["edge_color"] = edge_color
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
         self._store.edge_color_is_transparent = edge_color.a < 1
 
     @property
@@ -284,7 +284,7 @@ class PointsMarkerMaterial(PointsMaterial):
     @edge_width.setter
     def edge_width(self, edge_width):
         self.uniform_buffer.data["edge_width"] = float(edge_width)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def marker(self):

--- a/pygfx/materials/_text.py
+++ b/pygfx/materials/_text.py
@@ -91,7 +91,7 @@ class TextMaterial(Material):
     def color(self, color):
         color = Color(color)
         self.uniform_buffer.data["color"] = color
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
         self._store.color_is_transparent = color.a < 1
 
     @property
@@ -109,7 +109,7 @@ class TextMaterial(Material):
     @outline_thickness.setter
     def outline_thickness(self, value):
         self.uniform_buffer.data["outline_thickness"] = max(0.0, min(0.5, float(value)))
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def outline_color(self):
@@ -120,7 +120,7 @@ class TextMaterial(Material):
     def outline_color(self, outline_color):
         outline_color = Color(outline_color)
         self.uniform_buffer.data["outline_color"] = outline_color
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
         self._store.outline_color_is_transparent = outline_color.a < 1
 
     @property
@@ -143,4 +143,4 @@ class TextMaterial(Material):
     @weight_offset.setter
     def weight_offset(self, value):
         self.uniform_buffer.data["weight_offset"] = float(value)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()

--- a/pygfx/materials/_volume.py
+++ b/pygfx/materials/_volume.py
@@ -72,7 +72,7 @@ class VolumeBasicMaterial(Material):
         clim = float(clim[0]), float(clim[1])
         # Update uniform data
         self.uniform_buffer.data["clim"] = clim
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def interpolation(self):
@@ -120,7 +120,7 @@ class VolumeSliceMaterial(VolumeBasicMaterial):
     @plane.setter
     def plane(self, plane):
         self.uniform_buffer.data["plane"] = plane
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
 
 class VolumeRayMaterial(VolumeBasicMaterial):
@@ -204,7 +204,7 @@ class VolumeIsoMaterial(VolumeRayMaterial):
     @threshold.setter
     def threshold(self, threshold: float) -> None:
         self.uniform_buffer.data["threshold"] = float(threshold)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def step_size(self) -> float:
@@ -217,7 +217,7 @@ class VolumeIsoMaterial(VolumeRayMaterial):
     @step_size.setter
     def step_size(self, size: float) -> None:
         self.uniform_buffer.data["step_size"] = float(size)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def substep_size(self) -> float:
@@ -230,7 +230,7 @@ class VolumeIsoMaterial(VolumeRayMaterial):
     @substep_size.setter
     def substep_size(self, size: float) -> None:
         self.uniform_buffer.data["substep_size"] = float(size)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def emissive(self):
@@ -244,7 +244,7 @@ class VolumeIsoMaterial(VolumeRayMaterial):
     def emissive(self, color):
         color = Color(color)
         self.uniform_buffer.data["emissive_color"] = color
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def shininess(self):
@@ -256,4 +256,4 @@ class VolumeIsoMaterial(VolumeRayMaterial):
     @shininess.setter
     def shininess(self, value):
         self.uniform_buffer.data["shininess"] = float(value)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -154,7 +154,7 @@ class WorldObject(EventTarget, RootTrackable):
         self.name = name
 
         # Compose complete uniform type
-        buffer = Buffer(array_from_shadertype(self.uniform_type))
+        buffer = Buffer(array_from_shadertype(self.uniform_type), force_contiguous=True)
         buffer.data["world_transform"] = np.eye(4)
         buffer.data["world_transform_inv"] = np.eye(4)
 

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -186,7 +186,7 @@ class WorldObject(EventTarget, RootTrackable):
     def _update_uniform_buffers(self, transform: AffineBase):
         self.uniform_buffer.data["world_transform"] = transform.matrix.T
         self.uniform_buffer.data["world_transform_inv"] = transform.inverse_matrix.T
-        self.uniform_buffer.update_range()
+        self.uniform_buffer.update_full()
 
     def __repr__(self):
         return f"<pygfx.{self.__class__.__name__} {self.name} at {hex(id(self))}>"

--- a/pygfx/objects/_instanced.py
+++ b/pygfx/objects/_instanced.py
@@ -36,7 +36,9 @@ class InstancedMesh(Mesh):
             ]
         )
         instance_infos = np.zeros(count, dtype)
-        self._store.instance_buffer = Buffer(instance_infos, nitems=count)
+        self._store.instance_buffer = Buffer(
+            instance_infos, nitems=count, force_contiguous=True
+        )
         # Set ids
         self._idmap = {}
         for instance_index in range(count):

--- a/pygfx/objects/_lights.py
+++ b/pygfx/objects/_lights.py
@@ -92,7 +92,7 @@ class Light(WorldObject):
     @color.setter
     def color(self, color):
         self.uniform_buffer.data["color"] = Color(color)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def intensity(self):
@@ -113,7 +113,7 @@ class Light(WorldObject):
     @intensity.setter
     def intensity(self, value):
         self.uniform_buffer.data["intensity"] = float(value)
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def cast_shadow(self):
@@ -226,7 +226,7 @@ class PointLight(Light):
     @distance.setter
     def distance(self, value):
         self.uniform_buffer.data["distance"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def decay(self):
@@ -239,7 +239,7 @@ class PointLight(Light):
     @decay.setter
     def decay(self, value):
         self.uniform_buffer.data["decay"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
 
 class DirectionalLight(Light):
@@ -434,7 +434,7 @@ class SpotLight(Light):
     @distance.setter
     def distance(self, value):
         self.uniform_buffer.data["distance"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def angle(self):
@@ -450,7 +450,7 @@ class SpotLight(Light):
         self.uniform_buffer.data["cone_cos"] = cone_cos
         penumbra_cos = math.cos(self.angle * (1 - self.penumbra))
         self.uniform_buffer.data["penumbra_cos"] = penumbra_cos
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def penumbra(self):
@@ -464,7 +464,7 @@ class SpotLight(Light):
         self._penumbra = value
         penumbra_cos = math.cos(self.angle * (1 - self.penumbra))
         self.uniform_buffer.data["penumbra_cos"] = penumbra_cos
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
     @property
     def decay(self):
@@ -477,7 +477,7 @@ class SpotLight(Light):
     @decay.setter
     def decay(self, value):
         self.uniform_buffer.data["decay"] = value
-        self.uniform_buffer.update_range(0, 1)
+        self.uniform_buffer.update_full()
 
 
 # shadows
@@ -551,7 +551,7 @@ class LightShadow:
     def _gfx_update_uniform_buffer(self, light: Light):
         light.uniform_buffer.data["shadow_bias"] = self._bias
         self._update_matrix(light)
-        light.uniform_buffer.update_range(0, 1)
+        light.uniform_buffer.update_full()
 
     def _update_matrix(self, light: Light) -> None:
         shadow_camera = self.camera
@@ -562,7 +562,7 @@ class LightShadow:
         self._gfx_matrix_buffer.data["light_view_proj_matrix"] = (
             shadow_camera.camera_matrix.T
         )
-        self._gfx_matrix_buffer.update_range(0, 1)
+        self._gfx_matrix_buffer.update_full()
 
         light.uniform_buffer.data["light_view_proj_matrix"] = (
             shadow_camera.camera_matrix.T
@@ -652,5 +652,5 @@ class PointLightShadow(LightShadow):
             self._gfx_matrix_buffer[i].data[
                 "light_view_proj_matrix"
             ] = camera.camera_matrix.T
-            self._gfx_matrix_buffer[i].update_range(0, 1)
-        light.uniform_buffer.update_range(0, 1)
+            self._gfx_matrix_buffer[i].update_full()
+        light.uniform_buffer.update_full()

--- a/pygfx/objects/_lights.py
+++ b/pygfx/objects/_lights.py
@@ -515,7 +515,9 @@ class LightShadow:
         # TODO: move bias and cull_mode to Light so they can be reactive?
         self.bias = 0
         self.cull_mode = "front"
-        self._gfx_matrix_buffer = Buffer(array_from_shadertype(shadow_uniform_type))
+        self._gfx_matrix_buffer = Buffer(
+            array_from_shadertype(shadow_uniform_type), force_contiguous=True
+        )
 
     @property
     def camera(self):
@@ -627,7 +629,9 @@ class PointLightShadow(LightShadow):
         self._gfx_matrix_buffer = []
 
         for _ in range(6):
-            buffer = Buffer(array_from_shadertype(shadow_uniform_type))
+            buffer = Buffer(
+                array_from_shadertype(shadow_uniform_type), force_contiguous=True
+            )
             self._gfx_matrix_buffer.append(buffer)
 
     def _update_matrix(self, light: Light) -> None:

--- a/pygfx/objects/_ruler.py
+++ b/pygfx/objects/_ruler.py
@@ -419,8 +419,8 @@ class Ruler(WorldObject):
             new_n_slots = max(min_n_slots, int(n_positions * 1.2))
             positions = np.zeros((new_n_slots, 3), np.float32)
             sizes = np.zeros((new_n_slots,), np.float32)
-            self.points.geometry.positions = Buffer(positions)
-            self.points.geometry.sizes = Buffer(sizes)
+            self.points.geometry.positions = Buffer(positions, force_contiguous=True)
+            self.points.geometry.sizes = Buffer(sizes, force_contiguous=True)
             # Allocate text objects
             while len(self._text_object_pool) < new_n_slots:
                 ob = Text(

--- a/pygfx/objects/_ruler.py
+++ b/pygfx/objects/_ruler.py
@@ -412,8 +412,8 @@ class Ruler(WorldObject):
             # Re-use existing buffers
             positions = self.points.geometry.positions.data
             sizes = self.points.geometry.sizes.data
-            self.points.geometry.positions.update_range()
-            self.points.geometry.sizes.update_range()
+            self.points.geometry.positions.update_full()
+            self.points.geometry.sizes.update_full()
         else:
             # Allocate new buffers
             new_n_slots = max(min_n_slots, int(n_positions * 1.2))

--- a/pygfx/objects/_skins.py
+++ b/pygfx/objects/_skins.py
@@ -53,7 +53,8 @@ class Skeleton:
                     "bone_matrices": "4x4xf4",
                 },
                 count,
-            )
+            ),
+            force_contiguous=True,
         )
 
         if len(self.bone_inverses) == 0:

--- a/pygfx/objects/_skins.py
+++ b/pygfx/objects/_skins.py
@@ -106,7 +106,7 @@ class Skeleton:
                 bone.world.matrix @ self.bone_inverses[i]
             ).T
 
-        self.bone_matrices_buffer.update_range()
+        self.bone_matrices_buffer.update_full()
 
     def get_bone(self, name):
         for bone in self.bones:
@@ -145,7 +145,7 @@ class SkinnedMesh(Mesh):
     def bind_matrix(self, value):
         self._bind_matrix = value
         self.uniform_buffer.data["bind_matrix"] = self._bind_matrix.T
-        self.uniform_buffer.update_range()
+        self.uniform_buffer.update_full()
 
     @property
     def bind_matrix_inv(self):
@@ -156,7 +156,7 @@ class SkinnedMesh(Mesh):
     def bind_matrix_inv(self, value):
         self._bind_matrix_inv = value
         self.uniform_buffer.data["bind_matrix_inv"] = self._bind_matrix_inv.T
-        self.uniform_buffer.update_range()
+        self.uniform_buffer.update_full()
 
     @property
     def bind_mode(self):

--- a/pygfx/renderers/wgpu/engine/environment.py
+++ b/pygfx/renderers/wgpu/engine/environment.py
@@ -84,7 +84,7 @@ class Environment(Trackable):
         # The ambient light binding is easy, because ambient lights can be combined on CPU
 
         self.ambient_lights_buffer = Buffer(
-            array_from_shadertype(self._ambient_uniform_type)
+            array_from_shadertype(self._ambient_uniform_type), force_contiguous=True
         )
         self.bindings.append(
             Binding(
@@ -101,7 +101,8 @@ class Environment(Trackable):
         self.directional_lights_shadow_texture = None
         if self.dir_lights_num > 0:
             self.directional_lights_buffer = Buffer(
-                array_from_shadertype(self._dir_uniform_type, self.dir_lights_num)
+                array_from_shadertype(self._dir_uniform_type, self.dir_lights_num),
+                force_contiguous=True,
             )
             self.bindings.append(
                 Binding(
@@ -141,7 +142,8 @@ class Environment(Trackable):
         self.point_lights_shadow_texture = None
         if self.point_lights_num > 0:
             self.point_lights_buffer = Buffer(
-                array_from_shadertype(self._point_uniform_type, self.point_lights_num)
+                array_from_shadertype(self._point_uniform_type, self.point_lights_num),
+                force_contiguous=True,
             )
             self.bindings.append(
                 Binding(
@@ -181,7 +183,8 @@ class Environment(Trackable):
         self.spot_lights_shadow_texture = None
         if self.spot_lights_num > 0:
             self.spot_lights_buffer = Buffer(
-                array_from_shadertype(self._spot_uniform_type, self.spot_lights_num)
+                array_from_shadertype(self._spot_uniform_type, self.spot_lights_num),
+                force_contiguous=True,
             )
             self.bindings.append(
                 Binding(

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -673,7 +673,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
         stdinfo_data["physical_size"] = physical_size
         stdinfo_data["logical_size"] = logical_size
         # Upload to GPU
-        self._shared.uniform_buffer.update_range(0, 1)
+        self._shared.uniform_buffer.update_full()
 
     # Picking
 

--- a/pygfx/renderers/wgpu/engine/shared.py
+++ b/pygfx/renderers/wgpu/engine/shared.py
@@ -83,7 +83,9 @@ class Shared(Trackable):
         # Create a uniform buffer for std info
         # Stored on _store so if we'd ever swap it out for another buffer,
         # the pipeline automatically update.
-        self._store.uniform_buffer = Buffer(array_from_shadertype(stdinfo_uniform_type))
+        self._store.uniform_buffer = Buffer(
+            array_from_shadertype(stdinfo_uniform_type), force_contiguous=True
+        )
         self._store.uniform_buffer._wgpu_usage |= wgpu.BufferUsage.UNIFORM
 
         # Init glyph atlas texture

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -184,7 +184,9 @@ class LineShader(BaseShader):
                 "For rendering (thick) lines, the geometry.positions must be Nx3."
             )
 
-        uniform_buffer = Buffer(array_from_shadertype(renderer_uniform_type))
+        uniform_buffer = Buffer(
+            array_from_shadertype(renderer_uniform_type), force_contiguous=True
+        )
         uniform_buffer.data["last_i"] = positions1.nitems - 1
 
         rbuffer = "buffer/read_only_storage"

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -310,7 +310,7 @@ class Buffer(Resource):
         nitems = self.nitems
         # Normalize inputs
         offset = int(offset or 0)
-        size = int(self.nitems if size is None else size)
+        size = int(nitems if size is None else size)
         # Checks
         if size == 0:
             return
@@ -321,6 +321,9 @@ class Buffer(Resource):
         # Get indices
         index1 = offset
         index2 = min(nitems, offset + size)
+        # Shortcut?
+        if index1 == 0 and index2 == nitems:
+            return self.update_full()
         # Update map
         div = self._chunk_size
         self._chunk_mask[floor(index1 / div) : ceil(index2 / div)] = True

--- a/pygfx/utils/text/_atlas.py
+++ b/pygfx/utils/text/_atlas.py
@@ -400,7 +400,7 @@ class PygfxGlyphAtlas(GlyphAtlas):
         super()._set_new_glyphs_array(*args)
         # Create resource object if needed
         if self._array is not array:
-            self._texture = Texture(self._array, dim=2)
+            self._texture = Texture(self._array, dim=2, force_contiguous=True)
         # Schedule an update. Note that the infos array is updated due to repacking.
         w, h = self._array.shape[1], self._array.shape[0]
         self._texture.update_range((0, 0, 0), (w, h, 1))
@@ -412,7 +412,7 @@ class PygfxGlyphAtlas(GlyphAtlas):
         super()._set_new_infos_array(*args)
         # Create resource object if needed
         if self._infos is not infos:
-            self._infos_buffer = Buffer(self._infos)
+            self._infos_buffer = Buffer(self._infos, force_contiguous=True)
         # Schedule an update
         self._infos_buffer.update_range(0, self._infos.shape[0])
 


### PR DESCRIPTION
*Relies on #795*

* [x] Change `.update_range()` to `.update_full()` or `.update_indices()` where it makes sense.
* [x] Use `force_contiguous` internally.
* [x] Make `update_range()` call `update_full`, if without args, or args resilting in a full range.