### PR TITLE
Small change in spelling

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,15 +1,15 @@
-# pygfx code of conduct
+# Pygfx code of conduct
 
 ## Introduction
 
-This code of conduct applies to all spaces managed by the pygfx project, 
-including all public and private mailing lists, issue trackers, wikis, blogs, 
-Twitter, and any other communication channel used by our community, including 
-any in-person events, whether directly organized by pygfx developers 
-or associated people. 
+This code of conduct applies to all spaces managed by the Pygfx project,
+including all public and private mailing lists, issue trackers, wikis, blogs,
+Twitter, and any other communication channel used by our community, including
+any in-person events, whether directly organized by Pygfx developers
+or associated people.
 
 This code of conduct should be honored by everyone who participates in
-the pygfx community formally or informally, or claims any affiliation with the
+the Pygfx community formally or informally, or claims any affiliation with the
 project, in any project-related activities, and, especially, when representing the
 project, in any role.
 
@@ -80,24 +80,24 @@ most appropriate). If you would prefer not to do that, please feel free to
 report to the Code of Conduct committee directly, or ask the committee for
 advice, in confidence.
 
-You can report issues to the pygfx core team: 
+You can report issues to the Pygfx core team:
 
 [Korijn van Golen](https://github.com/Korijn)
 [Almar Klein](https://github.com/almarklein)
 
-If your report involves any members of the pygfx core team, or if they feel they have
+If your report involves any members of the Pygfx core team, or if they feel they have
 a conflict of interest in handling it, then they will recuse themselves from
 considering your report.
 
 ## Incident reporting resolution & Code of Conduct enforcement
 
-We will investigate and respond to all complaints. The pygfx Code of Conduct
-Committee and the pygfx Steering Committee (if involved) will protect the
+We will investigate and respond to all complaints. The Pygfx Code of Conduct
+Committee and the Pygfx Steering Committee (if involved) will protect the
 identity of the reporter, and treat the content of complaints as confidential
 (unless the reporter agrees otherwise).
 
 In case of severe and obvious breaches, e.g., personal threat or violent, sexist
-or racist language, we will immediately disconnect the originator from pygfx
+or racist language, we will immediately disconnect the originator from Pygfx
 communication channels; please see the manual for details.
 
 In cases not involving clear severe and obvious breaches of this code of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,7 @@ Currently, the best way to ask for help from the maintainers is to start a
 
 ## Coding Style
 
-The pygfx project uses `black` to automatically format the code. Additionally
+The Pygfx project uses `black` to automatically format the code. Additionally
 `flake8` is used to ensure "clean code". Use these commands:
 
 ```bash
@@ -80,5 +80,5 @@ We distinguish four kinds of attributes:
 
 * Public attributes for the user: should in most cases be ``@property``'s.
 * Private attributes: prefixed with "_" as usual.
-* Attributes used by other parts of pygfx but not intended for the user: prefixed with "_gfx_".
+* Attributes used by other parts of Pygfx but not intended for the user: prefixed with "_gfx_".
 * Attributes to store WgpuRenderer-specific data on a WorldObject or Material (the objects themselves are unaware): prefixed with "_wgpu_".

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center"><img src="docs/_static/pygfx.svg" height="80"><br>pygfx</h1>
+<h1 align="center"><img src="docs/_static/pygfx.svg" height="80"><br>Pygfx</h1>
 
 [![CI ](https://github.com/pygfx/pygfx/workflows/CI/badge.svg)
 ](https://github.com/pygfx/pygfx/actions)
@@ -28,7 +28,7 @@ Pygfx (pronounced "py-graphics") is built on [wgpu](https://github.com/pygfx/wgp
 Need help? We offer the following professional services:
 
 * **Priority Support:** Rest assured with our dedicated support, prioritizing your needs for quick issue resolution and feature implementation.
-* **Integration Support:** Get assistance with integrating pygfx into your application, ensuring a smooth transition and optimal performance.
+* **Integration Support:** Get assistance with integrating Pygfx into your application, ensuring a smooth transition and optimal performance.
 * **Customized Solutions:** Whether it's crafting specific visualizations or developing shaders, we work closely with you to create tailored solutions that address your unique requirements.
 * **Training and Workshops:** We provide informative training sessions and workshops aimed at boosting skills and knowledge.
 
@@ -41,7 +41,7 @@ For further inquiries reach out to us at [support@pygfx.com](mailto:support@pygf
 pip install -U pygfx glfw
 ```
 
-To work correctly, pygfx needs _some_ window to render to. Glfw is one
+To work correctly, Pygfx needs _some_ window to render to. Glfw is one
 lightweight option, but there are others, too. If you use a different
 wgpu-compatible window manager or only render offscreen you may choose to omit
 glfw. Examples of alternatives include: `jupyter_rfb` (rendering in Jupyter),
@@ -57,7 +57,7 @@ We're currently working towards version `1.0`, which means that the API
 can change with each version. We expect to reach `1.0` near the end of
 2024, at which point we start caring about backwards compatibility.
 
-This means that until then, you should probably pin the pygfx version
+This means that until then, you should probably pin the Pygfx version
 that you're using, and check the [release notes](https://github.com/pygfx/pygfx/releases)
 when you update.
 
@@ -93,7 +93,7 @@ if __name__ == "__main__":
 
 
 ## Feature Highlights
-Some of pygfx's key features are:
+Some of Pygfx's key features are:
 
 - SDF based text rendering ([example](
   https://pygfx.com/stable/_gallery/feature_demo/text_contrast.html))
@@ -117,14 +117,14 @@ Pygfx is licensed under the [BSD 2-Clause "Simplified" License](LICENSE). This m
 - :white_check_mark: It is free (and open source) forever. :cupid:
 - :white_check_mark: You _can_ use it commercially.
 - :white_check_mark: You _can_ distribute it and freely make changes.
-- :x: You _can not_ hold us accountable for the results of using pygfx.
+- :x: You _can not_ hold us accountable for the results of using Pygfx.
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ### Development Install
-To get a working dev install of pygfx you can use the following steps:
+To get a working dev install of Pygfx you can use the following steps:
 
 ```bash
 # Click the Fork button on GitHub and navigate to your fork
@@ -147,3 +147,9 @@ tests for the examples.
 ### Code of Conduct
 
 Our code of conduct can be found here: [Code of Conduct](./CODE_OF_CONDUCT.md)
+
+
+## Spelling and pronunciation
+
+Lowercase "pygfx" is used in code. You can refer to the project in written text using "Pygfx".
+Pygfx is pronounced as *pie-graphics*.

--- a/docs/advanced_shaders.rst
+++ b/docs/advanced_shaders.rst
@@ -1,9 +1,9 @@
 Writing custom shaders
 ======================
 
-This document explains how to write shaders for pygfx for the WgpuRenderer.
+This document explains how to write shaders for Pygfx for the WgpuRenderer.
 This may be useful if you want to improve the existing shaders, add new
-shaders to pygfx, or if you want to implement custom shaders in your
+shaders to Pygfx, or if you want to implement custom shaders in your
 own project.
 
 
@@ -156,9 +156,9 @@ Varyings
 
 Variables passed between vertex shader and fragment shader are called "varyings"
 in GPU terminology (because they vary as they are interpolated between
-vertices). In pygfx, each vertex function has a ``Varyings`` as output,
+vertices). In Pygfx, each vertex function has a ``Varyings`` as output,
 and this is the input of every fragment function. You don't have to
-define the ``Varyings`` struct anywhere - pygfx takes care of that based
+define the ``Varyings`` struct anywhere - Pygfx takes care of that based
 on the attributes that are assigned in the vertex shader. The only catch
 is that the attributes must be set with an explicit type cast:
 
@@ -192,9 +192,9 @@ FragmentOutput
 In a somewhat similar way, the output of the fragment shader is
 predefined. Though in this case the output is determined by the blend
 mode and render pass (opaque or transparent), and the details are hidden
-from the shader author. This way, pygfx can support advanced handling
+from the shader author. This way, Pygfx can support advanced handling
 of transparency without affecting individual shaders.
-All fragment functions in pygfx are somewhat like this:
+All fragment functions in Pygfx are somewhat like this:
 
 
 .. code-block:: python
@@ -289,7 +289,7 @@ discard the fragment if it's outside of the clipping planes. Or use
 Colormapping
 ------------
 
-Many materials in pygfx support colormapping. We distinguish between colormaps
+Many materials in Pygfx support colormapping. We distinguish between colormaps
 with image input data, and vertex input data (texture coordinates). The number of
 channels of the input data must match the dimensionality of the colormap (1D, 2D or 3D).
 

--- a/docs/guide.rst
+++ b/docs/guide.rst
@@ -1,5 +1,5 @@
 ===============
-The pygfx guide
+The Pygfx guide
 ===============
 
 
@@ -19,7 +19,7 @@ or install the bleeding edge from Github:
     pip install -U https://github.com/pygfx/pygfx/archive/main.zip
 
 
-What is pygfx?
+What is Pygfx?
 --------------
 
 Pygfx is a render engine. It renders objects that are organized in a scene, and
@@ -31,7 +31,7 @@ The `WGPU <https://github.com/pygfx/wgpu-py>`_ library provides the low level AP
 communicate with the hardware. WGPU is itself based on Vulkan, Metal and DX12.
 
 
-How to use pygfx?
+How to use Pygfx?
 -----------------
 
 Before jumping into the details, here is a minimal example of how to use the
@@ -50,7 +50,7 @@ library::
 .. image:: _static/guide_hello_world.png
 
 And with that we rendered our first scene using wgpu! Simple, right? At the same
-time, this is just scratching the surface of what we can do with pygfx and next
+time, this is just scratching the surface of what we can do with Pygfx and next
 up we will have a look at the three main building blocks involved in creating
 more complex rendering setups: (1) `Scenes`, (2) `Canvases`, and (3)
 `Renderers`.
@@ -109,7 +109,7 @@ exactly what you've created and potentially spot any problems.
 
 The second main building block is the `Canvas`. A `Canvas` provides the surface
 onto which the scene should be rendered, and to use it we directly import it
-from wgpu-py (on top of which pygfx is built). Wgpu-py has several canvases that
+from wgpu-py (on top of which Pygfx is built). Wgpu-py has several canvases that
 we can choose from, but for starters the most important one is ``auto``, which
 automatically selects an appropriate backend to create a window on your screen::
 
@@ -528,7 +528,7 @@ both direct and colormapped colors can be 1-4 values.
 Colorspaces
 ===========
 
-All colors in pygfx are interpreted as sRGB by default. This is the same
+All colors in Pygfx are interpreted as sRGB by default. This is the same
 how webbrowsers interpret colors. Internally, all calculations are performed
 in the physical colorspace (sometimes called Linear sRGB) so that these
 calculations are physically correct.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@
 
 .. raw:: html
 
-    <h1 class="frontpage-header">pygfx</h1>
+    <h1 class="frontpage-header">Pygfx</h1>
 
 Pygfx' purpose is to bring powerful and reliable visualization to the Python world. 🚀
 

--- a/docs/using_pygfx_gallery_scraper.rst
+++ b/docs/using_pygfx_gallery_scraper.rst
@@ -1,8 +1,8 @@
-Using the pygfx gallery scraper
+Using the Pygfx gallery scraper
 ===============================
 
 Pygfx implements its own scraper for Sphinx-gallery. Upstream projects that want
-to create a gallery using pygfx, can make use of it.
+to create a gallery using Pygfx, can make use of it.
 
 
 In conf.py
@@ -43,7 +43,7 @@ example that you want to have in the docs.
 Finding the canvas
 ------------------
 
-The pygfx scraper needs to find the canvas or renderer to take the screenshot from.
+The Pygfx scraper needs to find the canvas or renderer to take the screenshot from.
 It does this by looking for an object called ``disp``, ``renderer`` or ``canvas``.
 
 If your library hides these details, we're open to expanding the logic so it is
@@ -59,6 +59,6 @@ You don't have to use the ``find_examples_for_gallery()`` to collect examples.
 You can also set "ignore_pattern" and "filename_pattern" yourself. However, if
 the scaper does not see the comment, it won't render a screenshot.
 
-You can also create your own scraper and re-use some parts of the pygfx scraper.
+You can also create your own scraper and re-use some parts of the Pygfx scraper.
 We tried to write ```pygfx/utils/gallery_scraper.py`` such that the code is very
 much re-usable.

--- a/examples/HOWTO.md
+++ b/examples/HOWTO.md
@@ -1,15 +1,15 @@
 # How to contribute examples
 
-This folder contain the pygfx example scripts.
+This folder contain the Pygfx example scripts.
 
 
 ## Purpose
 
 Examples can serve a few purposes:
 
-* They demonstrate the capabilities of pygfx.
+* They demonstrate the capabilities of Pygfx.
 * They explain how a particular visualization is performed (i.e. documentation).
-* They help make sure that pygfx does what it promises (i.e. testing).
+* They help make sure that Pygfx does what it promises (i.e. testing).
 
 When creating / modifying an example, keep in mind how they're used.
 

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -1,2 +1,2 @@
-Examples that use pygfx
+Examples that use Pygfx
 =======================

--- a/examples/feature_demo/multiprocessing_zmq/compute.py
+++ b/examples/feature_demo/multiprocessing_zmq/compute.py
@@ -1,8 +1,8 @@
 """
-Compute data and send over zmq to be rendered by pygfx in another process
+Compute data and send over zmq to be rendered by Pygfx in another process
 =========================================================================
 
-Example that demonstrates how to use zmq send data to another process that then uses pygfx to visualize it.
+Example that demonstrates how to use zmq send data to another process that then uses Pygfx to visualize it.
 Use in conjunction with "view.py" in this directory.
 
 First run `view.py`, and then separately run `compute.py`

--- a/examples/other/integration_pytorch.py
+++ b/examples/other/integration_pytorch.py
@@ -7,8 +7,8 @@ Pytorch Integration
 
 Pygfx Integration with PyTorch Lightning and PyTorch Geometric: A Practical Example.
 
-This code example demonstrates the integration of pygfx with PyTorch Lightning and PyTorch Geometric for training a
-graph neural network on a 3D mesh and simultaneously rendering the results in real-time using pygfx.
+This code example demonstrates the integration of Pygfx with PyTorch Lightning and PyTorch Geometric for training a
+graph neural network on a 3D mesh and simultaneously rendering the results in real-time using Pygfx.
 
 ARCHITECTURE:
 The code example follows a modular architecture, separating the concerns of data loading, model definition, training,
@@ -32,7 +32,7 @@ and rendering. The main components of the architecture are:
    - Configures the optimizer for training.
 
 4. Rendering (SceneHandler):
-   - Handles the creation and rendering of the pygfx scene.
+   - Handles the creation and rendering of the Pygfx scene.
    - Creates two viewports: one for the ground truth mesh and another for the predicted mesh.
    - Receives mesh data messages from the training process via a multiprocessing queue.
    - Updates the meshes in the scene based on the received mesh data.
@@ -40,9 +40,9 @@ and rendering. The main components of the architecture are:
 
 5. Callback (PyGfxCallback):
    - Facilitates communication between the training process and the rendering process.
-   - Creates a separate process for pygfx rendering.
+   - Creates a separate process for Pygfx rendering.
    - Sends mesh data messages to the rendering process via a multiprocessing queue.
-   - Updates the meshes in the pygfx scene based on the training progress and results.
+   - Updates the meshes in the Pygfx scene based on the training progress and results.
 
 INTERACTION:
 The interaction between the different components of the code example is as follows:
@@ -59,19 +59,19 @@ The interaction between the different components of the code example is as follo
 4. During training, the PyTorch Lightning Trainer uses the ExampleDataModule to load the data and the ExampleModule to
    define the model and training process.
 
-5. The PyGfxCallback, registered as a callback with the Trainer, creates a separate process for pygfx rendering using
+5. The PyGfxCallback, registered as a callback with the Trainer, creates a separate process for Pygfx rendering using
    the SceneHandler.
 
 6. After each training or validation batch, the PyGfxCallback sends the mesh data (vertices, faces, ground truth
    curvature, and predicted curvature) to the rendering process via a multiprocessing queue.
 
 7. The SceneHandler, running in a separate process, receives the mesh data messages from the queue and updates the
-   meshes in the pygfx scene accordingly. It colors the meshes based on the Gaussian curvature values.
+   meshes in the Pygfx scene accordingly. It colors the meshes based on the Gaussian curvature values.
 
-8. The pygfx rendering process continuously renders the scene, displaying the ground truth and predicted meshes in
+8. The Pygfx rendering process continuously renders the scene, displaying the ground truth and predicted meshes in
    real-time as the training progresses.
 
-This architecture allows for seamless integration of pygfx with PyTorch Lightning and PyTorch Geometric, enabling
+This architecture allows for seamless integration of Pygfx with PyTorch Lightning and PyTorch Geometric, enabling
 real-time visualization of the training progress and results on a 3D mesh. The modular design separates the concerns
 of data loading, model definition, training, and rendering, making the code more maintainable and extensible.
 

--- a/examples/other/integration_qt.py
+++ b/examples/other/integration_qt.py
@@ -1,5 +1,5 @@
 """
-Integrate pygfx in Qt
+Integrate Pygfx in Qt
 =====================
 """
 

--- a/pygfx/cameras/_base.py
+++ b/pygfx/cameras/_base.py
@@ -57,7 +57,7 @@ class NDCCamera(Camera):
 
     Its projection matrix is the identity transform (but its position and rotation can still be set).
 
-    In the NDC coordinate system of WGPU (and pygfx), x and y are in
+    In the NDC coordinate system of wgpu (and Pygfx), x and y are in
     the range -1..1, z is in the range 0..1, and (-1, -1, 0) represents
     the bottom left corner.
     """

--- a/pygfx/controllers/_base.py
+++ b/pygfx/controllers/_base.py
@@ -37,11 +37,11 @@ class Controller:
     -----
 
     There are multiple ways that the controller can be used.
-    The easiest (and most common) approach is to use the pygfx event system and
+    The easiest (and most common) approach is to use the Pygfx event system and
     make the controller listen to viewport events (using ``register_events``).
 
     An alternative is to feed your own events into the ``handle_event()``
-    method. You'd have to mimic or use pygfx event objects.
+    method. You'd have to mimic or use Pygfx event objects.
 
     The controller can also be used programmatically by calling "action methods"
     like ``pan()``, ``zoom()`` and ``rotate()``.

--- a/pygfx/geometries/_text.py
+++ b/pygfx/geometries/_text.py
@@ -72,6 +72,12 @@ class TextItem:
         Newline after the text.
     allow_break : bool
         If True, allow a linebreak to be placed after this piece of text.
+    index : int
+        Index into the positions buffer. If given,
+        this text item is positioned relative to geometry.positions[index] (in world coords).
+        All further text items are positioned with the same position.
+        The layout algorithm does a fresh start when it encounters a text item with a given index.
+        This way one can create groups of text that are positioned and layed out individually.
 
     """
 
@@ -233,9 +239,20 @@ class TextGeometry(Geometry):
         super().__init__()
 
         # Init stub buffers
-        self.indices = None
-        self.positions = None
-        self.sizes = None
+        # self.indices = None
+        # self.positions = None
+        # self.sizes = None
+
+        self.glyph_atlas_indices = None
+        self.glyph_item_indices = None
+        self.glyph_positions = None
+
+        # todo: rename by dropping prefix
+        self.item_positions = None
+        self.item_sizes = None
+        # self.colors = None
+
+        self._text_items = []
 
         # Init props unrelated to layout
         self.screen_space = screen_space
@@ -293,6 +310,12 @@ class TextGeometry(Geometry):
     @screen_space.setter
     def screen_space(self, value):
         self._store.screen_space = bool(value)
+
+    def set_text_item_count(self):
+        pass
+
+    def get_text_item(self):
+        """Get a new text item, that can be"""
 
     def set_text_items(self, text_items):
         """Update the text using one or more TextItems.
@@ -377,16 +400,19 @@ class TextGeometry(Geometry):
             glyph_count += item.indices.size
 
         # Do we need new buffers?
-        if self.indices is None or self.indices.nitems < glyph_count:
-            self.indices = Buffer(np.zeros((glyph_count,), np.uint32))
-            self.positions = Buffer(np.zeros((glyph_count, 2), np.float32))
+        if (
+            self.glyph_atlas_indices is None
+            or self.glyph_atlas_indices.nitems < glyph_count
+        ):
+            self.glyph_atlas_indices = Buffer(np.zeros((glyph_count,), np.uint32))
+            self.glyph_positions = Buffer(np.zeros((glyph_count, 2), np.float32))
             self.sizes = Buffer(np.zeros((glyph_count,), np.float32))
 
         # Copy the glyph arrays into the buffers
         for item in self._glyph_items:
             i1, i2 = item.offset, item.offset + item.indices.shape[0]
-            self.indices.data[i1:i2] = item.indices
-            self.positions.data[i1:i2] = item.positions
+            self.glyph_atlas_indices.data[i1:i2] = item.indices
+            self.glyph_positions.data[i1:i2] = item.positions
 
         # Disable the unused space by setting the sizes to zero, leading
         # to degenerate triangles. Leave the indices intact, so that
@@ -394,8 +420,8 @@ class TextGeometry(Geometry):
         self.sizes.data[glyph_count:] = 0
 
         # Trigger new indices and sizes to be uploaded to the GPU.
-        self.sizes.update_range(0, self.indices.nitems)
-        self.indices.update_range(0, self.indices.nitems)
+        self.sizes.update_range(0, self.sized.nitems)
+        self.glyph_atlas_indices.update_full()
 
         # Finalize the buffers by applying the layout algorithm.
         self.apply_layout()
@@ -615,15 +641,15 @@ class TextGeometry(Geometry):
             # bounding box.
             return np.array([[0, 0, 0], [0, 0, 0]], np.float32)
         else:
-            if self._aabb_rev == self.positions.rev:
+            if self._aabb_rev == self.glyph_positions.rev:
                 return self._aabb
-            pos = self.positions.data
+            pos = self.glyph_positions.data
             aabb_2d = np.array(
                 [np.nanmin(pos, axis=0), np.nanmax(pos, axis=0)], np.float32
             )
             self._aabb[1, 0] += self.font_size  # positions do not include char width
             self._aabb = np.column_stack([aabb_2d, np.zeros((2, 1), np.float32)])
-            self._aabb_rev = self.positions.rev
+            self._aabb_rev = self.glyph_positions.rev
             return self._aabb
 
     def _apply_layout(self):
@@ -673,7 +699,7 @@ class TextGeometry(Geometry):
             elif text_align_last == "start":
                 text_align_last = "right"
 
-        positions_array = self.positions.data
+        positions_array = self.glyph_positions.data
         sizes_array = self.sizes.data
         is_horizontal = self._direction is None or self._direction in ("ltr", "rtl")
 
@@ -858,7 +884,7 @@ class TextGeometry(Geometry):
 
         # Trigger uploads to GPU
         self.sizes.update_range(0, i2)
-        self.positions.update_range(0, i2)
+        self.glyph_positions.update_range(0, i2)
 
     def apply_layout(self):
         """Update the internal contained glyphs.

--- a/pygfx/resources/__init__.py
+++ b/pygfx/resources/__init__.py
@@ -1,7 +1,7 @@
 """
 Containers for buffers and textures.
 
-In pygfx, data is stored in buffers and textures. We collectively call these resources.
+In Pygfx, data is stored in buffers and textures. We collectively call these resources.
 
 .. currentmodule:: pygfx.resources
 

--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -1,5 +1,5 @@
 """
-Utility functions for pygfx.
+Utility functions for Pygfx.
 
 .. currentmodule:: pygfx.utils
 


### PR DESCRIPTION
## Changes

* [x] Change spelling to refer to the project to "Pygfx"
* [x] Add a note on spelling and pronounciation in readme.

## Reasoning, in case you're interested

At some point around #442 we decided that pygfx should be written all lowercase. We're not the only library that does this. Other examples include e.g. scikit-image, wgpu (the Rust project), aiohttp.

In my experience it feels a bit odd when writing about pygfx. The biggest hurdle being how to write it when its the first word in a sentence. There are a few approaches:
* Avoid using the word as the first word in a sentence, resting in stuff like "The xx library ...".
* Write the name in backticks. This kinda works in a readme or docs, but feels awkward in say a blog post.
* Still write the name all lowercase. I'm not from the language police, but this looks horrible to me.
* Write the first letter in uppercase. This looks better, but now it somehow feels weird to use lowercase later.

For the aforementioned projects that are written lowercase, they'd actually look weird if they'd start with an uppercase letter. And the same applies to wgpu-py, so I'd argue we keep it all lowercase for wgpu.

But pygfx looks perfectly fine written as Pygfx.

For clarity, this applies when referring to the project in written text. The name is still all lowercase in code, urls, etc.

BTW, we also considered PyGfx, but the "gfx" feel like they should not be broken up, and PyGFX feels off/intimidating.

 