### PR TITLE
Fix pick_write not really being dynamic

### DIFF
--- a/pygfx/renderers/wgpu/engine/pipeline.py
+++ b/pygfx/renderers/wgpu/engine/pipeline.py
@@ -335,6 +335,7 @@ class PipelineContainer:
             with wobject.tracker.track_usage("reset"):
                 self.wobject_info["pick_write"] = wobject.material.pick_write
             changed.update(("bindings", "pipeline_info", "render_info"))
+            self.wgpu_shaders = {}
 
         if "bindings" in changed:
             self.shader.unlock_hash()


### PR DESCRIPTION
Fixes #840

The problem was that the shaders remained intact and where never updated when the `pick_write` prop is changed.