### PR TITLE
Fix binding layout

### DIFF
--- a/pygfx/renderers/wgpu/engine/binding.py
+++ b/pygfx/renderers/wgpu/engine/binding.py
@@ -96,7 +96,7 @@ class Binding:
                 "buffer": {
                     "type": getattr(wgpu.BufferBindingType, subtype),
                     "has_dynamic_offset": False,
-                    "min_binding_size": resource.itemsize,
+                    "min_binding_size": resource.nbytes,
                 },
             }
         elif self.type.startswith("sampler/"):


### PR DESCRIPTION
After updating to the latest version of `wgpu-py`, I encountered an error in one of my use cases related to a mismatch between ResourceBinding and the pipeline layout:

```
In wgpuDeviceCreateRenderPipeline
Error matching ShaderStages(FRAGMENT) shader requirements against the pipeline
Shader global ResourceBinding { group: 0, binding: 0 } is not available in the pipeline layout
Buffer structure size 48, added to one element of an unbound array, if it's the last field, ended up greater than the given min_binding_size, which is 16
```

Upon look into it, I found that the `min_binding_size` was not properly set when creating the bind group layout.

This issue likely existed for a long time, but previous versions of `wgpu` did not report the error. It’s possible that the `min_binding_size` parameter did not take effect or was properly validated in earlier versions. 
