### PR TITLE
Use new repo of gltf assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -125,6 +125,7 @@ venv.bak/
 .mypy_cache/
 
 glTF-Sample-Models
+glTF-Sample-Assets
 reactive_rendering_state.pkl
 
 # jetbrains idea

--- a/examples/data/DamagedHelmet/README.md
+++ b/examples/data/DamagedHelmet/README.md
@@ -1,6 +1,6 @@
 # Damaged Helmet
 
-https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/DamagedHelmet
+https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/DamagedHelmet
 
 ## License Information
 

--- a/examples/other/sponza_scene.py
+++ b/examples/other/sponza_scene.py
@@ -5,7 +5,7 @@ Sponza Scene
 This example shows how to load the Sponza scene. To run it, you have
 to have access to the sponza demo scene, which you can get using::
 
-    git clone https://github.com/KhronosGroup/glTF-Sample-Models
+    git clone https://github.com/KhronosGroup/glTF-Sample-Assets
 
 The current implementation assumes that you cloned that repo
 in this directory, or *any* of its parent directories.
@@ -21,21 +21,15 @@ from wgpu.gui.auto import WgpuCanvas, run
 import pygfx as gfx
 
 
-# Note: __file__ is the relative path from cwd when called as "__main__". Hence,
-# we need to resolve() to allow calling from anywhere in the repo.
-# Note: if we want a better way to find that repo, let's use an env var ...
-path = Path(__file__).resolve().parent
-while True:
-    gltf_samples_repo = path / "glTF-Sample-Models"
-    if gltf_samples_repo.is_dir():
+# Find assets directory
+for path in Path(__file__).resolve().parents:
+    gltf_samples_dir = path / "glTF-Sample-Assets"
+    if gltf_samples_dir.is_dir():
         break
-    try:
-        path = path.parents[0]
-    except IndexError:
-        raise RuntimeError("Could not find 'glTF-Sample-Models' directory.")
+else:
+    raise RuntimeError("Could not find 'glTF-Sample-Assets' directory.")
 
-
-gltf_path = gltf_samples_repo / "2.0" / "Sponza" / "glTF" / "Sponza.gltf"
+gltf_path = gltf_samples_dir / "Models" / "Sponza" / "glTF" / "Sponza.gltf"
 
 # Init
 canvas = WgpuCanvas(size=(640, 480), title="gltf viewer")

--- a/pygfx/materials/_compat.py
+++ b/pygfx/materials/_compat.py
@@ -107,7 +107,7 @@ def material_from_trimesh(x):
 
         if material.normalTexture is not None:
             gfx_material.normal_map = texture_from_pillow_image(material.normalTexture)
-            # See: https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/NormalTangentTest#problem-flipped-y-axis-or-flipped-green-channel
+            # See: https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/NormalTangentTest#problem-flipped-y-axis-or-flipped-green-channel
             gfx_material.normal_scale = (1.0, -1.0)
 
         if material.occlusionTexture is not None:

--- a/pygfx/utils/load_gltf.py
+++ b/pygfx/utils/load_gltf.py
@@ -318,7 +318,7 @@ class _GLTF:
                 scale_factor = 1.0
 
             # pygfx now assume the normal map is in tangent space, so we need to flip the y-axis.
-            # See: https://github.com/KhronosGroup/glTF-Sample-Models/tree/master/2.0/NormalTangentTest#problem-flipped-y-axis-or-flipped-green-channel
+            # See: https://github.com/KhronosGroup/glTF-Sample-Assets/tree/main/Models/NormalTangentTest#problem-flipped-y-axis-or-flipped-green-channel
             # TODO: support object space normal map, and flip the y-axis when only in tangent space.(check if the tangent attribute in the mesh primitive)
             gfx_material.normal_scale = (scale_factor, -scale_factor)
 


### PR DESCRIPTION
In our code we refer to this repo a few times: https://github.com/KhronosGroup/glTF-Sample-Models And the Sponza example requires it to be checked out in one of the parent directories. However, that repo is archived and replaced with https://github.com/KhronosGroup/glTF-Sample-Assets.

I just had trouble checking out the old repo, maybe cloning it is slower because it's archived? Anyway, using the new repo was much quicker, and I guess more future proof. Also updated some links to the old repo.