### PR TITLE
Use vstack and not row_stack

### DIFF
--- a/pygfx/objects/_ruler.py
+++ b/pygfx/objects/_ruler.py
@@ -256,7 +256,7 @@ class Ruler(WorldObject):
         # Get ndc coords for begin and end pos. Use numpy broadcasting for performance and compactness.
         positions = np.column_stack(
             [
-                np.row_stack([self._start_pos, self._end_pos]),
+                np.vstack([self._start_pos, self._end_pos]),
                 np.ones((2, 1), np.float64),
             ]
         )


### PR DESCRIPTION
  /home/mark/git/pygfx/pygfx/objects/_ruler.py:259: DeprecationWarning: `row_stack` alias is deprecated. Use `np.vstack` directly.
    np.row_stack([self._start_pos, self._end_pos]),

![image](https://github.com/user-attachments/assets/467980b8-7bcc-418b-a75a-64837af033e5)
