### PR TITLE
Get a longer version string on dev installs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,11 +116,12 @@ jobs:
     - name: Install package and dev dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -U -e .
+        pip install -U .
         pip install pytest psutil pyinstaller
     - name: Unit tests
       run: |
-        pytest -v pygfx/__pyinstaller
+        pushd $HOME
+        pytest -v --pyargs pygfx.__pyinstaller
 
   test-examples-build:
     name: Test examples ${{ matrix.pyversion }}
@@ -149,6 +150,7 @@ jobs:
         pip install -e .[examples]
     - name: Show wgpu backend
       run: |
+        python -c "import pygfx; print(pygfx.__version__)"
         python -c "from examples.tests.testutils import adapter; print(adapter.info)"
     - name: Test examples
       env:
@@ -188,6 +190,7 @@ jobs:
           rm -rf ./pygfx
           pushd $HOME
           pip install $GITHUB_WORKSPACE/dist/*.tar.gz
+          python -c "import pygfx; print(pygfx.__version__)"
           popd
           # don't run tests, we just want to know if the sdist can be installed
           pip uninstall -y pygfx

--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -1,5 +1,7 @@
+"""The Pygfx render engine."""
 # ruff: noqa: F401, F403
 
+from ._version import __version__, repo_dir as _repo_dir
 from . import utils
 
 from .resources import *
@@ -27,24 +29,23 @@ import pylinalg
 del pylinalg
 
 
-__version__ = "0.5.0"
-version_info = tuple(map(int, __version__.split(".")))
+version_info = tuple(
+    int(i) if i.isnumeric() else i for i in __version__.split("+")[0].split(".")
+)
 
 
 def _get_dependency_version_ranges():
+    # The only case where this dependency checking makes sense is for devs
+    # using pygfx from a Git repo.
+    if not _repo_dir:
+        return {}
     # Try import, dont care when this fails (e.g. frozen or py < 3.11)
     try:
         import os, tomllib  # noqa
     except ImportError:
         return {}
-    # Look for the pyproject file. If its there, pygfx is likely installed in dev mode,
-    # which is the only case where this dependency checking is interesting.
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    pyproject_file = os.path.join(this_dir, "..", "pyproject.toml")
-    if not os.path.isfile(pyproject_file):
-        return {}
-    # Load versions
-    with open(pyproject_file, "rb") as fp:
+    # Load dependency versions
+    with open(os.path.join(_repo_dir, "pyproject.toml"), "rb") as fp:
         dependencies = tomllib.load(fp)["project"]["dependencies"]
     # Parse
     limits_per_dependency = {}

--- a/pygfx/__main__.py
+++ b/pygfx/__main__.py
@@ -1,0 +1,48 @@
+"""A very tiny CLI.
+
+Invoke using e.g. ``python -m pygfx version``.
+"""
+
+import sys
+import argparse
+
+import pygfx
+
+
+def main(argv=None):
+    # Get argv so we can massage it
+    if argv is None:
+        argv = sys.argv
+    if argv and argv[0].endswith(".py"):
+        argv = argv[1:]
+
+    # Defaults and aliases
+    if not argv:
+        argv = ["help"]
+    if argv == ["--version"]:
+        argv = ["version"]
+
+    # Let the rest to argparse
+
+    parser = argparse.ArgumentParser(
+        prog="pygfx",
+        description="The (very basic) Pygfx CLI",
+    )
+
+    parser.add_argument(
+        "command", action="store", help="The command to run: 'help' or 'version'"
+    )
+
+    args = parser.parse_args(argv)
+    command = args.command.lower()
+
+    if command == "help":
+        parser.print_help()
+    if command == "version":
+        print("pygfx v" + pygfx.__version__)
+    else:
+        print(f"Invalid command '{command}'")
+
+
+if __name__ == "__main__":
+    main()

--- a/pygfx/_version.py
+++ b/pygfx/_version.py
@@ -1,0 +1,93 @@
+"""
+Versioning for Pygfx. We use a hard-coded version number, because it's simple
+and alwayd works. And for dev installs we add extra versioning info.
+"""
+
+import logging
+import subprocess
+from pathlib import Path
+
+
+# This is the reference version number, to be bumped before each release.
+# The build system (Flit) detects this definition when building a distribution.
+__version__ = "0.5.0"
+
+
+logger = logging.getLogger("pygfx")
+
+# Get whether this is a repo. If so, repo_dir is the path, otherwise repo_dir is None.
+repo_dir = Path(__file__).parents[1]
+repo_dir = repo_dir if repo_dir.joinpath(".git").is_dir() else None
+
+
+def get_version():
+    """Get the version string."""
+    if repo_dir:
+        return get_extended_version()
+    else:
+        return __version__
+
+
+def get_extended_version():
+    """Get an extended version string with information from git."""
+
+    release, post, labels = get_version_info_from_git()
+
+    # Sample first 3 parts of __version__
+    base_release = ".".join(__version__.split(".")[:3])
+
+    # Check release
+    if not release:
+        release = base_release
+    elif release != base_release:
+        logger.warning("Pygfx version from git and __version__ don't match.")
+
+    # Build the total version
+    version = release
+    if post and post != "0":
+        version += f".post{post}"
+    if labels:
+        version += "+" + ".".join(labels)
+
+    return version
+
+
+def get_version_info_from_git():
+    """Get (release, post, labels) from Git.
+
+    With `release` the version number from the latest tag, `post` the
+    number of commits since that tag, and `labels` a tuple with the
+    git-hash and optionally a dirty flag.
+    """
+
+    # Call out to Git
+    command = [
+        "git",
+        "describe",
+        "--long",
+        "--always",
+        "--tags",
+        "--dirty",
+        "--first-parent",
+    ]
+    p = subprocess.run(
+        command, cwd=repo_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+    )
+
+    # Parse the result into parts
+    output = p.stdout.decode(errors="ignore")
+    if p.returncode:
+        logger.warning("Could not get pygfx version: " + output)
+        parts = (None, None, "unknown")
+    else:
+        parts = output.strip().lstrip("v").split("-")
+        if len(parts) <= 2:
+            # No tags (and thus also no post). Only git hash and maybe 'dirty'
+            parts = (None, None, *parts)
+
+    # Return unpacked parts
+    release, post, *labels = parts
+    return release, post, labels
+
+
+__version__ = get_version()


### PR DESCRIPTION
Closes #696

This idea was discussed in https://github.com/pygfx/pygfx/issues/696, and recently @hmaarrfk nerd-sniped me again in https://github.com/hmaarrfk/pygfx/pull/9.

I still come to the conclusion that the source not having a hard-coded version number can easily become a source of problems (PyInstaller being one example).

So what I did in this PR: Still a hard-coded `__version__`, but when the code is in a git-repo (i.e. a dev build), the extra info from git is added to the version (number of commits since the release, git hash, dirty status).

Also added a tiny CLI, so one can do `python -m pygfx version`.