### PR TITLE
Do not mix stdout and stderr in version detection

### DIFF
--- a/pygfx/_version.py
+++ b/pygfx/_version.py
@@ -71,7 +71,7 @@ def get_version_info_from_git():
         "--first-parent",
     ]
     p = subprocess.run(
-        command, cwd=repo_dir, stdout=subprocess.PIPE, stderr=subprocess.STDOUT
+        command, cwd=repo_dir, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )
 
     # Parse the result into parts


### PR DESCRIPTION
Consider the strange strange case that a user wants to start their app through Steam.

And steam provides a 32 bit LDPRELOAD in 2024.

So the output is actually

> CompletedProcess(args=['git', 'describe', '--long', '--always', '--tags', '--dirty', '--first-parent'], returncode=0, stdout=b"ERROR: ld.so: object '/home/mark/.local/share/Steam/ubuntu12_32/gameoverlayrenderer.so' from LD_PRELOAD cannot be preloaded (wrong ELF class: ELFCLASS32): ignored.\nv0.5.0-3-g94e5939-dirty\n")


Which then wrecks any access to the version variable.

Korinj knew that these kinds of bugs would happen...