### PR TITLE
Fix that image shader was not invalided when map is set to None

### DIFF
--- a/pygfx/renderers/wgpu/shaders/imageshader.py
+++ b/pygfx/renderers/wgpu/shaders/imageshader.py
@@ -23,6 +23,41 @@ vertex_and_fragment = wgpu.ShaderStage.VERTEX | wgpu.ShaderStage.FRAGMENT
 class ImageShader(BaseShader):
     type = "render"
 
+    def __init__(self, wobject):
+        super().__init__(wobject)
+        material = wobject.material
+        geometry = wobject.geometry
+
+        # Check grid
+        if geometry.grid is None:
+            raise ValueError("Image.geometry must have a grid (texture).")
+        elif not isinstance(geometry.grid, Texture):
+            raise TypeError("Image.geometry.grid must be a Texture.")
+        elif geometry.grid.dim != 2:
+            raise TypeError("Image.geometry.grid must a 2D texture")
+
+        # Set img_format and climcorrection
+        self["climcorrection"] = ""
+        fmt = to_texture_format(geometry.grid.format)
+        if "norm" in fmt or "float" in fmt:
+            self["img_format"] = "f32"
+            if "unorm" in fmt:
+                self["climcorrection"] = " * 255.0"
+            elif "snorm" in fmt:
+                self["climcorrection"] = " * 255.0 - 128.0"
+        elif "uint" in fmt:
+            self["img_format"] = "u32"
+        else:
+            self["img_format"] = "i32"
+
+        # Channels
+        self["img_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
+
+        # Determine colorspace
+        self["colorspace"] = geometry.grid.colorspace
+        if material.map is not None:
+            self["colorspace"] = material.map.colorspace
+
     def get_bindings(self, wobject, shared):
         geometry = wobject.geometry
         material = wobject.material
@@ -33,43 +68,15 @@ class ImageShader(BaseShader):
             Binding("u_material", "buffer/uniform", material.uniform_buffer),
         ]
 
-        self["climcorrection"] = ""
-
-        # Collect texture and sampler
-        if geometry.grid is None:
-            raise ValueError("Image.geometry must have a grid (texture).")
-        else:
-            if not isinstance(geometry.grid, Texture):
-                raise TypeError("Image.geometry.grid must be a Texture.")
-            if geometry.grid.dim != 2:
-                raise TypeError("Image.geometry.grid must a 2D texture")
-            tex_view = GfxTextureView(geometry.grid)
-            sampler = GfxSampler(material.interpolation, "clamp")
-            self["colorspace"] = geometry.grid.colorspace
-            # Sampling type
-            fmt = to_texture_format(geometry.grid.format)
-            if "norm" in fmt or "float" in fmt:
-                self["img_format"] = "f32"
-                if "unorm" in fmt:
-                    self["climcorrection"] = " * 255.0"
-                elif "snorm" in fmt:
-                    self["climcorrection"] = " * 255.0 - 128.0"
-            elif "uint" in fmt:
-                self["img_format"] = "u32"
-            else:
-                self["img_format"] = "i32"
-            # Channels
-            self["img_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
-
+        tex_view = GfxTextureView(geometry.grid)
+        sampler = GfxSampler(material.interpolation, "clamp")
         bindings.append(Binding("s_img", "sampler/filtering", sampler, "FRAGMENT"))
         bindings.append(Binding("t_img", "texture/auto", tex_view, vertex_and_fragment))
 
-        # If a colormap is applied ...
         if material.map is not None:
             bindings.extend(
                 self.define_img_colormap(material.map, material.map_interpolation)
             )
-            self["colorspace"] = material.map.colorspace
 
         bindings = {i: b for i, b in enumerate(bindings)}
         self.define_bindings(0, bindings)

--- a/pygfx/renderers/wgpu/shaders/imageshader.py
+++ b/pygfx/renderers/wgpu/shaders/imageshader.py
@@ -28,6 +28,10 @@ class ImageShader(BaseShader):
         material = wobject.material
         geometry = wobject.geometry
 
+        # In this method we want to set all shader variables (i.e. self['xx']),
+        # so that we can properly detect when stuff changes that (may) affect
+        # these values, and trigger a recompile.
+
         # Check grid
         if geometry.grid is None:
             raise ValueError("Image.geometry must have a grid (texture).")

--- a/pygfx/renderers/wgpu/shaders/volumeshader.py
+++ b/pygfx/renderers/wgpu/shaders/volumeshader.py
@@ -19,29 +19,20 @@ vertex_and_fragment = wgpu.ShaderStage.VERTEX | wgpu.ShaderStage.FRAGMENT
 
 
 class BaseVolumeShader(BaseShader):
-    def get_bindings(self, wobject, shared):
-        geometry = wobject.geometry
+    def __init__(self, wobject):
+        super().__init__(wobject)
         material = wobject.material
+        geometry = wobject.geometry
 
-        bindings = [
-            Binding("u_stdinfo", "buffer/uniform", shared.uniform_buffer),
-            Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer),
-            Binding("u_material", "buffer/uniform", material.uniform_buffer),
-        ]
-
-        # Collect texture and sampler
+        # Check grid
         if geometry.grid is None:
             raise ValueError("Volume.geometry must have a grid (texture).")
-        if not isinstance(geometry.grid, Texture):
+        elif not isinstance(geometry.grid, Texture):
             raise TypeError("Volume.geometry.grid must be a Texture")
-        if geometry.grid.dim != 3:
+        elif geometry.grid.dim != 3:
             raise TypeError("Volume.geometry.grid must a 3D texture (view)")
 
-        tex_view = GfxTextureView(geometry.grid)
-        sampler = GfxSampler(material.interpolation, "clamp")
-        self["colorspace"] = geometry.grid.colorspace
-
-        # Sampling type
+        # Set image format
         self["climcorrection"] = ""
         fmt = to_texture_format(geometry.grid.format)
         if "norm" in fmt or "float" in fmt:
@@ -58,15 +49,30 @@ class BaseVolumeShader(BaseShader):
         # Channels
         self["img_nchannels"] = len(fmt) - len(fmt.lstrip("rgba"))
 
+        # Colorspace
+        self["colorspace"] = geometry.grid.colorspace
+        if material.map is not None:
+            self["colorspace"] = material.map.colorspace
+
+    def get_bindings(self, wobject, shared):
+        geometry = wobject.geometry
+        material = wobject.material
+
+        bindings = [
+            Binding("u_stdinfo", "buffer/uniform", shared.uniform_buffer),
+            Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer),
+            Binding("u_material", "buffer/uniform", material.uniform_buffer),
+        ]
+
+        tex_view = GfxTextureView(geometry.grid)
+        sampler = GfxSampler(material.interpolation, "clamp")
         bindings.append(Binding("s_img", "sampler/filtering", sampler, "FRAGMENT"))
         bindings.append(Binding("t_img", "texture/auto", tex_view, vertex_and_fragment))
 
-        # If a colormap is applied ...
         if material.map is not None:
             bindings.extend(
                 self.define_img_colormap(material.map, material.map_interpolation)
             )
-            self["colorspace"] = material.map.colorspace
 
         bindings = {i: b for i, b in enumerate(bindings)}
         self.define_bindings(0, bindings)

--- a/tests/utils/test_trackable.py
+++ b/tests/utils/test_trackable.py
@@ -251,6 +251,10 @@ def make_changes_on_sub(root, parent, t1, t2):
     t1.foo = 42
     assert not root.pop_changed()
 
+    # None is a valid value
+    t1.foo = None
+    assert root.pop_changed() == {"L1"}
+
     # -- Removing the sub
 
     parent.sub1 = None


### PR DESCRIPTION
Closes #881 

The problem was that the `.map` was used in `get_bindins()`, so setting the map to `None`  was detected as a change in bindings, but not as a change in the shader. Actually, all the setting of shader variables should happen in the `__init__` so that changes that affect shader variables are detected properly.

Fixed for both `Image`  and `Volume`.

Also added a little test to make sure that `None` is tracked as a value.