### PR TITLE
implement suggested improvements listed in issue343

### DIFF
--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -423,7 +423,7 @@ class Color:
         return h / 360.0, s / 100.0, light / 100.0, self.a
 
     def lerp(self, target, t):
-        """Linear interpolate from source color towards target color with factor t.
+        """Linear interpolate from source color towards target color with factor t in RGBA space.
 
         Parameters
         ----------
@@ -443,7 +443,7 @@ class Color:
         a = self.a + (target.a - self.a) * t
         return Color(r, g, b, a)
 
-    def lerp_in_hue(self, target, t, colorspace="hsv"):
+    def lerp_in_hue(self, target, t, colorspace="hsluv"):
         """Linear interpolate from source color towards target color with factor t in specified colorspace.
 
         Parameters
@@ -453,7 +453,7 @@ class Color:
         t : float
             Interpolation factor between 0 and 1
         colorspace : str
-            The colorspace to interpolate in. One of "hsl", "hsluv", "hsv"
+            The colorspace to interpolate in. One of "hsl", "hsluv", "hsv". Default is "hsluv"
 
         Returns
         -------
@@ -490,7 +490,7 @@ class Color:
 
         return to_rgba(h, s, light, a)
 
-    def lighter(self, factor=0.5, colorspace="hsv"):
+    def lighter(self, factor=0.5, colorspace="hsluv"):
         """Make the color lighter by the given factor.
 
         Parameters
@@ -498,7 +498,7 @@ class Color:
         factor : float
             Factor to lighten by, between 0 and 1. Default is 0.5
         colorspace : str
-            The colorspace to use, one of "hsl", "hsluv", or "hsv". Default is "hsl"
+            The colorspace to use, one of "hsl", "hsluv", or "hsv". Default is "hsluv"
 
         Returns
         -------
@@ -525,7 +525,7 @@ class Color:
             v = v + (1 - v) * factor
             return Color.from_hsv(h, s, v, self.a)
 
-    def darker(self, factor=0.5, colorspace="hsv"):
+    def darker(self, factor=0.5, colorspace="hsluv"):
         """Make the color darker by the given factor.
 
         Parameters
@@ -533,7 +533,7 @@ class Color:
         factor : float
             Factor to darken by, between 0 and 1. Default is 0.5
         colorspace : str
-            The colorspace to use, one of "hsl", "hsluv", or "hsv". Default is "hsl"
+            The colorspace to use, one of "hsl", "hsluv", or "hsv". Default is "hsluv"
 
         Returns
         -------

--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -340,7 +340,7 @@ class Color:
 
     @classmethod
     def from_hsv(cls, hue, saturation, value, alpha=1):
-        """Create a Color object from an a color in the HSV (a.k.a. HSB) colorspace.
+        """Create a Color object from a color in the HSV (a.k.a. HSB) colorspace.
 
         HSV stands for hue, saturation, value (aka brightness). The hue
         component indicates the color tone. Values go from red (0) to
@@ -366,7 +366,7 @@ class Color:
 
     @classmethod
     def from_hsl(cls, hue, saturation, lightness, alpha=1):
-        """Create a Color object from an a color in the HSL colorspace.
+        """Create a Color object from a color in the HSL colorspace.
 
         The HSL colorspace is similar to the HSV colorspace, except the
         "value" is replaced with "lightness". This lightness scales the
@@ -391,7 +391,7 @@ class Color:
 
     @classmethod
     def from_hsluv(cls, hue, saturation, lightness, alpha=1):
-        """Create a Color object from an a color in the HSLuv colorspace.
+        """Create a Color object from a color in the HSLuv colorspace.
 
         HSLuv is a human-friendly alternative to HSL. The hue component works
         the same as HSL/HSV, going from red (0) through green (0.333) and blue (0.666)

--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -1,34 +1,28 @@
 """Provides utilities to deal with color."""
 
-# Possible improvements:
-#
-# Colorspaces
-# * Support for HSLuv, a colorspace with uniform brightness https://www.hsluv.org/
-#
-# CSS:
-# * Support "rgb(100%, 50%, 0%)"
-# * Support "hsl(...)" and "hsla(...)"
-#
-# Other:
-# * Color.lerp(color, t) linear interpolate towards other color.
-# * Color.lerpHSL(color, t) same as lerp but interpolate in HSL / HSLuv space.
-# * Color.lighter(factor) and Color.darker(factor)
-
 import ctypes
 import colorsys
+import hsluv
 
 
 F4 = ctypes.c_float * 4
 
 
-def _float_from_css_value(v, i):
+def _float_from_css_value(v, i, is_hue=False):
     v = v.strip()
-    if v.endswith("%"):
-        return float(v[:-1]) / 100
-    elif i < 3:
-        return float(v) / 255
+    if not is_hue:
+        if v.endswith("%"):
+            return float(v[:-1]) / 100
+        elif i < 3:
+            return float(v) / 255
+        else:
+            return float(v)
     else:
-        return float(v)
+        # Hue is a special case, it can be in degrees or raw number between 0 and 1
+        if i == 0:
+            return float(v[:-3]) / 360 if v.endswith("deg") else float(v)
+        else:
+            return float(v[:-1]) / 100 if v.endswith("%") else float(v)
 
 
 class Color:
@@ -63,8 +57,14 @@ class Color:
 
     CSS color functions:
 
-        * `Color("rgb(255, 0, 0)")`.
-        * `Color("rgba(255, 0, 0, 1.0)")`.
+        * `Color("rgb(255, 0, 0)")` or `Color("rgb(100%, 0%, 0%)")`.
+        * `Color("rgba(255, 0, 0, 1.0)")` or `Color("rgba(100%, 0%, 0%, 100%)")`.
+        * `Color("hsv(0.333, 1, 0.5)")` or `Color("hsv(120deg, 100%, 50%)")`.
+        * `Color("hsva(0.333, 1, 0.5, 1.0)")` or `Color("hsva(120deg, 100%, 50%, 100%)")`.
+        * `Color("hsl(0.333, 1, 0.5)")` or `Color("hsl(120deg, 100%, 50%)")`.
+        * `Color("hsla(0.333, 1, 0.5, 1.0)")` or `Color("hsla(120deg, 100%, 50%, 100%)")`.
+        * `Color("hsluv(0.333, 0.5, 0.5)")` or `Color("hsluv(120deg, 50%, 50%)")`.
+        * `Color("hsluva(0.333, 0.5, 0.5, 1.0)")` or `Color("hsluva(120deg, 50%, 50%, 100%)")`.
 
     Parameters
     ----------
@@ -207,6 +207,25 @@ class Color:
                 raise ValueError(
                     f"CSS color {color.split('(')[0]}(..) must have 3 or 4 elements, not {len(parts)} "
                 )
+        elif color.startswith(("hsl(", "hsla(", "hsv(", "hsva(", "hsluv(", "hsluva(")):
+            parts = color.split("(")[1].split(")")[0].split(",")
+            parts = [
+                _float_from_css_value(p, i, is_hue=True) for i, p in enumerate(parts)
+            ]
+            if len(parts) == 3 or len(parts) == 4:
+                if color.startswith(("hsl(", "hsla(")):
+                    color = Color.from_hsla(*parts)
+                elif color.startswith(("hsv(", "hsva(")):
+                    color = Color.from_hsva(*parts)
+                elif color.startswith(("hsluv(", "hsluva(")):
+                    color = Color.from_hsluva(*parts)
+                self._set_from_rgba(
+                    color._val[0], color._val[1], color._val[2], color._val[3]
+                )
+            else:
+                raise ValueError(
+                    f"CSS color {color.split('(')[0]}(..) must have 3 or 4 elements, not {len(parts)} "
+                )
         else:
             # Maybe a named color
             try:
@@ -320,9 +339,31 @@ class Color:
         """
         return Color(colorsys.hsv_to_rgb(hue, saturation, value))
 
+    @classmethod
+    def from_hsva(cls, hue, saturation, value, alpha=1):
+        """Create a Color object from an a color in the HSV (a.k.a. HSB) colorspace.
+
+        HSV stands for hue, saturation, value (aka brightness). The hue
+        component indicates the color tone. Values go from red (0) to
+        green (0.333) to blue (0.666) and back to red (1). The
+        satutation indicates vividness, with 0 meaning gray and 1
+        meaning the primary color. The value/brightness indicates goes
+        from 0 (black) to 1 (white).
+
+        The alpha channel is optional and defaults to 1.
+        """
+        color = Color.from_hsv(hue, saturation, value)
+        color._val[3] = alpha
+        return color
+
     def to_hsv(self):
         """Get the color represented in the HSV colorspace, as 3 floats."""
         return colorsys.rgb_to_hsv(*self.rgb)
+
+    def to_hsva(self):
+        """Get the color represented in the HSV colorspace, as 3 floats."""
+        h, s, v = colorsys.rgb_to_hsv(*self.rgb)
+        return h, s, v, self.a
 
     @classmethod
     def from_hsl(cls, hue, saturation, lightness):
@@ -335,10 +376,189 @@ class Color:
         """
         return Color(colorsys.hls_to_rgb(hue, lightness, saturation))
 
+    @classmethod
+    def from_hsla(cls, hue, saturation, lightness, alpha=1):
+        """Create a Color object from an a color in the HSL colorspace.
+
+        The HSL colorspace is similar to the HSV colorspace, except the
+        "value" is replaced with "lightness". This lightness scales the
+        color differently, e.g. a lightness of 1 always represents full
+        white.
+
+        The alpha channel is optional and defaults to 1.
+        """
+        color = Color.from_hsl(hue, saturation, lightness)
+        color._val[3] = alpha
+        return color
+
     def to_hsl(self):
         """Get the color represented in the HSL colorspace, as 3 floats."""
         hue, lightness, saturation = colorsys.rgb_to_hls(*self.rgb)
         return hue, saturation, lightness
+
+    def to_hsla(self):
+        """Get the color represented in the HSL colorspace, as 3 floats."""
+        hue, lightness, saturation = colorsys.rgb_to_hls(*self.rgb)
+        return hue, saturation, lightness, self.a
+
+    @classmethod
+    def from_hsluv(cls, hue, saturation, lightness):
+        """Create a Color object from an a color in the HSLuv colorspace.
+
+        HSLuv is a human-friendly alternative to HSL. The hue component works
+        the same as HSL/HSV, going from red (0) through green (0.333) and blue (0.666)
+        back to red (1). The saturation ranges from 0 (grayscale) to 1 (pure color).
+        The lightness ranges from 0 (black) to 1 (white). Unlike HSL/HSV, HSLuv
+        provides perceptually uniform brightness and saturation.
+        """
+        h, s, light = 360.0 * hue, 100.0 * saturation, 100.0 * lightness
+        return Color(hsluv.hsluv_to_rgb((h, s, light)))
+
+    @classmethod
+    def from_hsluva(cls, hue, saturation, lightness, alpha=1):
+        """Create a Color object from an a color in the HSLuv colorspace.
+
+        HSLuv is a human-friendly alternative to HSL. The hue component works
+        the same as HSL/HSV, going from red (0) through green (0.333) and blue (0.666)
+        back to red (1). The saturation ranges from 0 (grayscale) to 1 (pure color).
+        The lightness ranges from 0 (black) to 1 (white). Unlike HSL/HSV, HSLuv
+        provides perceptually uniform brightness and saturation.
+
+        The alpha channel is optional and defaults to 1.
+        """
+        color = Color.from_hsluv(hue, saturation, lightness)
+        color._val[3] = alpha
+        return color
+
+    def to_hsluv(self):
+        """Get the color represented in the HSLuv colorspace, as 3 floats."""
+        h, s, light = hsluv.rgb_to_hsluv(self.rgb)
+        return h / 360.0, s / 100.0, light / 100.0
+
+    def to_hsluva(self):
+        """Get the color represented in the HSLuv colorspace, as 3 floats."""
+        h, s, light = hsluv.rgb_to_hsluv(self.rgb)
+        return h / 360.0, s / 100.0, light / 100.0, self.a
+
+    def lerp(self, target, t):
+        """Linear interpolate from source color towards target color with factor t.
+
+        Parameters
+        ----------
+        target : Color
+            The target color to interpolate towards
+        t : float
+            Interpolation factor between 0 and 1
+
+        Returns
+        -------
+        Color
+            The interpolated color
+        """
+        r = self.r + (target.r - self.r) * t
+        g = self.g + (target.g - self.g) * t
+        b = self.b + (target.b - self.b) * t
+        a = self.a + (target.a - self.a) * t
+        return Color(r, g, b, a)
+
+    def lerp_in_hue(self, target, t, colorspace="hsl"):
+        """Linear interpolate from source color towards target color with factor t in specified colorspace.
+
+        Parameters
+        ----------
+        target : Color
+            The target color to interpolate towards
+        t : float
+            Interpolation factor between 0 and 1
+        colorspace : str
+            The colorspace to interpolate in. One of "hsl", "hsluv", "hsv"
+
+        Returns
+        -------
+        Color
+            The interpolated color
+        """
+        if colorspace == "hsl":
+            h1, s1, l1 = self.to_hsl()
+            h2, s2, l2 = target.to_hsl()
+            to_rgba = lambda h, s, light, a: Color.from_hsla(h, s, light, a)
+        elif colorspace == "hsluv":
+            h1, s1, l1 = self.to_hsluv()
+            h2, s2, l2 = target.to_hsluv()
+            to_rgba = lambda h, s, light, a: Color.from_hsluva(h, s, light, a)
+        elif colorspace == "hsv":
+            h1, s1, l1 = self.to_hsv()
+            h2, s2, l2 = target.to_hsv()
+            to_rgba = lambda h, s, light, a: Color.from_hsva(h, s, light, a)
+        else:
+            raise ValueError(f"Unknown colorspace {colorspace}")
+
+        # Special case for hue - interpolate along shortest path
+        if abs(h2 - h1) > 0.5:
+            if h1 > h2:
+                h2 += 1.0
+            else:
+                h1 += 1.0
+        h = (h1 + (h2 - h1) * t) % 1.0
+        s = s1 + (s2 - s1) * t
+        light = l1 + (l2 - l1) * t
+        a = self.a + (target.a - self.a) * t
+
+        return to_rgba(h, s, light, a)
+
+    def lighter(self, factor=0.5, colorspace="hsl"):
+        """Make the color lighter by the given factor.
+
+        Parameters
+        ----------
+        factor : float
+            Factor to lighten by, between 0 and 1. Default is 0.5
+        colorspace : str
+            The colorspace to use, either "hsl" or "hsluv". Default is "hsl"
+
+        Returns
+        -------
+        Color
+            A lighter version of the color
+        """
+        if colorspace not in ["hsl", "hsluv"]:
+            raise ValueError("colorspace must be either 'hsl' or 'hsluv'")
+
+        if colorspace == "hsl":
+            h, s, light = self.to_hsl()
+            light = light + (1 - light) * factor
+            return Color.from_hsla(h, s, light, self.a)
+        else:  # hsluv
+            h, s, light = self.to_hsluv()
+            light = light + (1 - light) * factor
+            return Color.from_hsluva(h, s, light, self.a)
+
+    def darker(self, factor=0.5, colorspace="hsl"):
+        """Make the color darker by the given factor.
+
+        Parameters
+        ----------
+        factor : float
+            Factor to darken by, between 0 and 1. Default is 0.5
+        colorspace : str
+            The colorspace to use, either "hsl" or "hsluv". Default is "hsl"
+
+        Returns
+        -------
+        Color
+            A darker version of the color
+        """
+        if colorspace not in ["hsl", "hsluv"]:
+            raise ValueError("colorspace must be either 'hsl' or 'hsluv'")
+
+        if colorspace == "hsl":
+            h, s, light = self.to_hsl()
+            light = light * (1 - factor)
+            return Color.from_hsla(h, s, light, self.a)
+        else:  # hsluv
+            h, s, light = self.to_hsluv()
+            light = light * (1 - factor)
+            return Color.from_hsluva(h, s, light, self.a)
 
 
 def _srgb2physical(c):

--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -2,20 +2,9 @@
 
 import ctypes
 import colorsys
+import hsluv
 
 F4 = ctypes.c_float * 4
-
-# Try to import hsluv once at module level
-try:
-    import hsluv
-
-    HAVE_HSLUV = True
-except ImportError:
-    HAVE_HSLUV = False
-    HSLUV_IMPORT_ERROR = ImportError(
-        "The hsluv package is required for HSLuv colors. "
-        "Install it with 'pip install hsluv'"
-    )
 
 
 def _float_from_css_value(v, i, is_hue=False):
@@ -228,8 +217,6 @@ class Color:
                 elif color.startswith(("hsv(", "hsva(")):
                     color = Color.from_hsv(*parts)
                 elif color.startswith(("hsluv(", "hsluva(")):
-                    if not HAVE_HSLUV:
-                        raise HSLUV_IMPORT_ERROR
                     color = Color.from_hsluv(*parts)
                 self._set_from_rgba(
                     color._val[0], color._val[1], color._val[2], color._val[3]
@@ -401,8 +388,6 @@ class Color:
 
         The alpha channel is optional and defaults to 1.
         """
-        if not HAVE_HSLUV:
-            raise HSLUV_IMPORT_ERROR
         h, s, light = 360.0 * hue, 100.0 * saturation, 100.0 * lightness
         color = Color(hsluv.hsluv_to_rgb((h, s, light)))
         color._val[3] = alpha
@@ -410,15 +395,11 @@ class Color:
 
     def to_hsluv(self):
         """Get the color represented in the HSLuv colorspace, as 3 floats."""
-        if not HAVE_HSLUV:
-            raise HSLUV_IMPORT_ERROR
         h, s, light = hsluv.rgb_to_hsluv(self.rgb)
         return h / 360.0, s / 100.0, light / 100.0
 
     def to_hsluva(self):
         """Get the color represented in the HSLuv colorspace, as 4 floats."""
-        if not HAVE_HSLUV:
-            raise HSLUV_IMPORT_ERROR
         h, s, light = hsluv.rgb_to_hsluv(self.rgb)
         return h / 360.0, s / 100.0, light / 100.0, self.a
 
@@ -465,8 +446,6 @@ class Color:
             h2, s2, l2 = target.to_hsl()
             to_rgba = lambda h, s, light, a: Color.from_hsl(h, s, light, a)
         elif colorspace == "hsluv":
-            if not HAVE_HSLUV:
-                raise HSLUV_IMPORT_ERROR
             h1, s1, l1 = self.to_hsluv()
             h2, s2, l2 = target.to_hsluv()
             to_rgba = lambda h, s, light, a: Color.from_hsluv(h, s, light, a)
@@ -515,8 +494,6 @@ class Color:
             light = light + (1 - light) * factor
             return Color.from_hsl(h, s, light, self.a)
         elif colorspace == "hsluv":
-            if not HAVE_HSLUV:
-                raise HSLUV_IMPORT_ERROR
             h, s, light = self.to_hsluv()
             light = light + (1 - light) * factor
             return Color.from_hsluv(h, s, light, self.a)
@@ -550,8 +527,6 @@ class Color:
             light = light * (1 - factor)
             return Color.from_hsl(h, s, light, self.a)
         elif colorspace == "hsluv":
-            if not HAVE_HSLUV:
-                raise HSLUV_IMPORT_ERROR
             h, s, light = self.to_hsluv()
             light = light * (1 - factor)
             return Color.from_hsluv(h, s, light, self.a)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ docs = [
     "imgui-bundle>=1.6.0",
 ]
 tests = ["pytest", "psutil", "trimesh", "httpx", "gltflib", "imageio"]
-dev = ["pygfx[lint,tests,examples,docs]"]
+dev = ["pygfx[lint,tests,examples,docs,optional]"]
 
 [project.entry-points."pyinstaller40"]
 hook-dirs = "pygfx.__pyinstaller:get_hook_dirs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ dependencies = [
     "freetype-py",
     "uharfbuzz",
     "jinja2",
-    "hsluv==5.0.0",
 ]
 
 [project.optional-dependencies]
 lint = ["ruff"]
+hsluv = ["hsluv==5.0.0"]
 examples = [
     "pytest",
     "imageio[pyav]",
@@ -50,7 +50,7 @@ docs = [
     "imgui-bundle>=1.6.0",
 ]
 tests = ["pytest", "psutil", "trimesh", "httpx", "gltflib", "imageio"]
-dev = ["pygfx[lint,tests,examples,docs]"]
+dev = ["pygfx[lint,tests,examples,docs,hsluv]"]
 
 [project.entry-points."pyinstaller40"]
 hook-dirs = "pygfx.__pyinstaller:get_hook_dirs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 
 [project.optional-dependencies]
 lint = ["ruff"]
-hsluv = ["hsluv==5.0.0"]
+optional = ["hsluv==5.0.0"]
 examples = [
     "pytest",
     "imageio[pyav]",
@@ -50,7 +50,7 @@ docs = [
     "imgui-bundle>=1.6.0",
 ]
 tests = ["pytest", "psutil", "trimesh", "httpx", "gltflib", "imageio"]
-dev = ["pygfx[lint,tests,examples,docs,hsluv]"]
+dev = ["pygfx[lint,tests,examples,docs]"]
 
 [project.entry-points."pyinstaller40"]
 hook-dirs = "pygfx.__pyinstaller:get_hook_dirs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,11 @@ dependencies = [
     "freetype-py",
     "uharfbuzz",
     "jinja2",
+    "hsluv==5.0.0",
 ]
 
 [project.optional-dependencies]
 lint = ["ruff"]
-optional = ["hsluv==5.0.0"]
 examples = [
     "pytest",
     "imageio[pyav]",
@@ -50,7 +50,7 @@ docs = [
     "imgui-bundle>=1.6.0",
 ]
 tests = ["pytest", "psutil", "trimesh", "httpx", "gltflib", "imageio"]
-dev = ["pygfx[lint,tests,examples,docs,optional]"]
+dev = ["pygfx[lint,tests,examples,docs]"]
 
 [project.entry-points."pyinstaller40"]
 hook-dirs = "pygfx.__pyinstaller:get_hook_dirs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "freetype-py",
     "uharfbuzz",
     "jinja2",
+    "hsluv==5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "freetype-py",
     "uharfbuzz",
     "jinja2",
-    "hsluv==5.0.4",
+    "hsluv >=5.0.0,<6.0.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "freetype-py",
     "uharfbuzz",
     "jinja2",
-    "hsluv==5.0.0",
+    "hsluv==5.0.4",
 ]
 
 [project.optional-dependencies]

--- a/tests/utils/test_color.py
+++ b/tests/utils/test_color.py
@@ -1,3 +1,4 @@
+from colorsys import ONE_THIRD
 from pytest import raises
 import numpy as np
 
@@ -164,6 +165,7 @@ def test_color_css():
     assert Color("rgba(10, 20, 30, 0.5)").hexa == "#0a141e80"
     assert TColor("rgb(10%, 20%, 30%)").matches(0.1, 0.2, 0.3, 1)
     assert TColor("rgba(10%, 20%, 30%, 0.5)").matches(0.1, 0.2, 0.3, 0.5)
+    assert TColor("rgba(10%, 20%, 30%, 50%)").matches(0.1, 0.2, 0.3, 0.5)
 
     assert Color("#0a141eff").css == "rgb(10,20,30)"
     assert Color("#0a141e80").css == "rgba(10,20,30,0.502)"
@@ -172,6 +174,22 @@ def test_color_css():
         Color("rgb(10, 20, 30, 40, 50)")
     with raises(ValueError):
         Color("rgb(10, 20)")
+
+    assert Color("hsl(120deg, 100%, 50%)").hexa == "#00ff00ff"
+    assert Color("hsla(120deg, 100%, 50%, 50%)").hexa == "#00ff0080"
+
+    assert Color("hsv(120deg, 100%, 50%)").hexa == "#008000ff"
+    assert Color("hsva(120deg, 100%, 50%, 50%)").hexa == "#00800080"
+
+    assert Color("hsluv(120deg, 50%, 50%)").hexa == "#5e8052ff"
+    assert Color("hsluva(120deg, 50%, 50%, 50%)").hexa == "#5e805280"
+
+    with raises(ValueError):
+        Color("hsl(120deg, 100%)")
+    with raises(ValueError):
+        Color("hsv(120deg, 100%)")
+    with raises(ValueError):
+        Color("hsluv(120deg, 100%)")
 
 
 def test_color_min_max():
@@ -240,11 +258,64 @@ def test_color_colorspaces():
         Color.from_physical(0.0, 0.5, 1.0).to_physical(), (0.0, 0.5, 1.0)
     )
 
-    assert Color.from_hsv(0.333333, 1, 0.5).hex == "#008000"
-    assert np.allclose(Color.from_hsv(0.333333, 1, 0.5).to_hsv(), (0.333333, 1, 0.5))
+    assert Color.from_hsv(ONE_THIRD, 1, 0.5).hex == "#008000"
+    assert np.allclose(Color.from_hsv(ONE_THIRD, 1, 0.5).to_hsv(), (ONE_THIRD, 1, 0.5))
 
-    assert Color.from_hsl(0.333333, 1, 0.5).hex == "#00ff00"
-    assert np.allclose(Color.from_hsl(0.333333, 1, 0.5).to_hsl(), (0.333333, 1, 0.5))
+    assert Color.from_hsl(ONE_THIRD, 1, 0.5).hex == "#00ff00"
+    assert np.allclose(Color.from_hsl(ONE_THIRD, 1, 0.5).to_hsl(), (ONE_THIRD, 1, 0.5))
+
+    assert Color.from_hsluv(ONE_THIRD, 0.5, 0.5).hexa == "#5e8052ff"
+    assert np.allclose(
+        Color.from_hsluv(ONE_THIRD, 0.5, 0.5).to_hsluv(), (ONE_THIRD, 0.5, 0.5)
+    )
+
+    assert Color.from_hsv(ONE_THIRD, 1.0, 0.5).hexa == "#008000ff"
+    assert np.allclose(
+        Color.from_hsv(ONE_THIRD, 1.0, 0.5).to_hsv(), (ONE_THIRD, 1.0, 0.5)
+    )
+
+    assert Color.from_hsl(ONE_THIRD, 1.0, 0.5).hexa == "#00ff00ff"
+    assert np.allclose(
+        Color.from_hsl(ONE_THIRD, 1.0, 0.5).to_hsl(), (ONE_THIRD, 1.0, 0.5)
+    )
+
+
+def test_color_lerp_lighter_darker():
+    green = Color("#00ff00")
+    red = Color("#ff0000")
+
+    # half way between green and red
+    assert np.allclose(green.lerp(red, 0.5).rgb, (0.5, 0.5, 0))
+    # green
+    assert np.allclose(green.lerp(red, 0.0).rgb, (0.0, 1.0, 0))
+    # red
+    assert np.allclose(green.lerp(red, 1.0).rgb, (1.0, 0.0, 0.0))
+
+    assert np.allclose(green.lerp_in_hue(red, 0.0, "hsl").to_hsl(), green.to_hsl())
+    assert np.allclose(green.lerp_in_hue(red, 1.0, "hsl").to_hsl(), red.to_hsl())
+
+    assert np.allclose(green.lerp_in_hue(red, 0.0, "hsv").to_hsv(), green.to_hsv())
+    assert np.allclose(green.lerp_in_hue(red, 1.0, "hsv").to_hsv(), red.to_hsv())
+
+    assert np.allclose(
+        green.lerp_in_hue(red, 0.0, "hsluv").to_hsluv(), green.to_hsluv()
+    )
+    assert np.allclose(green.lerp_in_hue(red, 1.0, "hsluv").to_hsluv(), red.to_hsluv())
+
+    # Test lighter() and darker()
+    assert np.allclose(
+        green.lighter(0.5, "hsl").to_hsl()[2],
+        green.to_hsl()[2] + (1 - green.to_hsl()[2]) * 0.5,
+    )
+    assert np.allclose(green.darker(0.5, "hsl").to_hsl()[2], green.to_hsl()[2] * 0.5)
+
+    assert np.allclose(
+        green.lighter(0.5, "hsluv").to_hsluv()[2],
+        green.to_hsluv()[2] + (1 - green.to_hsluv()[2]) * 0.5,
+    )
+    assert np.allclose(
+        green.darker(0.5, "hsluv").to_hsluv()[2], green.to_hsluv()[2] * 0.5
+    )
 
 
 if __name__ == "__main__":

--- a/tests/utils/test_color.py
+++ b/tests/utils/test_color.py
@@ -317,6 +317,12 @@ def test_color_lerp_lighter_darker():
         green.darker(0.5, "hsluv").to_hsluv()[2], green.to_hsluv()[2] * 0.5
     )
 
+    assert np.allclose(
+        green.lighter(0.5, "hsv").to_hsv()[2],
+        green.to_hsv()[2] + (1 - green.to_hsv()[2]) * 0.5,
+    )
+    assert np.allclose(green.darker(0.5, "hsv").to_hsv()[2], green.to_hsv()[2] * 0.5)
+
 
 if __name__ == "__main__":
     test_color_basics()


### PR DESCRIPTION
Issue https://github.com/pygfx/pygfx/issues/343

1. Added support for HSLuv (with new dependency). With unified interface in range [0, 1] like others.
2. CSS string support for rgb(100%, 50%, 0%) was maintained
3. Added support for hsl(XYZdeg, XY%, YZ%), hsla(...), hsv(...), hsva(...), hsluv(...), hsluva(...)
4. Added `lerp(self, target, t)` for RGB and `lerp_in_hue(self, target, t, colorspace)` for all other hue-based colorspaces
5. Added `lighter(self, factor, colorspace)` and `darker(self, factor, colorspace)`, implemented only in HSL and HSLuv because they have lightness components