### PR TITLE
Bump imgui pin to 1.6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ examples = [
     "scikit-image",
     "trimesh",
     "gltflib",
-    "imgui-bundle>=1.2.1",
+    "imgui-bundle>=1.6.0",
 ]
 docs = [
     "sphinx>7.2",
@@ -46,7 +46,7 @@ docs = [
     "scikit-image",
     "trimesh",
     "gltflib",
-    "imgui-bundle>=1.2.1",
+    "imgui-bundle>=1.6.0",
 ]
 tests = ["pytest", "psutil", "trimesh", "httpx", "gltflib", "imageio"]
 dev = ["pygfx[lint,tests,examples,docs]"]


### PR DESCRIPTION
xref: https://github.com/pygfx/wgpu-py/pull/645

Seems to be blocking the [docs](https://github.com/pygfx/pygfx/actions/runs/11976014151/job/33390704327?pr=876) [generation](https://readthedocs.org/projects/pygfx/builds/26367751/)

I `grep`'d around for any mentions of the keypress modifiers causing this but they seem to be contained to wgpu-py. 

