### PR TITLE
Auto update skeleton and skeleton_helper

### DIFF
--- a/examples/feature_demo/animation_mixer.py
+++ b/examples/feature_demo/animation_mixer.py
@@ -336,9 +336,6 @@ def animate():
 
     animation_mixer.update(dt)
 
-    model_obj.children[0].skeleton.update()
-    skeleton_helper.update()
-
     with stats:
         renderer.render(scene, camera, flush=False)
 

--- a/examples/feature_demo/gltf_animations.py
+++ b/examples/feature_demo/gltf_animations.py
@@ -178,9 +178,6 @@ def animate():
     dt = clock.get_delta()
     mixer.update(dt)
 
-    model_obj.children[0].skeleton.update()
-    skeleton_helper.update()
-
     with stats:
         renderer.render(scene, camera, flush=False)
     stats.render()

--- a/examples/feature_demo/gltf_viewer.py
+++ b/examples/feature_demo/gltf_viewer.py
@@ -245,22 +245,9 @@ gui_renderer.set_gui(draw_imgui)
 load_remote_model(0)
 
 
-def update_skeleton(obj):
-    if isinstance(obj, gfx.SkinnedMesh):
-        obj.skeleton.update()
-
-
 def animate():
     dt = clock.get_delta()
     mixer.update(dt)
-
-    # Update the skeleton
-    # todo: this is a temporary workaround, we should update the skeleton automatically
-    # see: https://github.com/pygfx/pygfx/pull/894
-    if skeleton_helper and skeleton_helper.visible:
-        skeleton_helper.update()
-    if model_obj:
-        model_obj.traverse(update_skeleton)
 
     with stats:
         renderer.render(scene, camera, flush=False)

--- a/examples/feature_demo/skinned_mesh.py
+++ b/examples/feature_demo/skinned_mesh.py
@@ -113,9 +113,6 @@ def animate():
         rotation_y = math.sin(t) * 2 / len(mesh.skeleton.bones)
         bone.local.rotation = la.quat_from_euler((0, rotation_y, 0))
 
-    mesh.skeleton.update()
-    skeleton_helper.update()
-
     renderer.render(scene, camera)
     canvas.request_draw()
 

--- a/examples/feature_demo/skinning_animation.py
+++ b/examples/feature_demo/skinning_animation.py
@@ -140,9 +140,6 @@ def animate():
 
     animation_mixer.update(dt)
 
-    model_obj.children[0].skeleton.update()
-    skeleton_helper.update()
-
     with stats:
         renderer.render(scene, camera, flush=False)
     stats.render()

--- a/examples/feature_demo/skinning_bind_detached.py
+++ b/examples/feature_demo/skinning_bind_detached.py
@@ -98,9 +98,6 @@ def animate():
     dt = clock.get_delta()
     mixer.update(dt)
 
-    skeleton.update()
-    skeleton_helper.update()
-
     with stats:
         renderer.render(scene, camera, flush=False)
     stats.render()

--- a/pygfx/helpers/_skeleton.py
+++ b/pygfx/helpers/_skeleton.py
@@ -72,6 +72,3 @@ class SkeletonHelper(Line):
             bones.extend(self._get_bones(child))
 
         return bones
-
-    def on_before_render(self, renderer):
-        self.update()

--- a/pygfx/helpers/_skeleton.py
+++ b/pygfx/helpers/_skeleton.py
@@ -72,3 +72,6 @@ class SkeletonHelper(Line):
             bones.extend(self._get_bones(child))
 
         return bones
+
+    def on_before_render(self, renderer):
+        self.update()

--- a/pygfx/helpers/_skeleton.py
+++ b/pygfx/helpers/_skeleton.py
@@ -38,6 +38,7 @@ class SkeletonHelper(Line):
         # Update on every draw: the helper matrix always follows the root object
         self.local.matrix = self.root.world.matrix
         super()._update_object()
+        self.update()
 
     def update(self):
         # TODO: we should update it automatically by some mechanism.

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -543,13 +543,3 @@ class WorldObject(EventTarget, Trackable):
         """
 
         self.world.forward = target - self.world.position
-
-    def on_before_render(self, renderer):
-        """Called before the object is rendered.
-
-        This method is called by the renderer before the object is rendered.
-        The renderer is passed as an argument.
-
-        Notice that this callback is only executed for **renderable** 3D objects.
-        """
-        pass

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -543,3 +543,13 @@ class WorldObject(EventTarget, Trackable):
         """
 
         self.world.forward = target - self.world.position
+
+    def on_before_render(self, renderer):
+        """Called before the object is rendered.
+
+        This method is called by the renderer before the object is rendered.
+        The renderer is passed as an argument.
+
+        Notice that this callback is only executed for **renderable** 3D objects.
+        """
+        pass

--- a/pygfx/objects/_skins.py
+++ b/pygfx/objects/_skins.py
@@ -194,3 +194,9 @@ class SkinnedMesh(Mesh):
     def pose(self):
         """Reset the skinned mesh to the binding-time pose."""
         self.skeleton.pose()
+
+    def on_before_render(self, renderer):
+        # todo: theoretically, it's not appropriate to update the skeleton here.
+        # because skeleton can be shared by multiple skinned meshes, which could result in redundant updates and caculations.
+        if self.skeleton:
+            self.skeleton.update()

--- a/pygfx/objects/_skins.py
+++ b/pygfx/objects/_skins.py
@@ -195,7 +195,8 @@ class SkinnedMesh(Mesh):
         """Reset the skinned mesh to the binding-time pose."""
         self.skeleton.pose()
 
-    def on_before_render(self, renderer):
+    def _update_object(self):
+        super()._update_object()
         # todo: theoretically, it's not appropriate to update the skeleton here.
         # because skeleton can be shared by multiple skinned meshes, which could result in redundant updates and caculations.
         if self.skeleton:


### PR DESCRIPTION
This is an optional callback that gets executed immediately before a `WorldObject` is rendered. It can be very useful in specific scenarios, allowing users to dynamically update the settings or state of a particular world object before each frame is rendered.

It’s important to note that this hook is primarily intended for updating **the state or behavior of the object itself** or adding specific logic for certain objects in the scene. However, it is **not suitable** for general per-frame updates to internal GPU objects, such as updating the vertex attributes of geometry or properties in material, as these resources may be shared across multiple WorldObject instances and generally need to be updated only once per frame.

Similarly, the automatic updating of `Skeleton` faces a comparable challenge. While placing such updates in the `on_before_renderer` method of the `SkinnedMesh` object is not ideal from a design perspective, it serves as a temporary solution to relieve users from the burden of explicitly managing skeleton updates in their application logic. This is especially helpful when dealing with complex scenes (e.g., loading from glTF files), where users would otherwise need to locate all SkinnedMesh instances in the scene and manually trigger skeleton updates—a process that is both tedious and undermines out-of-the-box usability.