### PR TITLE
Add internal util to easily check arg types

### DIFF
--- a/pygfx/materials/_image.py
+++ b/pygfx/materials/_image.py
@@ -1,5 +1,6 @@
 from ..resources import Texture
 from ._base import Material
+from ..utils import assert_type
 
 
 class ImageBasicMaterial(Material):
@@ -51,7 +52,7 @@ class ImageBasicMaterial(Material):
 
     @map.setter
     def map(self, map):
-        assert map is None or isinstance(map, Texture)
+        assert_type("map", map, None, Texture)
         self._store.map = map
 
     @property

--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -36,7 +36,9 @@ completeness and you will likely never have to instantiate them directly.
 """
 
 import os
+import types
 import logging
+import inspect
 
 import numpy as np
 
@@ -182,3 +184,38 @@ def normals_from_vertices(rr, tris):
     size[size == 0] = 1.0  # prevent ugly divide-by-zero
     nn /= size[:, np.newaxis]
     return nn.astype(np.float32)
+
+
+def assert_type(name, value, *classes):
+    allow_none = False
+    if classes[0] is None:
+        if value is None:
+            return
+        allow_none = True
+        classes = classes[1:]
+
+    if not isinstance(value, classes):
+        # Get traceback object to point of the frame of interest
+        f = inspect.currentframe()
+        f = f.f_back
+        if name:
+            # Step back to calling code
+            f = f.f_back
+            # If this is a constructor that has name as a (kw) argument, take another step back
+            if f.f_code.co_name == "__init__" and name in f.f_code.co_varnames:
+                f = f.f_back
+        tb = types.TracebackType(None, f, f.f_lasti, f.f_lineno)
+
+        # Build error message
+        msg = "Expected"
+        if name:
+            msg += f" '{name}' to be"
+        class_strings = [cls.__name__ for cls in classes]
+        msg += f" an instance of {' | '.join(class_strings)}"
+        if allow_none:
+            msg += " or None"
+        valuestr = value.__class__.__name__
+        msg += f", but got {valuestr} object."
+
+        # Raise message with alt traceback
+        raise TypeError(msg).with_traceback(tb) from None


### PR DESCRIPTION
Add a little helper to check the type of arguments in property setters and methods. This helps in two ways:

* Make it almost as simple as writing `assert` to check the arg, no tedious `if .. else raise ...`.
* When the error does occur, the traceback shows more precisely where their code is wrong.

Example 1:
```py
import pygfx as gfx

m = gfx.ImageBasicMaterial()
m.map = 3
```
The last line in the traceback points to my code:
```
>>> (executing cell "" (line 160 of "tmp.py"))
Traceback (most recent call last):
  File "/Users/almar/dev/py/tmp.py", line 164, in <module>
    m.map = 3
    ^^^^^
  File "/Users/almar/dev/py/pygfx/pygfx/materials/_image.py", line 55, in map
    assert_type("map", map, None, Texture)
  File "/Users/almar/dev/py/pygfx/pygfx/utils/__init__.py", line 221, in assert_type
    raise TypeError(msg).with_traceback(tb) from None
  File "/Users/almar/dev/py/tmp.py", line 164, in <module>
    m.map = 3
    ^^^^^
TypeError: Expected 'map' to be an instance of Texture or None, but got int object.
```


Another example, now setting a prop via the constructor, which is a common pattern in pygfx:
```py
import pygfx as gfx

gfx.ImageBasicMaterial(map=3)
```
In this case the traceback steps an extra frame back to still point at my code:
```
>>> (executing cell "" (line 160 of "tmp.py"))
Traceback (most recent call last):
  File "/Users/almar/dev/py/tmp.py", line 164, in <module>
    gfx.ImageBasicMaterial(map=3)
  File "/Users/almar/dev/py/pygfx/pygfx/materials/_image.py", line 39, in __init__
    self.map = map
    ^^^^^^^^
  File "/Users/almar/dev/py/pygfx/pygfx/materials/_image.py", line 55, in map
    assert_type("map", map, None, Texture)
  File "/Users/almar/dev/py/pygfx/pygfx/utils/__init__.py", line 221, in assert_type
    raise TypeError(msg).with_traceback(tb) from None
  File "/Users/almar/dev/py/tmp.py", line 164, in <module>
    gfx.ImageBasicMaterial(map=3)
TypeError: Expected 'map' to be an instance of Texture or None, but got int object.

```

