### PR TITLE
Fix that send_data could not set  multiple layers at once

### DIFF
--- a/examples/feature_demo/video_yuv.py
+++ b/examples/feature_demo/video_yuv.py
@@ -320,17 +320,12 @@ def animate():
             tex.send_data((0, 0, 1), u)
             tex.send_data((w // 2, 0, 1), v)
     elif FORMAT == "yuv444p":
-        y = data[0]
-        u = data[1]
-        v = data[2]
         if THREE_GRID_YUV:
-            tex.send_data((0, 0), y)
-            u_tex.send_data((0, 0), u)
-            v_tex.send_data((0, 0), v)
+            tex.send_data((0, 0), data[0])
+            u_tex.send_data((0, 0), data[1])
+            v_tex.send_data((0, 0), data[2])
         else:
-            tex.send_data((0, 0, 0), y)
-            tex.send_data((0, 0, 1), u)
-            tex.send_data((0, 0, 2), v)
+            tex.send_data((0, 0, 0), data)
     elif FORMAT == "rgba":
         # The data is already rgba, so we can just send it as one blob.
         # That blob is more than twice the size of the yuv420 data though.


### PR DESCRIPTION
In the `video_yuv.py` example, we set the individual texture layers for yuv444p one by one, because `send_data` did not work well when setting it in a single chunk. The reason is that it basically assumed the data to be single-channel. This fixes that.

One problem to solve is that `send_data` must interpret the size of the data from the array shape, with color channels possibly adding to the dimensionality of the array.

I considered two approaches: 1) we could require that the caller reshapes the data so that it is always a 3D chunk. Apart from putting more work on the user, it's also prone to errors; the user may do it wrong, and we would not notice because of the ambiguity with the color channel dimension.

So instead, the number of channels is derived from the format, and singleton dimensions are added as needed. This makes `send_data()` more friendly. E.g. you can set one image row by providing an 1D array (2D for color). 

cc @hmaarrfk @claydugo 