### PR TITLE
Ensure Transforms are evaluated lazily

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ examples/data/sam2*.pt
 offscreen.png
 docs/sg_execution_times.rst
 nogit/
+*.txt
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -132,6 +132,8 @@ class WorldObject(EventTarget, RootTrackable):
         id="i4",
     )
 
+    transform_updates = weakref.WeakKeyDictionary()
+
     def __init__(
         self,
         geometry=None,
@@ -164,7 +166,7 @@ class WorldObject(EventTarget, RootTrackable):
         self.world = RecursiveTransform(
             self.local, is_camera_space=self._FORWARD_IS_MINUS_Z, reference_up=(0, 1, 0)
         )
-        self.world.on_update(self._update_uniform_buffers)
+        self.world.on_update(self.flag_transform_update)
 
         # Set id
         self._id = id_provider.claim_id(self)
@@ -183,6 +185,9 @@ class WorldObject(EventTarget, RootTrackable):
         self.name = name
 
     @callback
+    def flag_transform_update(self, transform: AffineBase):
+        self.transform_updates[self] = transform
+
     def _update_uniform_buffers(self, transform: AffineBase):
         orig_err_setting = np.seterr(under="ignore")
         self.uniform_buffer.data["world_transform"] = transform.matrix.T


### PR DESCRIPTION
This PR addresses a significant performance issue in the transform system originally reported by @panxinmiao  https://github.com/pygfx/pygfx/pull/715#issuecomment-2053385803

There were two independent issues to resolve:

* WorldObject registered an **on_update callback** to update its world matrix uniform buffer. However on_update is called as soon as a transform is marked as dirty. Reading the world matrix in that callback means we are computing the new world matrix as soon as the cache is invalidated. In other words, eagerly, always. The lazy caching mechanism was kind of sabotaged in this way.
* The **reference_up** property can be set both on local and world transforms, and they update eachother bidirectionally, to stay in sync. However this is implemented eagerly and also depends on the world matrix (and the inverse world matrix). Whenever you change an object's parent, immediately the entire scene graph is traversed and all world matrices are computed again. So if you're making a lot of changes to the scene graph, that becomes super expensive very quickly.

In order to address both issues I made the following changes:

* WorldObject manages a WeakKeyDictionary of world objects with an updated transform. The renderer, just before rendering, knows which objects are about to be rendered, and pops them from the dictionary, updating their uniform buffers, consuming their world matrices. Only then will they be recomputed. This change was relatively simple.
* Addressing the reference_up problem was a lot more challenging. I couldn't figure out how to solve it without making the local transform keep a reference to the world transform, but I did end up being quite satisfied with the solution. It's easier to follow. The world transform has all the information needed to compute the local, parent and world reference_up vectors. The goal was to make them cached and lazily evaluated. So the trick was to move all the logic to RecursiveTransform, and make the AffineTransform class defer to that.

Additional changes:
* Added unit tests to assert laziness

Also see #915 for an independent performance improvement to the hot code paths of transform in pylinalg