### PR TITLE
Base AffineTransform state on position/scale/rotation instead of matrix

### DIFF
--- a/examples/feature_demo/skinned_mesh.py
+++ b/examples/feature_demo/skinned_mesh.py
@@ -67,8 +67,6 @@ def create_mesh(geometry, bones):
     skeleton = gfx.Skeleton(bones)
 
     mesh.add(bones[0])
-    # update the world matrix from root to leaf bone manually
-    bones[0].update_matrix_world()
     mesh.bind(skeleton)
 
     mesh.local.rotation = la.quat_from_euler((-math.pi / 2, 0, 0))

--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -4,7 +4,7 @@ import numpy as np
 from ._base import WorldObject
 from ..resources import Buffer
 from ..utils import unpack_bitfield, array_from_shadertype
-from ..utils.transform import AffineBase, callback
+from ..utils.transform import AffineBase
 from ..materials import BackgroundMaterial
 
 
@@ -434,12 +434,8 @@ class Text(WorldObject):
             name=name,
         )
 
-        # calling super from callback is possible, but slow so we register it as a second callback instead
-        self.world.on_update(super()._update_uniform_buffers)
-
-    @callback
     def _update_uniform_buffers(self, transform: AffineBase):
-        # super()._update_uniform_buffers(transform)
+        super()._update_uniform_buffers(transform)
         # When rendering in screen space, the world transform is used
         # to establish the point in the scene where the text is placed.
         # The only part of the local transform that is used is the

--- a/pygfx/objects/_skins.py
+++ b/pygfx/objects/_skins.py
@@ -17,80 +17,9 @@ class Bone(WorldObject):
 
     """
 
-    class _Transform:
-        position: np.ndarray
-        rotation: np.ndarray
-        scale: np.ndarray
-        matrix: np.ndarray
-
     def __init__(self, name=""):
         super().__init__(name=name)
         self.visible = False
-
-        self._children: "List[Bone]" = []
-        self._parent: "Bone" = None
-
-        self.__matrix_world_needs_update = False
-
-        # compatible with cuurrent WorldObject RecursiveTransform system, but does nothing.
-        # temporary solution before we refactor the WorldObject transform system.
-        # See: https://github.com/pygfx/pygfx/pull/715#issuecomment-2053385803
-        self.world = Bone._Transform()
-        self.world.matrix = np.eye(4)
-        self.local = Bone._Transform()
-        self.local.position = np.zeros(3)
-        self.local.rotation = np.zeros(4)
-        self.local.scale = np.ones(3)
-        self.local.matrix = np.eye(4)
-
-    @property
-    def parent(self):
-        if self._parent is None:
-            return None
-        if isinstance(self._parent, Bone):
-            return self._parent
-        else:
-            return self._parent()
-
-    def update_matrix(self):
-        self.local.matrix = la.mat_compose(
-            self.local.position, self.local.rotation, self.local.scale
-        )
-        self.__matrix_world_needs_update = True
-
-    def update_matrix_world(self):
-        self.update_matrix()
-
-        if self.__matrix_world_needs_update:
-            if self.parent is not None:
-                self.world.matrix = self.parent.world.matrix @ self.local.matrix
-            else:
-                self.world.matrix = self.local.matrix
-            self.__matrix_world_needs_update = False
-
-        for child in self._children:
-            child.update_matrix_world()
-
-    def add(self, *bones: "Bone") -> "Bone":
-        for obj in bones:
-            if obj == self:
-                # can't add self as a child
-                continue
-
-            if obj and isinstance(obj, Bone):
-                if obj._parent is not None:
-                    obj._parent.remove(obj)
-
-                obj._parent = self
-                self._children.append(obj)
-            else:
-                pass
-                # Now the Bone class has specific logic, so we just pass if it's not a Bone
-
-        return self
-
-    def __repr__(self) -> str:
-        return f"Bone {self.name} {self.local.position} {self.local.rotation}\n"
 
 
 class Skeleton:
@@ -172,13 +101,6 @@ class Skeleton:
         # TODO: we should update the bone matrices buffer automatically by some mechanism.
         # See: https://github.com/pygfx/pygfx/pull/715#issuecomment-2046493145
         """Update the bone matrices buffer."""
-
-        # TODO: update bone matrices from root to leaf, it's a temporary solution.
-        # See: https://github.com/pygfx/pygfx/pull/715#issuecomment-2053385803
-        for bone in self.bones:
-            if bone.parent and isinstance(bone.parent, Bone):
-                continue
-            bone.update_matrix_world()
 
         for i, bone in enumerate(self.bones):
             self.bone_matrices_buffer.data[i]["bone_matrices"] = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">= 3.9"
 dependencies = [
     "rendercanvas >= 2",
     "wgpu >=0.19.0,<0.20.0",
-    "pylinalg >=0.6.0,<0.7.0",
+    "pylinalg >=0.6.1,<0.7.0",
     "numpy",
     "freetype-py",
     "uharfbuzz",

--- a/tests/objects/test_world_object.py
+++ b/tests/objects/test_world_object.py
@@ -439,9 +439,10 @@ def test_scaling_signs_manual_matrix():
     npt.assert_array_almost_equal(child.world.scale, expected)
 
     s2 = (-4, -4, 4)
+    expected2 = np.array(expected) * np.array(s2)
     child.local.scale = s2
     npt.assert_array_almost_equal(child.local.scale, s2)
-    npt.assert_array_almost_equal(child.world.scale, [-4, 8, 12])
+    npt.assert_array_almost_equal(child.world.scale, expected2)
 
 
 def test_rotation_derived():


### PR DESCRIPTION
Changes:

* Base AffineTransform state on position/scale/rotation instead of matrix
* All ndarrays are now read only
* Reuse all local state ndarrays instead of constantly replacing them
* Remove performance workarounds to allow for performance testing

This yields really impressive performance increases (roughly 300-400%) for examples where transforms are updated every frame.
And we still have all our world space transform getters and setters with lazy evaluation & caching.
No need to call "update()" functions manually in pygfx (like in Three.js).
Best of both worlds! I'm very pleased with this outcome.

Future work (separate PR):
* I could add an option to AffineTransform to toggle between the matrix or position/scale/rotation as the source of truth. There are scenarios where that is preferred. See #920