### PR TITLE
Default TextureMap settting

### DIFF
--- a/pygfx/materials/_image.py
+++ b/pygfx/materials/_image.py
@@ -43,6 +43,8 @@ class ImageBasicMaterial(Material):
         If None, the values themselves represents the color. The
         dimensionality of the texture map can be 1D, 2D or 3D, but
         should match the number of channels in the image.
+
+        Note: for scientific data, it is usually to set wrap mode to 'clamp'.
         """
         return self._store.map
 
@@ -50,7 +52,7 @@ class ImageBasicMaterial(Material):
     def map(self, map):
         assert_type("map", map, None, Texture, TextureMap)
         if isinstance(map, Texture):
-            map = TextureMap(map)
+            map = TextureMap(map, wrap="clamp")
         self._store.map = map
 
     @property

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -687,7 +687,7 @@ class MeshToonMaterial(MeshBasicMaterial):
     @property
     def gradient_map(self):
         """Gradient map for toon shading.
-        The gradient map sampler method is always 'nearest'.
+        It's usually to set filter to 'nearest' for the gradient map.
         """
         return self._store.gradient_map
 
@@ -695,7 +695,7 @@ class MeshToonMaterial(MeshBasicMaterial):
     def gradient_map(self, map):
         assert_type("gradient_map", map, None, Texture, TextureMap)
         if isinstance(map, Texture):
-            map = TextureMap(map)
+            map = TextureMap(map, filter="nearest")
         self._store.gradient_map = map
 
 


### PR DESCRIPTION
In #913 , @kushalkolar suggested that the default setting of colormap for the Image should use `wrap=clamp` for displaying scientific data.

Additionally, the `gradient_map` of `MeshToonMaterial` is typically set to `filter=nearest` to maintain the cartoon-style banding effect.