### PR TITLE
Matrix inverse

### DIFF
--- a/pygfx/cameras/_base.py
+++ b/pygfx/cameras/_base.py
@@ -1,7 +1,7 @@
 import numpy as np
+import pylinalg as la
 
 from ..objects._base import WorldObject
-from ..utils.transform import mat_inv
 
 
 class Camera(WorldObject):
@@ -89,4 +89,4 @@ class ScreenCoordsCamera(Camera):
         m = sx, 0, 0, dx, 0, sy, 0, dy, 0, 0, sz, dz, 0, 0, 0, 1
         proj_view = self.projection_matrix.ravel()
         proj_view[:] = m
-        self.projection_matrix_inverse = mat_inv(self.projection_matrix)
+        self.projection_matrix_inverse = la.mat_inverse(self.projection_matrix)

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -4,7 +4,6 @@ import numpy as np
 import pylinalg as la
 
 from ..objects._base import WorldObject
-from ..utils.transform import mat_inv
 from ._base import Camera
 
 
@@ -296,7 +295,7 @@ class PerspectiveCamera(Camera):
             self.projection_matrix = la.mat_perspective(
                 left, right, top, bottom, near, far, depth_range=(0, 1)
             )
-            self.projection_matrix_inverse = mat_inv(self.projection_matrix)
+            self.projection_matrix_inverse = la.mat_inverse(self.projection_matrix)
 
         else:
             # The reference view plane is scaled with the zoom factor
@@ -319,7 +318,7 @@ class PerspectiveCamera(Camera):
             proj = la.mat_orthographic(
                 left, right, top, bottom, near, far, depth_range=(0, 1)
             )
-            proj_i = mat_inv(proj)
+            proj_i = la.mat_inverse(proj)
             self.projection_matrix = proj
             self.projection_matrix_inverse = proj_i
 

--- a/pygfx/helpers/_gizmo.py
+++ b/pygfx/helpers/_gizmo.py
@@ -10,7 +10,7 @@ from ..geometries import Geometry, sphere_geometry, cone_geometry, box_geometry
 from ..materials import MeshBasicMaterial, LineMaterial
 from ..objects import WorldObject
 from ..utils.viewport import Viewport
-from ..utils.transform import AffineTransform, mat_inv
+from ..utils.transform import AffineTransform
 
 
 # Colors in hsluv space - https://www.hsluv.org/
@@ -633,7 +633,7 @@ class TransformGizmo(WorldObject):
         """Translate action, either using a translate1 or translate2 handle."""
 
         world_to_screen = self._ndc_to_screen @ self._camera.camera_matrix
-        screen_to_world = mat_inv(world_to_screen)
+        screen_to_world = la.mat_inverse(world_to_screen)
 
         if isinstance(self._ref["dim"], int):
             travel_directions = (self._ref["dim"],)
@@ -654,7 +654,7 @@ class TransformGizmo(WorldObject):
             units_traveled = get_scale_factor(screen_directions[..., :2], screen_travel)
         else:
             # translate 2D: change basis from screen to gizmo axes
-            screen_to_axes = mat_inv(screen_directions[..., :2].T)
+            screen_to_axes = la.mat_inverse(screen_directions[..., :2].T)
             units_traveled = screen_to_axes @ screen_travel
 
         # pixel units to world units

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -25,7 +25,6 @@ from ....cameras import Camera
 from ....resources import Texture
 from ....resources._base import resource_update_registry
 from ....utils import Color
-from ....utils.transform import mat_inv  # noqa
 
 from ... import Renderer
 from . import blender as blender_module

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -10,13 +10,6 @@ from typing import Tuple, Union
 PRECISION_EPSILON = 1e-7
 
 
-if int(np.__version__.split(".")[0]) >= 2:
-    mat_inv = np.linalg.inv
-else:
-    # Avoid cpu's spinning at 300%, see issue #763
-    mat_inv = np.linalg.pinv
-
-
 class cached:  # noqa: N801
     """Cache for computed properties.
 
@@ -184,7 +177,7 @@ class AffineBase:
 
     @cached
     def _inverse_matrix(self) -> np.ndarray:
-        mat = mat_inv(self.matrix)
+        mat = la.mat_inverse(self.matrix)
         mat.flags.writeable = False
         return mat
 


### PR DESCRIPTION
This issue is an extension of https://github.com/pygfx/pylinalg/pull/90.

Recently, I upgraded numpy from version 1.26.4 to 2.2.1, and encountered the `np.linalg.LinAlgError (singular matrix)` exception when scaling was set to 0. Due to the changes in https://github.com/pygfx/pylinalg/pull/90, I realized that this is indeed the expected behavior, and we need to handle it accordingly.

However, I suddenly realized that with numpy 1.26.4, even with the changes from https://github.com/pygfx/pylinalg/pull/90, this exception was not raised. This is because in version 1.26.4, we were using np.linalg.pinv to compute the pseudo-inverse, which still returns an approximate inverse matrix even when the matrix is singular.

However, rendering engines typically **do not use pseudo-inverses**:

- The pseudo-inverse is not an exact inverse; it is merely an approximation. For transformation matrices in rendering engines, what we generally need is an exact inverse matrix, and the pseudo-inverse does not meet this requirement. Additionally, using the pseudo-inverse in some cases might lead to numerical instability and unpredictable results.

- From a theoretical standpoint, the complexity of computing the pseudo-inverse is much higher than that of computing the inverse matrix. For transformation matrices, this overhead is unnecessary.


I checked the code history, and the reason we used pinv was to 
> “avoid high CPU usage (see issue #763).” 

It seems that there were some bugs with np.linalg.inv in numpy 1.X versions, but even so, pinv is not the most appropriate choice. For numpy 1.X, I believe we can replace it with a pure Python implementation of inv.

I referred to the implementation in three.js and wrote a pure Python version of the matrix inverse, and performed some tests.

<details>
<summary>Test Script</summary>

```
import timeit
import numpy as np

import pylinalg as la

m = la.mat_compose(np.array([1, 2, 3]), np.array([0, 0, 0, 1]), np.array([1, 1, 1]))


def _mat_inv(m):
    out = np.empty((4, 4), dtype=np.float32)
    me = m.flat

    n11 = me[0]
    n21 = me[4]
    n31 = me[8]
    n41 = me[12]
    n12 = me[1]
    n22 = me[5]
    n32 = me[9]
    n42 = me[13]
    n13 = me[2]
    n23 = me[6]
    n33 = me[10]
    n43 = me[14]
    n14 = me[3]
    n24 = me[7]
    n34 = me[11]
    n44 = me[15]

    t11 = (
        n23 * n34 * n42
        - n24 * n33 * n42
        + n24 * n32 * n43
        - n22 * n34 * n43
        - n23 * n32 * n44
        + n22 * n33 * n44
    )
    t12 = (
        n14 * n33 * n42
        - n13 * n34 * n42
        - n14 * n32 * n43
        + n12 * n34 * n43
        + n13 * n32 * n44
        - n12 * n33 * n44
    )
    t13 = (
        n13 * n24 * n42
        - n14 * n23 * n42
        + n14 * n22 * n43
        - n12 * n24 * n43
        - n13 * n22 * n44
        + n12 * n23 * n44
    )
    t14 = (
        n14 * n23 * n32
        - n13 * n24 * n32
        - n14 * n22 * n33
        + n12 * n24 * n33
        + n13 * n22 * n34
        - n12 * n23 * n34
    )

    det = n11 * t11 + n21 * t12 + n31 * t13 + n41 * t14

    if det == 0:
        return out

    det_inv = 1 / det

    te = out.flat
    te[0] = t11 * det_inv
    te[4] = (
        n24 * n33 * n41
        - n23 * n34 * n41
        - n24 * n31 * n43
        + n21 * n34 * n43
        + n23 * n31 * n44
        - n21 * n33 * n44
    ) * det_inv
    te[8] = (
        n22 * n34 * n41
        - n24 * n32 * n41
        + n24 * n31 * n42
        - n21 * n34 * n42
        - n22 * n31 * n44
        + n21 * n32 * n44
    ) * det_inv
    te[12] = (
        n23 * n32 * n41
        - n22 * n33 * n41
        - n23 * n31 * n42
        + n21 * n33 * n42
        + n22 * n31 * n43
        - n21 * n32 * n43
    ) * det_inv

    te[1] = t12 * det_inv
    te[5] = (
        n13 * n34 * n41
        - n14 * n33 * n41
        + n14 * n31 * n43
        - n11 * n34 * n43
        - n13 * n31 * n44
        + n11 * n33 * n44
    ) * det_inv
    te[9] = (
        n14 * n32 * n41
        - n12 * n34 * n41
        - n14 * n31 * n42
        + n11 * n34 * n42
        + n12 * n31 * n44
        - n11 * n32 * n44
    ) * det_inv
    te[13] = (
        n12 * n33 * n41
        - n13 * n32 * n41
        + n13 * n31 * n42
        - n11 * n33 * n42
        - n12 * n31 * n43
        + n11 * n32 * n43
    ) * det_inv

    te[2] = t13 * det_inv
    te[6] = (
        n14 * n23 * n41
        - n13 * n24 * n41
        - n14 * n21 * n43
        + n11 * n24 * n43
        + n13 * n21 * n44
        - n11 * n23 * n44
    ) * det_inv
    te[10] = (
        n12 * n24 * n41
        - n14 * n22 * n41
        + n14 * n21 * n42
        - n11 * n24 * n42
        - n12 * n21 * n44
        + n11 * n22 * n44
    ) * det_inv
    te[14] = (
        n13 * n22 * n41
        - n12 * n23 * n41
        - n13 * n21 * n42
        + n11 * n23 * n42
        + n12 * n21 * n43
        - n11 * n22 * n43
    ) * det_inv

    te[3] = t14 * det_inv
    te[7] = (
        n13 * n24 * n31
        - n14 * n23 * n31
        + n14 * n21 * n33
        - n11 * n24 * n33
        - n13 * n21 * n34
        + n11 * n23 * n34
    ) * det_inv
    te[11] = (
        n14 * n22 * n31
        - n12 * n24 * n31
        - n14 * n21 * n32
        + n11 * n24 * n32
        + n12 * n21 * n34
        - n11 * n22 * n34
    ) * det_inv
    te[15] = (
        n12 * n23 * n31
        - n13 * n22 * n31
        + n13 * n21 * n32
        - n11 * n23 * n32
        - n12 * n21 * n33
        + n11 * n22 * n33
    ) * det_inv

    return out


def test_np_inv():
    return np.linalg.inv(m)

def test_np_pinv():
    return np.linalg.pinv(m)

def test_inv():
    return _mat_inv(m)

print("inv", np.linalg.inv(m))
print("pinv", np.linalg.pinv(m))
print("python inv", _mat_inv(m))

time = timeit.timeit(test_np_inv, number=100000)
print(f"np.linalg.inv, time: {time} seconds")

time = timeit.timeit(test_np_pinv, number=100000)
print(f"np.linalg.pinv time: {time} seconds")

time = timeit.timeit(test_inv, number=100000)
print(f"_mat_inv, time: {time} seconds")

```

</details>


**Outputs:**

- For numpy 1.26.4: 

```
inv [[ 1.  0.  0. -1.]
 [ 0.  1.  0. -2.]
 [ 0.  0.  1. -3.]
 [ 0.  0.  0.  1.]]
pinv [[ 1.00000000e+00 -4.62029910e-16  3.19485066e-16 -1.00000000e+00]
 [-5.29094592e-17  1.00000000e+00  7.74666651e-16 -2.00000000e+00]
 [-4.95543739e-17 -1.74588509e-15  1.00000000e+00 -3.00000000e+00]
 [-1.14551985e-16  6.42717943e-16 -4.56019187e-17  1.00000000e+00]]
python inv [[ 1.  0.  0. -1.]
 [ 0.  1.  0. -2.]
 [ 0.  0.  1. -3.]
 [ 0.  0.  0.  1.]]
np.linalg.inv, time: 1.6844719999935478 seconds
np.linalg.pinv time: 1.4958708999911323 seconds
_mat_inv, time: 1.189121100003831 seconds
```
The performance of `np.linalg.inv` and `np.linalg.pinv` seems similar (although, in terms of computational complexity, pinv should have a higher cost than inv, so the inv implementation in numpy 1.26.4 may have some issues). Both are slower than the pure Python implementation.

- For numpy 2.2.1: 

```
inv [[ 1.  0.  0. -1.]
 [ 0.  1.  0. -2.]
 [ 0.  0.  1. -3.]
 [ 0.  0.  0.  1.]]
pinv [[ 1.00000000e+00 -4.62029910e-16  3.19485066e-16 -1.00000000e+00]
 [-5.29094592e-17  1.00000000e+00  7.74666651e-16 -2.00000000e+00]
 [-4.95543739e-17 -1.74588509e-15  1.00000000e+00 -3.00000000e+00]
 [-1.14551985e-16  6.42717943e-16 -4.56019187e-17  1.00000000e+00]]
python inv [[ 1.  0.  0. -1.]
 [ 0.  1.  0. -2.]
 [ 0.  0.  1. -3.]
 [ 0.  0.  0.  1.]]
np.linalg.inv, time: 0.33592380001209676 seconds
np.linalg.pinv time: 1.5744645999511704 seconds
_mat_inv, time: 1.2034183000214398 seconds
```
The performance of `np.linalg.inv` is significantly better than `np.linalg.pinv`, which is the expected behavior.

Additionally, the test results also show that the output of `pinv` is not **numerically stable**.