### PR TITLE
Implement GLTFCubicSplineInterpolant

### DIFF
--- a/pygfx/animation/__init__.py
+++ b/pygfx/animation/__init__.py
@@ -21,6 +21,7 @@ This module contains classes for working with animations.
 # flake8: noqa
 
 from .interpolant import (
+    Interpolant,
     LinearInterpolant,
     StepInterpolant,
     QuaternionLinearInterpolant,


### PR DESCRIPTION
This PR implements the CubicSpline interpolation algorithm as specified in the glTF standard.

Additional Notes:

In glTF, unlike other animation track data, for animation tracks using CUBICSPLINE interpolation, each input element corresponds to three output elements: an in-tangent, a spline vertex, and an out-tangent.

ref: https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#interpolation-cubic

You can view the [InterpolationTest](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/Models/InterpolationTest/README.md) use case in the `gltf_viewer.py` example.

![Video_2025-01-15_105305](https://github.com/user-attachments/assets/5e36d095-67d7-4250-a2e2-972d9413b4da)
