### PR TITLE
Fix ior & specular not work correctly

### DIFF
--- a/pygfx/renderers/wgpu/wgsl/light_pbr_fragment.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/light_pbr_fragment.wgsl
@@ -24,7 +24,7 @@ material.roughness += geometry_roughness;
 material.roughness = min( material.roughness, 1.0 );
 
 
-$$ if IOR is defined
+$$ if USE_IOR is defined
     material.ior = u_material.ior;
 
     $$ if USE_SPECULAR
@@ -42,8 +42,8 @@ $$ if IOR is defined
         material.specular_f90 = mix( specular_intensity, 1.0, metalness_factor );
     
     $$ else
-        specular_intensity = 1.0;
-        specular_color = vec3f( 1.0 );
+        let specular_intensity = 1.0;
+        let specular_color = vec3f( 1.0 );
         material.specular_f90 = 1.0;
 
     $$ endif


### PR DESCRIPTION
Ior and specular did not take effect correctly in MeshPhysicalMaterial:
![image](https://github.com/user-attachments/assets/efbc6e30-62b3-4df2-a23a-83913a4531ee)

Fixed:
![image](https://github.com/user-attachments/assets/252929d6-fffd-4e44-8cb0-12e4d4c254e3)
