### PR TITLE
Add `package_name` as an argument for `load_wgsl`

### DIFF
--- a/pygfx/renderers/wgpu/wgsl/__init__.py
+++ b/pygfx/renderers/wgpu/wgsl/__init__.py
@@ -8,10 +8,9 @@ import importlib.resources
 
 
 @functools.lru_cache(maxsize=None)
-def load_wgsl(shader_name):
+def load_wgsl(shader_name, package_name="pygfx.renderers.wgpu.wgsl"):
     """Load wgsl code from pygfx builtin shader snippets."""
 
-    package_name = "pygfx.renderers.wgpu.wgsl"
     if sys.version_info < (3, 9):
         context = importlib.resources.path(package_name, shader_name)
     else:


### PR DESCRIPTION
Hello pygfx team,

We wanted to load a custom wgsl shader file but since `load_wgsl` function has `package_name` directing to pygfx and we want to use as many pygfx functions as we can, can `package_name` be an argument so that we are able to use it directly?

Thanks