### PR TITLE
Optimize last_modified tracking

### DIFF
--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -4,7 +4,6 @@ import numpy as np
 from ._base import WorldObject
 from ..resources import Buffer
 from ..utils import unpack_bitfield, array_from_shadertype
-from ..utils.transform import AffineBase
 from ..materials import BackgroundMaterial
 
 
@@ -434,8 +433,8 @@ class Text(WorldObject):
             name=name,
         )
 
-    def _update_uniform_buffers(self, transform: AffineBase):
-        super()._update_uniform_buffers(transform)
+    def _update_uniform_buffers(self):
+        super()._update_uniform_buffers()
         # When rendering in screen space, the world transform is used
         # to establish the point in the scene where the text is placed.
         # The only part of the local transform that is used is the

--- a/pygfx/objects/_skins.py
+++ b/pygfx/objects/_skins.py
@@ -3,7 +3,7 @@ import pylinalg as la
 from typing import List
 from ._base import WorldObject
 from ..utils import array_from_shadertype
-from ..utils.transform import AffineBase, callback
+from ..utils.transform import callback
 from ..utils.enums import BindMode
 from ..resources import Buffer
 from ._more import Mesh
@@ -174,8 +174,8 @@ class SkinnedMesh(Mesh):
         self._bind_mode = value
 
     @callback
-    def _update_uniform_buffers(self, transform: AffineBase):
-        super()._update_uniform_buffers(transform)
+    def _update_uniform_buffers(self):
+        super()._update_uniform_buffers()
 
         if self.bind_mode == BindMode.attached:
             self.bind_matrix_inv = self.world.inverse_matrix

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -489,9 +489,9 @@ class WgpuRenderer(RootEventHandler, Renderer):
 
         # Update transform uniform buffers
         for wobject in wobject_list:
-            transform = WorldObject.transform_updates.pop(wobject, None)
-            if transform:
-                wobject._update_uniform_buffers(transform)
+            if wobject._uniform_buffers_dirty:
+                wobject._update_uniform_buffers()
+                wobject._uniform_buffers_dirty = False
 
         # Prepare the shared object
         self._shared.pre_render_hook()


### PR DESCRIPTION
With these micro optimizations (based on cprofile reports) I was able to boost the FPS on the skinning animation example from 145 to 170 on my machine.

Changes:

* Simplified world object transform buffer update tracking to a boolean instead of a WeakKeyDictionary
* Minimized function call overhead for flag_update() since it is being called ridiculously often (it's the main bottleneck in this example)

To get this example to run even faster, the following problems would need to be tackled, as these are the bottlenecks:

* Make flag_update() much cheaper to do or avoid the need for it completely somehow
* Make Stats.__exit__() much more efficient (right now it recomputes all text rendering info on every frame, it should just update maybe a few characters/TextItems instead)
* Make Interpolation of transform attributes more efficient (perhaps precompute?)

I'm not going to pursue any of these challenges right now