### PR TITLE
Optimize last_modified tracking

### DIFF
--- a/pygfx/cameras/_base.py
+++ b/pygfx/cameras/_base.py
@@ -4,7 +4,7 @@ import numpy as np
 import pylinalg as la
 
 from ..objects._base import WorldObject
-from ..utils.transform import cached, callback
+from ..utils.transform import cached
 
 
 class Camera(WorldObject):
@@ -27,16 +27,17 @@ class Camera(WorldObject):
 
     def __init__(self):
         super().__init__()
-        self.last_modified = perf_counter_ns()
+        self._last_modified = perf_counter_ns()
 
         self._view_size = 1.0, 1.0
         self._view_offset = None
 
-        self.world.on_update(self.flag_update)
+    def flag_update(self):
+        self._last_modified = perf_counter_ns()
 
-    @callback
-    def flag_update(self, *args, **kwargs):
-        self.last_modified = perf_counter_ns()
+    @property
+    def last_modified(self) -> int:
+        return max(self._last_modified, self.world.last_modified)
 
     def set_view_size(self, width, height):
         """Sets the logical size of the target. Set by the renderer; you should typically not use this."""

--- a/pygfx/helpers/_skeleton.py
+++ b/pygfx/helpers/_skeleton.py
@@ -34,11 +34,10 @@ class SkeletonHelper(Line):
 
         self.local.matrix = wobject.world.matrix
 
+    def _update_uniform_buffers(self):
         # the helper matrix always follows the root object
-        def _update_matrix(*args):
-            self.local.matrix = self.root.world.matrix
-
-        self.root.world.on_update(_update_matrix)
+        self.local.matrix = self.root.world.matrix
+        super()._update_uniform_buffers()
 
     def update(self):
         # TODO: we should update it automatically by some mechanism.

--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -4,7 +4,6 @@ import numpy as np
 from ._base import WorldObject
 from ..resources import Buffer
 from ..utils import unpack_bitfield, array_from_shadertype
-from ..utils.transform import AffineBase
 from ..materials import BackgroundMaterial
 
 
@@ -434,8 +433,8 @@ class Text(WorldObject):
             name=name,
         )
 
-    def _update_uniform_buffers(self, transform: AffineBase):
-        super()._update_uniform_buffers(transform)
+    def _update_uniform_buffers(self):
+        super()._update_uniform_buffers()
         # When rendering in screen space, the world transform is used
         # to establish the point in the scene where the text is placed.
         # The only part of the local transform that is used is the

--- a/pygfx/objects/_skins.py
+++ b/pygfx/objects/_skins.py
@@ -3,7 +3,7 @@ import pylinalg as la
 from typing import List
 from ._base import WorldObject
 from ..utils import array_from_shadertype
-from ..utils.transform import AffineBase, callback
+from ..utils.transform import callback
 from ..utils.enums import BindMode
 from ..resources import Buffer
 from ._more import Mesh
@@ -174,8 +174,8 @@ class SkinnedMesh(Mesh):
         self._bind_mode = value
 
     @callback
-    def _update_uniform_buffers(self, transform: AffineBase):
-        super()._update_uniform_buffers(transform)
+    def _update_uniform_buffers(self):
+        super()._update_uniform_buffers()
 
         if self.bind_mode == BindMode.attached:
             self.bind_matrix_inv = self.world.inverse_matrix

--- a/pygfx/objects/_skins.py
+++ b/pygfx/objects/_skins.py
@@ -3,7 +3,6 @@ import pylinalg as la
 from typing import List
 from ._base import WorldObject
 from ..utils import array_from_shadertype
-from ..utils.transform import callback
 from ..utils.enums import BindMode
 from ..resources import Buffer
 from ._more import Mesh
@@ -173,7 +172,6 @@ class SkinnedMesh(Mesh):
         assert value in BindMode, f"bind_mode must be one of {BindMode}, not {value}"
         self._bind_mode = value
 
-    @callback
     def _update_uniform_buffers(self):
         super()._update_uniform_buffers()
 

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -484,9 +484,8 @@ class WgpuRenderer(RootEventHandler, Renderer):
 
         # Update transform uniform buffers
         for wobject in wobject_list:
-            if wobject._uniform_buffers_dirty:
-                wobject._update_uniform_buffers()
-                wobject._uniform_buffers_dirty = False
+            # TODO: precompute last_modified for all nodes while traversing
+            wobject.update_uniform_buffers()
 
         # Prepare the shared object
         self._shared.pre_render_hook()

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -484,7 +484,6 @@ class WgpuRenderer(RootEventHandler, Renderer):
 
         # Update transform uniform buffers
         for wobject in wobject_list:
-            # TODO: precompute last_modified for all nodes while traversing
             wobject.update_uniform_buffers()
 
         # Prepare the shared object

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -484,9 +484,9 @@ class WgpuRenderer(RootEventHandler, Renderer):
 
         # Update transform uniform buffers
         for wobject in wobject_list:
-            transform = WorldObject.transform_updates.pop(wobject, None)
-            if transform:
-                wobject._update_uniform_buffers(transform)
+            if wobject._uniform_buffers_dirty:
+                wobject._update_uniform_buffers()
+                wobject._uniform_buffers_dirty = False
 
         # Prepare the shared object
         self._shared.pre_render_hook()

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -742,7 +742,7 @@ class RecursiveTransform(AffineBase):
     @property
     def last_modified(self) -> int:
         return max(
-            self._last_modified, self.own.last_modified, self.parent.last_modified
+            self._last_modified, self.own.last_modified, self._parent.last_modified
         )
 
     @cached


### PR DESCRIPTION
🚀 Another massive performance boost! The skinning animation example runs at 180 fps on my machine now.

* Callback mechanism and weakrefs are completely removed from the Transform API, of course this implies refactoring in a few areas, notably lighting, but actually it is a big improvement because now light buffers are only updated just before rendering, instead of on every transform update
  * Note: I didn't look much further into the lights than needed to make the tests pass
  * Note 2: ⚠️ This is technically a breaking change since `on_update` is removed from the Transform API
* `last_modified` has its own specialized implementation in `AffineTransform`, `RecursiveTransform` and `Camera`, to be as simple as it can be in each case
* `flag_update` no longer immediately propagates, instead propagation happens lazily when a cache attribute is accessed in `RecursiveTransform.last_modified` and `Camera.last_modified` (and **not** in `AffineTransform`)
* The `cache` decorator only accesses `last_modified` once instead of three times
* WorldObjects have a `_world_last_modified` flag which is used to track if the buffers need an update when a frame is rendered

⏭️ **Next up:** I am working on another improvement to eliminate redundant propagation of last_modified, but I will do that in a separate pull request.

🥳 **Cool detail:** Some pretty cool news, with this PR, finally, the Transform API is no longer at the top of the cProfile report!

![image](https://github.com/user-attachments/assets/46c76790-6d84-48c6-9e27-e0ec2dffcb03)

> ncalls: Total number of calls to the function. If there are two numbers, that means the function recursed and the first is the total number of calls and the second is the number of primitive (non-recursive) calls.

So `RecursiveTransform.last_modified` is called ~460k times in one full animation run, and 4m times if you include recursive calls! 😱 It's definitely worthwhile to keep optimizing this, I think 😁 it may be pygfx' hottest codepath!