### PR TITLE
Fix CI by pinning trimesh

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ examples = [
     "pytest",
     "imageio[pyav]",
     "scikit-image",
-    "trimesh",
+    "trimesh <4.6",
     "gltflib",
     "imgui-bundle>=1.6.0",
 ]
@@ -46,11 +46,11 @@ docs = [
     # Duplicate from 'examples'
     "imageio[pyav]",
     "scikit-image",
-    "trimesh",
+    "trimesh <4.6",
     "gltflib",
     "imgui-bundle>=1.6.0",
 ]
-tests = ["pytest", "psutil", "trimesh", "httpx", "gltflib", "imageio"]
+tests = ["pytest", "psutil", "trimesh <4.6", "httpx", "gltflib", "imageio"]
 dev = ["pygfx[lint,tests,examples,docs]"]
 
 [project.entry-points."pyinstaller40"]


### PR DESCRIPTION
Trimesh underwent some API changes in its last release: https://github.com/mikedh/trimesh/releases/tag/4.6.0

I had a stab at updating our code, but the logic for handling meshes vs volumes must be changed quite a bit, with the transform from the one coming from another place than the other, and I got a bit stuck ... so I took the easy route for now 🤷   so that at least we can continue our other prs.