### PR TITLE
Add View class

### DIFF
--- a/examples/feature_demo/spheres.py
+++ b/examples/feature_demo/spheres.py
@@ -9,13 +9,12 @@ Example showing different types of geometric cylinders.
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
-renderer = gfx.renderers.WgpuRenderer(canvas)
-scene = gfx.Scene()
+canvas = RenderCanvas()
+view = gfx.View(canvas, background_color="#000")
 
 grid = gfx.Grid(
     None,
@@ -28,7 +27,7 @@ grid = gfx.Grid(
     orientation="xz",
 )
 grid.local.y = -10
-scene.add(grid)
+view.scene.add(grid)
 
 
 spheres = [
@@ -55,17 +54,8 @@ for pos, color, geometry in spheres:
     material = gfx.MeshPhongMaterial(color=color, flat_shading=True)
     wobject = gfx.Mesh(geometry, material)
     wobject.local.position = pos
-    scene.add(wobject)
-
-camera = gfx.PerspectiveCamera(70, 16 / 9)
-camera.show_object(scene, (-1, -1, -1), up=(0, 1, 0))
-
-scene.add(camera.add(gfx.DirectionalLight()))
-scene.add(gfx.AmbientLight())
-
-controller = gfx.OrbitController(camera, register_events=renderer)
+    view.scene.add(wobject)
 
 
 if __name__ == "__main__":
-    canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/introductory/cube.py
+++ b/examples/introductory/cube.py
@@ -11,22 +11,28 @@ Note: FPS is low since the gallery is rendered on a low-spec CI machine.
 # sphinx_gallery_pygfx_docs = 'animate 4s 25fps'
 # sphinx_gallery_pygfx_test = 'run'
 
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
+
 
 cube = gfx.Mesh(
     gfx.box_geometry(200, 200, 200),
     gfx.MeshPhongMaterial(color="#336699"),
 )
 
+canvas = RenderCanvas()
+view = gfx.View(canvas, camera="ortho")
 
-def animate():
+view.scene.add(cube)
+
+
+# todo: replace with animate event
+@canvas.add_event_handler("before_draw")
+def animate(event):
     rot = la.quat_from_euler((0.005, 0.01), order="XY")
     cube.local.rotation = la.quat_mul(rot, cube.local.rotation)
 
 
 if __name__ == "__main__":
-    disp = gfx.Display()
-    disp.before_render = animate
-    disp.stats = True
-    disp.show(cube)
+    loop.run()

--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -25,6 +25,7 @@ from .utils.load_gltf import (
     load_gltf_mesh_async,
     print_scene_graph,
 )
+from .utils.view import View
 from .utils.show import show, Display
 from .utils.viewport import Viewport
 from .utils.text import font_manager

--- a/pygfx/controllers/_base.py
+++ b/pygfx/controllers/_base.py
@@ -368,7 +368,7 @@ class Controller:
                         pos = event.x, event.y
                         self._create_action(key, action_tuple, pos, pos, rect)
                 else:
-                    self._handle_button_down(key, action_tuple, viewport)
+                    self._handle_button_down(key, action_tuple, viewport, rect)
         elif type == "pointer_move":
             # Update all drag actions
             for action in self._actions.values():
@@ -402,7 +402,7 @@ class Controller:
             action_tuple = self._controls.get(key)
             if action_tuple:
                 need_update = True
-                self._handle_button_down(key, action_tuple, viewport)
+                self._handle_button_down(key, action_tuple, viewport, rect)
         elif type == "key_up":
             # End key presses, regardless of modifier state
             need_update = self._handle_button_up(f"{event.key.lower()}")
@@ -410,12 +410,91 @@ class Controller:
         if need_update and self.auto_update:
             viewport.renderer.request_draw()
 
-    def _handle_button_down(self, key, action_tuple, viewport):
+    def handle_event_dict(self, event, viewport):
+        if not self.enabled:
+            return
+        if not self._cameras:
+            return
+
+        rect = viewport.rect_in_pixels
+        need_update = False
+
+        type = event["event_type"]
+        if type.startswith(("pointer_", "key_", "wheel")):
+            modifiers = {m.lower() for m in event["modifiers"]}
+            if type.startswith("key_"):
+                modifiers.discard(event["key"].lower())
+            modifiers_prefix = "+".join([*sorted(modifiers), ""])
+
+        if type == "before_render":
+            # Do a tick, updating all actions, and using them to update the camera state.
+            # Note that tick() removes actions that are done and have reached the target.
+            if self._auto_update and self._actions:
+                self.tick()
+                need_update = True
+        elif type == "pointer_down" and viewport.is_inside(event["x"], event["y"]):
+            # Start a drag, or an action with mode push/peek/repeat
+            key = modifiers_prefix + f"mouse{event['button']}"
+            action_tuple = self._controls.get(key)
+            if action_tuple:
+                need_update = True
+                if action_tuple[1] == "drag":
+                    # Dont start a new drag if there is one going
+                    if not any(
+                        (a.mode == "drag" and not a.done)
+                        for a in self._actions.values()
+                    ):
+                        pos = event["x"], event["y"]
+                        self._create_action(key, action_tuple, pos, pos, rect)
+                else:
+                    self._handle_button_down(key, action_tuple, viewport, rect)
+        elif type == "pointer_move":
+            # Update all drag actions
+            for action in self._actions.values():
+                if action.mode == "drag" and not action.done:
+                    action.set_target(np.array((event["x"], event["y"])))
+                    need_update = True
+        elif type == "pointer_up":
+            # Stop all drag actions
+            for action in self._actions.values():
+                if action.mode == "drag":
+                    action.done = True
+            # End button presses, regardless of modifier state
+            need_update = self._handle_button_up(f"mouse{event['button']}")
+        elif type == "wheel" and viewport.is_inside(event["x"], event["y"]):
+            # Wheel events. Technically there is horizontal and vertical scroll,
+            # but this does not work well cross-platform, so we consider it 1D.
+            key = modifiers_prefix + "wheel"
+            action_tuple = self._controls.get(key)
+            if action_tuple:
+                need_update = True
+                d = event["dy"] or event["dx"]
+                pos = event["x"], event["y"]
+                action = self._actions.get(key, None)
+                if action is None:
+                    action = self._create_action(key, action_tuple, 0, pos, rect)
+                    action.done = True
+                action.increase_target(d)
+        elif type == "key_down":
+            # Start an action with mode push/peek/repeat
+            key = modifiers_prefix + f"{event['key'].lower()}"
+            action_tuple = self._controls.get(key)
+            if action_tuple:
+                need_update = True
+                self._handle_button_down(key, action_tuple, viewport, rect)
+        elif type == "key_up":
+            # End key presses, regardless of modifier state
+            need_update = self._handle_button_up(f"{event['key'].lower()}")
+
+        if need_update and self.auto_update:
+            viewport.renderer.request_draw()
+
+    def _handle_button_down(self, key, action_tuple, viewport, rect):
         """Common code to handle key/mouse button presses."""
         mode = action_tuple[1]
         action = self._actions.get(key, None)
         if action is None:
-            action = self._create_action(key, action_tuple, 0, None, viewport.rect)
+            action = self._create_action(key, action_tuple, 0, None, rect)
             action.snap_distance = 0.01
         action.done = mode == "push"
         if mode in ("push", "peek"):

--- a/pygfx/utils/view.py
+++ b/pygfx/utils/view.py
@@ -1,0 +1,288 @@
+import pygfx as gfx
+
+
+event_types = [
+    "resize",
+    "pointer_down",
+    "pointer_move",
+    "pointer_up",
+    "key_down",
+    "key_up",
+    "wheel",
+    # "prepare_draw",
+    # "animate"
+]
+
+
+class View:
+    """The view is a convenience object that combines a renderer, scene, camera.
+
+    The view is a relatively simple object, but significantly reduces boilerplate code.
+    You are encouraged to look at the source code to see how it works.
+    """
+
+    _canvas = None
+    _renderer = None
+    _scene = None
+    _camera = None
+    _controller = None
+    _rect = None
+    _rect_in_pixels = None
+
+    def __init__(
+        self,
+        canvas=None,
+        *,
+        renderer=None,
+        rect=None,
+        scene=None,
+        camera=None,
+        controller=None,
+        background_color=None,
+    ):
+        if canvas is None:
+            from rendercanvas.auto import RenderCanvas
+
+            canvas = RenderCanvas()
+        self.canvas = canvas
+
+        self.renderer = renderer if renderer is not None else gfx.WgpuRenderer(canvas)
+
+        auto_scene = False
+        if scene is None:
+            auto_scene = True
+            scene = gfx.Scene()
+            if background_color is None:
+                background_color = "#646464", "#a9a9a9"
+            elif isinstance(background_color, str):
+                background_color = (background_color,)
+            elif isinstance(background_color, (list, tuple)):
+                if isinstance(background_color[0], (int, float)):
+                    background_color = (background_color,)
+            background = gfx.Background(None, gfx.BackgroundMaterial(*background_color))
+            scene.add(background)
+            scene.add(gfx.AmbientLight())
+        self.scene = scene
+
+        self._camera_needs_init = not isinstance(camera, gfx.Camera)
+        self.camera = camera if camera is not None else "perspective"
+
+        if auto_scene:
+            cam_has_light = next(
+                self.camera.iter(lambda x: isinstance(x, gfx.Light)), None
+            )
+            if not cam_has_light:
+                self.camera.add(gfx.DirectionalLight())
+            self.scene.add(self.camera)
+
+        if controller is None and camera == "2d":
+            controller = "2d"
+        self.controller = controller if controller is not None else "orbit"
+        self.rect = rect if rect is not None else ("0%", "0%", "100%", "100%")
+
+    # --- properties
+
+    @property
+    def canvas(self):
+        """The canvas that this view renders to.
+
+        Can be a ``rendercanvas.RenderCanvas``, or ``wgpu.gui.WgpuGuiCanvas``.
+        """
+        return self._canvas
+
+    @canvas.setter
+    def canvas(self, canvas):
+        # todo: drawing should really be done via an event!
+        # Disconnect from the previous canvas
+        if self._canvas is not None:
+            self._canvas.request_draw(lambda: None)
+            self._canvas.remove_event_handler(self._handle_event, *event_types)
+        # Connect new canvas
+        self._canvas = canvas
+        self._canvas.request_draw(self._render)
+        self._canvas.add_event_handler(self._handle_event, *event_types)
+
+    @property
+    def renderer(self):
+        """The renderer to use for this view."""
+        return self._renderer
+
+    @renderer.setter
+    def renderer(self, renderer):
+        if not isinstance(renderer, gfx.Renderer):
+            raise TypeError("View renderer must be a gfx.Renderer.")
+        self._renderer = renderer
+
+    @property
+    def scene(self):
+        """The scene that this view renders."""
+        return self._scene
+
+    @scene.setter
+    def scene(self, scene):
+        if not isinstance(scene, gfx.WorldObject):
+            raise TypeError("View scene must be a gfx.WorldObject.")
+        self._scene = scene
+
+    @property
+    def camera(self):
+        """The camera used to render this scene."""
+        return self._camera
+
+    @camera.setter
+    def camera(self, camera):
+        if isinstance(camera, str):
+            if camera.lower() in ["2d", "ortho", "orthographic"]:
+                camera = gfx.OrthographicCamera()
+            elif camera.lower() in ["3d", "persp", "perspective"]:
+                camera = gfx.PerspectiveCamera()
+            else:
+                raise TypeError(f"View camera str invalid: '{camera}'")
+        elif not isinstance(camera, gfx.Camera):
+            raise TypeError("View camera must be a gfx.Camera or str.")
+        # Disconnect controller
+        if self._camera is not None and self._controller is not None:
+            self._controller.remove_camera(self._camera)
+        # Connect new camera
+        self._camera = camera
+        if self._controller is not None:
+            self._controller.add_camera(self._camera)
+
+    @property
+    def controller(self):
+        """The controller used to control the camera."""
+        # todo: make it possible to have no controller, or maybe a NullController or somethin?
+        return self._controller
+
+    @controller.setter
+    def controller(self, controller):
+        # Check
+        if isinstance(controller, str):
+            if controller.lower() in ["2d", "panzoom"]:
+                controller = gfx.PanZoomController()
+            elif controller.lower() == "orbit":
+                controller = gfx.OrbitController()
+            elif controller.lower() == "trackball":
+                controller = gfx.TrackballController()
+            elif controller.lower() == "fly":
+                controller = gfx.FlyController()
+            else:
+                raise TypeError(f"View controller str invalid: '{controller}'")
+        elif not isinstance(controller, gfx.Controller):
+            raise TypeError("View controller must be a gfx.Controller or str.")
+        # Disconnect old controller
+        if self._controller is not None:
+            self._controller.remove_camera(self._camera)
+        # Connect new controller
+        self._controller = controller
+        self._controller.add_camera(self._camera)
+
+    @property
+    def rect(self):
+        """The rect (x, y, w, h) for this view.
+
+        Each element is a string e.g. '50% + 4px'. Supported units are 'px' and '%'.
+        Supported operarors are '+' and '-'.
+        """
+        return self._rect
+
+    @rect.setter
+    def rect(self, rect):
+        if not (isinstance(rect, (tuple, list)) and len(rect) == 4):
+            raise TypeError("View rect must be a 4-element tuple.")
+        rect2 = []
+        for i in rect:
+            if isinstance(i, (int, float)):
+                rect2.append(f"{i}px")
+            elif isinstance(i, str):
+                rect_item_to_pixels(i, 100)  # check validity
+                rect2.append(i)
+            else:
+                raise TypeError("View rect elements must be number or str.")
+        self._rect = tuple(rect2)
+
+    @property
+    def rect_in_pixels(self):
+        """The rect (x, y, w, h) expressed in logical pixels."""
+        if self._rect_in_pixels is None:
+            w, h = self._canvas.get_logical_size()
+            refs = [w, h, w, h]
+            self._rect_in_pixels = [
+                rect_item_to_pixels(i, r) for i, r in zip(self._rect, refs)
+            ]
+        return self._rect_in_pixels
+
+    # --- methods
+
+    def is_inside(self, x, y):
+        """Get whether the given positio (in logical pixels) is inside the viewport rect."""
+
+        vp = self.rect_in_pixels
+        return vp[0] <= x <= vp[0] + vp[2] and vp[1] <= y <= vp[1] + vp[3]
+
+    def _handle_event(self, event):
+        event_type = event["event_type"]
+
+        # Invalide cached absolute rect
+        if event_type == "resize":
+            self._rect_in_pixels = None
+
+        # todo: make event positions relative to this view
+        # Pass certain events to the controller
+        if event_type in [
+            "pointer_down",
+            "pointer_move",
+            "pointer_up",
+            "key_down",
+            "key_up",
+            "wheel",
+            "before_render",
+        ]:
+            if self._controller is not None:
+                self._controller.handle_event_dict(event, self)
+
+    def _render(self):
+        if self._camera_needs_init:
+            self._camera_needs_init = False
+            self._camera.show_object(self._scene)
+
+        # todo: use rendercanvas before_draw instead
+        event = {"event_type": "before_render"}
+        self._controller.handle_event_dict(event, self)
+
+        self._renderer.render(
+            self._scene,
+            self._camera,
+            flush=False,  # rect=self.rect_in_pixels
+        )
+        self._renderer.flush()
+        self._canvas.request_draw()
+
+
+def rect_item_to_pixels(s, ref):
+    """Convert a css-like position/size representation into a number in logical pixels."""
+    parts = s.split()
+    value = 0
+    cur_op = "+"
+    for part in parts:
+        if part in ("-", "+"):
+            cur_op = part
+        elif part[0].isnumeric() and part.endswith(("px", "%")):
+            part_without_unit = part[:-2] if part.endswith("px") else part[:-1]
+            try:
+                v = float(part_without_unit)
+            except ValueError:
+                raise ValueError(
+                    f"Cannot interpret {part_without_unit!r} in {s!r}."
+                ) from None
+            if part.endswith("%"):
+                v = (v / 100.0) * ref
+            if cur_op == "+":
+                value += v
+            elif cur_op == "-":
+                value -= v
+            else:
+                assert False, "should not happen"  # noqa
+        else:
+            raise ValueError(f"Cannot interpret {s!r}, don't know what {part!r} means.")
+    return value


### PR DESCRIPTION
This adds a new `View` class that replaces the `Viewport` class and `Display`/`show` functionality. Its a bit like a combination of both. The idea is that it automates all the plumbing to connect everything together that's needed for most use-cases.

Later we will make the renderer a bit more low-level by removing events; the viewport will take that role instead. See #492. One can also easily create subplots with this. For now this will be very inefficient, but it will become efficient again when we refactor the renderer to have a predefined size and not wrapping a canvas anymore (#492).

The idea is that with this, ppl can already move to the new api.