### PR TITLE
Tweak the method names that update world objects

### DIFF
--- a/pygfx/helpers/_lights.py
+++ b/pygfx/helpers/_lights.py
@@ -41,8 +41,9 @@ class PointLightHelper(Mesh):
         material = MeshBasicMaterial(color="#fff")
         super().__init__(geometry, material)
 
-    def _update_uniform_buffers(self):
-        super()._update_uniform_buffers()
+    def _update_object(self):
+        # Update on every draw
+        super()._update_object()
 
         if self._color is None and isinstance(self.parent, Light):
             color = self.parent.color
@@ -123,8 +124,9 @@ class DirectionalLightHelper(Line):
         self._show_shadow_extent = bool(value)
         self._shadow_helper.visible = self._show_shadow_extent
 
-    def _update_uniform_buffers(self):
-        super()._update_uniform_buffers()
+    def _update_object(self):
+        # Update on every draw.
+        super()._update_object()
 
         if not isinstance(self.parent, Light):
             return
@@ -210,8 +212,9 @@ class SpotLightHelper(Line):
             LineSegmentMaterial(thickness=1.0),
         )
 
-    def _update_uniform_buffers(self):
-        super()._update_uniform_buffers()
+    def _update_object(self):
+        # Update on every draw
+        super()._update_object()
 
         if not isinstance(self.parent, Light):
             return

--- a/pygfx/helpers/_skeleton.py
+++ b/pygfx/helpers/_skeleton.py
@@ -34,10 +34,10 @@ class SkeletonHelper(Line):
 
         self.local.matrix = wobject.world.matrix
 
-    def _update_uniform_buffers(self):
-        # the helper matrix always follows the root object
+    def _update_object(self):
+        # Update on every draw: the helper matrix always follows the root object
         self.local.matrix = self.root.world.matrix
-        super()._update_uniform_buffers()
+        super()._update_object()
 
     def update(self):
         # TODO: we should update it automatically by some mechanism.

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -182,13 +182,15 @@ class WorldObject(EventTarget, Trackable):
 
         self.name = name
 
-    def update_uniform_buffers(self):
+    def _update_object(self):
+        """This gets called (by the renderer) right before being drawn. Good time for lazy updates."""
         world_last_modified = self.world.last_modified
         if world_last_modified > self._world_last_modified:
             self._world_last_modified = world_last_modified
-            self._update_uniform_buffers()
+            self._update_world_transform()
 
-    def _update_uniform_buffers(self):
+    def _update_world_transform(self):
+        """This gets called right before being drawn, when the world transform has changed."""
         orig_err_setting = np.seterr(under="ignore")
         self.uniform_buffer.data["world_transform"] = self.world.matrix.T
         self.uniform_buffer.data["world_transform_inv"] = self.world.inverse_matrix.T

--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -433,8 +433,9 @@ class Text(WorldObject):
             name=name,
         )
 
-    def _update_uniform_buffers(self):
-        super()._update_uniform_buffers()
+    def _update_world_transform(self):
+        # Update when the world transform has changed
+        super()._update_world_transform()
         # When rendering in screen space, the world transform is used
         # to establish the point in the scene where the text is placed.
         # The only part of the local transform that is used is the

--- a/pygfx/objects/_skins.py
+++ b/pygfx/objects/_skins.py
@@ -172,8 +172,9 @@ class SkinnedMesh(Mesh):
         assert value in BindMode, f"bind_mode must be one of {BindMode}, not {value}"
         self._bind_mode = value
 
-    def _update_uniform_buffers(self):
-        super()._update_uniform_buffers()
+    def _update_world_transform(self):
+        # Update when the world transform has changed
+        super()._update_world_transform()
 
         if self.bind_mode == BindMode.attached:
             self.bind_matrix_inv = self.world.inverse_matrix

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -403,8 +403,8 @@ class WgpuRenderer(RootEventHandler, Renderer):
             # Add to semi-flat data structure
             wobject_dict.setdefault(ob.render_order, []).append(ob)
 
-            # Update transform and uniform buffer
-            ob.update_uniform_buffers()
+            # Update things like transform and uniform buffers
+            ob._update_object()
 
             if isinstance(ob, Light):
                 if isinstance(ob, PointLight):


### PR DESCRIPTION
This makes it more clear that objects that need to update stuff can implement `_update_object()`, which will be called on every draw, so implementations should make sure to exit early when possible.

* `update_uniform_buffers` -> `_update_object` gets called on every draw.
* `_update_uniform_buffers` -> `_update_world_transform` gets called when the world transform is outdated.
* In some helpers, the latter was used, while it looked like they needed the former, so I changed that.

ref #495 
