### PR TITLE
add python min to imgui pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ examples = [
     "scikit-image",
     "trimesh <4.6",
     "gltflib",
-    "imgui-bundle>=1.6.0; python_version >= '3.11'",
+    "imgui-bundle>=1.6.0; python_version >= '3.10'",
 ]
 docs = [
     "sphinx>7.2",
@@ -48,7 +48,7 @@ docs = [
     "scikit-image",
     "trimesh <4.6",
     "gltflib",
-    "imgui-bundle>=1.6.0; python_version >= '3.11'",
+    "imgui-bundle>=1.6.0; python_version >= '3.10'",
 ]
 tests = ["pytest", "psutil", "trimesh <4.6", "httpx", "gltflib", "imageio"]
 dev = ["pygfx[lint,tests,examples,docs]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ examples = [
     "scikit-image",
     "trimesh <4.6",
     "gltflib",
-    "imgui-bundle>=1.6.0",
+    "imgui-bundle>=1.6.0; python_version >= '3.11'",
 ]
 docs = [
     "sphinx>7.2",
@@ -48,7 +48,7 @@ docs = [
     "scikit-image",
     "trimesh <4.6",
     "gltflib",
-    "imgui-bundle>=1.6.0",
+    "imgui-bundle>=1.6.0; python_version >= '3.11'",
 ]
 tests = ["pytest", "psutil", "trimesh <4.6", "httpx", "gltflib", "imageio"]
 dev = ["pygfx[lint,tests,examples,docs]"]


### PR DESCRIPTION
This pins `imgui-bundle>=1.6.0; python_version >= '3.10'` (adding the min python version) in pyproject.

`uv sync` is a pretty great way to simply get up and running, and if you try to run `uv sync --extra dev` here, you get an error:

```
Creating virtual environment at: .venv
  × No solution found when resolving dependencies for split (python_full_version == '3.9.*'):
  ╰─▶ Because the requested Python version (>=3.9) does not satisfy Python>=3.10 and imgui-bundle>=1.6.0 depends on Python>=3.10, we can conclude
      that imgui-bundle>=1.6.0 cannot be used.
      And because only the following versions of imgui-bundle are available:
          imgui-bundle<=1.6.0
          imgui-bundle==1.6.1
          imgui-bundle==1.6.2
      we can conclude that imgui-bundle>=1.6.0 cannot be used.
      And because pygfx[dev] depends on imgui-bundle>=1.6.0 and your project requires pygfx[dev], we can conclude that your project's requirements
      are unsatisfiable.

      hint: The `requires-python` value (>=3.9) includes Python versions that are not supported by your dependencies (e.g., imgui-bundle>=1.6.0
      only supports >=3.10). Consider using a more restrictive `requires-python` value (like >=3.10).
```

It does actually make sense... imgui-bundle itself would never work in 3.9, so might as well? 🤷‍♂️