### PR TITLE
🚀 RecursiveTransform optimization

### DIFF
--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -394,6 +394,7 @@ class WorldObject(EventTarget, Trackable):
             obj._parent = weakref.ref(self)
             obj.world.parent = self.world
             self._children.insert(idx, obj)
+            self.world.children.insert(idx, obj.world)
 
             if keep_world_matrix:
                 obj.world.matrix = transform_matrix
@@ -405,6 +406,7 @@ class WorldObject(EventTarget, Trackable):
         for obj in objects:
             try:
                 self._children.remove(obj)
+                self.world.children.remove(obj.world)
             except ValueError:
                 logger.warning("Attempting to remove object that was not a child.")
                 continue
@@ -418,6 +420,7 @@ class WorldObject(EventTarget, Trackable):
             child._reset_parent(keep_world_matrix=keep_world_matrix)
 
         self._children.clear()
+        self.world.children.clear()
 
     def _reset_parent(self, *, keep_world_matrix=False):
         """Sets the parent to None.

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -738,9 +738,8 @@ class RecursiveTransform(AffineBase):
     def flag_update(self):
         """Signal that this transform has updated."""
         self.last_modified = perf_counter_ns()
-        if (
-            self.children
-        ):  # this if-statement makes a massive difference for performance
+        # this if-statement makes a massive difference for performance, don't remove it
+        if self.children:
             for child in self.children:
                 child.flag_update()
 

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -737,15 +737,12 @@ class RecursiveTransform(AffineBase):
 
     def flag_update(self):
         """Signal that this transform has updated."""
-        # TODO: micro-optimize
-        # TODO: use deque maybe?
-        stack = [self]
-        while stack:
-            # TODO: are pop and extend the most performant methods?
-            current = stack.pop()
-            # TODO: use perf_counter_ns()?
-            current.last_modified = perf_counter_ns()
-            stack.extend(current.children)
+        self.last_modified = perf_counter_ns()
+        if (
+            self.children
+        ):  # this if-statement makes a massive difference for performance
+            for child in self.children:
+                child.flag_update()
 
     @cached
     def __parent_reference_up(self) -> np.ndarray:

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -500,14 +500,14 @@ class AffineTransform(AffineBase):
         """The zero-tilt reference vector used for the direction setters."""
         if self._wrapper:
             return self._wrapper._parent_reference_up
-        return self._reference_up_view
+        return super().reference_up
 
     @reference_up.setter
     def reference_up(self, value):
         if self._wrapper:
             self._wrapper._parent_reference_up = value
-        else:
-            self._reference_up[:] = la.vec_normalize(value)
+            return
+        AffineBase.reference_up.fset(self, value)
 
     @property
     def state_basis(self) -> str:


### PR DESCRIPTION
Comparing main against this branch on my machine we go from 160 FPS to 180 FPS on the skinning animation example.

**Changes:**

Clean up:
* Sprinkled some more type hints in `transform.py`
* Renamed `_reference_up_provider` to `_wrapper` and moved it to `AffineTransform` since it is only used by that subclass
* Constructor arguments `base` and `parent` on `RecursiveTransform` require specific subclasses of `AffineBase` now, it didn't make sense anymore, and it's simply required if we want to go ahead with further performance boosting as done in this PR

The meat of this PR that enables the speed boost:
* `RecursiveTransform` now has a `children` list, maintained by `WorldObject` (just like it maintains the `parent` field)
* Using the `children` list, recursive cache invalidation is moved back to `RecursiveTransform.flag_update` (so at write time, not at read time) and I've used cProfile to micro optimize this function, I'm very sure this is the most performant implementation we can get
* `RecursiveTransform.parent` can be `None` now, avoiding a redundant matrix multiplication in the tree (it used to be a dummy `AffineTransform` instance for the root)

**Performance details:**

This is faster because we now avoid lots of redundant cache checks, and the hot path (`flag_update`) is _much_ more performant.

If you look at `RecursiveTransform.flag_update` closely you'll see an if statement that looks redundant, because the for loop would not iterate even once on an empty list, but it makes a 10 FPS difference. 🤡 I guess there's a lot of overhead involved in iteration, even if the list is empty.

I also looked at implementations with a stack (both list and deque based) so we don't have to recurse, but that's about 1.5x slower than using recursion.

**Next steps:**

Since I think I've squeezed all the performance I can out of the scene graph mechanics (whew! 😅), the next PR will focus on reusing the ndarrays in the cache, instead of constantly reallocating them.