### PR TITLE
⚡ Micro optimization

### DIFF
--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -208,6 +208,9 @@ class WorldObject(EventTarget, Trackable):
 
     def __del__(self):
         id_provider.release_id(self, self.id)
+        self.local._set_wrapper(
+            None
+        )  # break the circular reference so GC has it a little easier
 
     @property
     def up(self) -> np.ndarray:

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 import numpy as np
 import pylinalg as la
 from time import perf_counter_ns
+from operator import methodcaller, attrgetter
 
 from typing import Any, Tuple, Union
 
 
 PRECISION_EPSILON = 1e-7
+
+
+MC = methodcaller("flag_update")
+AC = attrgetter("children")
 
 
 class cached:  # noqa: N801
@@ -738,9 +743,8 @@ class RecursiveTransform(AffineBase):
     def flag_update(self):
         """Signal that this transform has updated."""
         self.last_modified = perf_counter_ns()
-        # this if-statement makes a massive difference for performance, don't remove it
-        if self.children:
-            for child in self.children:
+        if children := self.children:
+            for child in children:
                 child.flag_update()
 
     @cached

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -489,8 +489,8 @@ class AffineTransform(AffineBase):
     def flag_update(self):
         """Signal that this transform has updated."""
         self.last_modified = perf_counter_ns()
-        if self._wrapper:
-            self._wrapper.flag_update()
+        if wrapper := self._wrapper:
+            wrapper.flag_update()
 
     def _set_wrapper(self, wrapper: RecursiveTransform):
         self._wrapper = wrapper
@@ -738,6 +738,7 @@ class RecursiveTransform(AffineBase):
     def flag_update(self):
         """Signal that this transform has updated."""
         self.last_modified = perf_counter_ns()
+        # this if-statement makes a massive difference for performance, don't remove it
         if children := self.children:
             for child in children:
                 child.flag_update()

--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -3,16 +3,11 @@ from __future__ import annotations
 import numpy as np
 import pylinalg as la
 from time import perf_counter_ns
-from operator import methodcaller, attrgetter
 
 from typing import Any, Tuple, Union
 
 
 PRECISION_EPSILON = 1e-7
-
-
-MC = methodcaller("flag_update")
-AC = attrgetter("children")
 
 
 class cached:  # noqa: N801


### PR DESCRIPTION
* Addresses [this comment](https://github.com/pygfx/pygfx/pull/963#discussion_r1942551469) by @almarklein by breaking the reference cycle between `AffineTransform` and `RecursiveTransform` when a `WorldObject` is deleted
* Micro-optimizes `RecursiveTransform.flag_update` a little bit more with the walrus operator; instead of looking up an attribute on `self` multiple times, it's done once and after that the variable is a local which is much faster to access

Timing per call (time spent inside function and all subfunctions)
* main: 4.454e-06
* this branch: 4.016e-06

It makes every call to `RecursiveTransform.flag_update` 10% faster and there are _so many calls_ so it's totally worth it :)

Note: I haven't tried `__slots__` yet, that is probably worthwhile now that I've completed all the major refactoring. Will do that in a next PR 