### PR TITLE
Add Iridescence support to MeshPhysicalMaterial

### DIFF
--- a/examples/feature_demo/gltf_viewer.py
+++ b/examples/feature_demo/gltf_viewer.py
@@ -27,9 +27,7 @@ renderer = gfx.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
 
-dl = gfx.DirectionalLight()
-dl.local.position = (-3, 10, 10)
-scene.add(gfx.AmbientLight(intensity=0.1), dl)
+scene.add(gfx.AmbientLight(intensity=0.1))
 camera = gfx.PerspectiveCamera(45, 1280 / 720)
 
 gfx.OrbitController(camera, register_events=renderer)
@@ -60,7 +58,7 @@ response.raise_for_status()
 model_list: list = response.json()
 
 # filter out models having "core" in tags
-model_list = [m for m in model_list if "core" in m.get("tags", [])]
+# model_list = [m for m in model_list if "core" in m.get("tags", [])]
 
 mixer = gfx.AnimationMixer()
 

--- a/examples/feature_demo/gltf_viewer.py
+++ b/examples/feature_demo/gltf_viewer.py
@@ -82,6 +82,8 @@ background = gfx.Background(None, gfx.BackgroundSkyboxMaterial(map=env_tex))
 background.visible = False
 scene.add(background)
 
+scene.add(gfx.Background.from_color((0.1, 0.1, 0.1, 1)))
+
 
 def add_env_map(obj):
     if isinstance(obj, gfx.Mesh) and isinstance(obj.material, gfx.MeshStandardMaterial):

--- a/examples/feature_demo/gltf_viewer.py
+++ b/examples/feature_demo/gltf_viewer.py
@@ -58,7 +58,7 @@ response.raise_for_status()
 model_list: list = response.json()
 
 # filter out models having "core" in tags
-# model_list = [m for m in model_list if "core" in m.get("tags", [])]
+model_list = [m for m in model_list if "core" in m.get("tags", [])]
 
 mixer = gfx.AnimationMixer()
 

--- a/examples/feature_demo/iridescence.py
+++ b/examples/feature_demo/iridescence.py
@@ -1,0 +1,60 @@
+"""
+Iridescence Abalone
+===================
+
+This example demonstrates iridescence on the abalone shell.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+import imageio.v3 as iio
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+
+# Init
+canvas = WgpuCanvas(size=(1280, 720), title="Iridescence")
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+# Read cube image and turn it into a 3D image (a 4d array)
+env_img = iio.imread("imageio:meadow_cube.jpg")
+cube_size = env_img.shape[1]
+env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+
+# Create environment map
+env_tex = gfx.Texture(
+    env_img, dim=2, size=(cube_size, cube_size, 6), generate_mipmaps=True
+)
+
+gltf_path = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/IridescenceAbalone/glTF-Binary/IridescenceAbalone.glb"
+
+gltf = gfx.load_gltf(gltf_path)
+
+# gfx.print_scene_graph(gltf.scene)  # Uncomment to see the tree structure
+scene.add(gltf.scene)
+
+
+def add_env_map(obj):
+    if isinstance(obj, gfx.Mesh) and isinstance(obj.material, gfx.MeshStandardMaterial):
+        obj.material.env_map = env_tex
+
+
+gltf.scene.traverse(add_env_map)
+
+scene.add(gfx.AmbientLight(intensity=0.1))
+
+# Create camera and controller
+camera = gfx.PerspectiveCamera(45, 640 / 480)
+camera.show_object(gltf.scene, view_dir=(1.8, -0.6, -2.7))
+controller = gfx.OrbitController(camera, register_events=renderer)
+
+
+def animate():
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    renderer.request_draw(animate)
+    run()

--- a/examples/feature_demo/iridescence2.py
+++ b/examples/feature_demo/iridescence2.py
@@ -1,0 +1,105 @@
+"""
+Iridescence
+===========
+
+This example demonstrates iridescence on a set of spheres.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+from time import perf_counter
+import numpy as np
+
+import imageio.v3 as iio
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+
+# Init
+canvas = WgpuCanvas(size=(640, 480), title="Iridescence2")
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+# Lights
+scene.add(gfx.AmbientLight("#c1c1c1", 0.1))
+
+background = gfx.Background.from_color("#444488")
+scene.add(background)
+
+# Read cube image and turn it into a 3D image (a 4d array)
+env_img = iio.imread("imageio:meadow_cube.jpg")
+cube_size = env_img.shape[1]
+env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+
+# Create environment map, use for IBL.
+env_tex = gfx.Texture(
+    env_img, dim=2, size=(cube_size, cube_size, 6), generate_mipmaps=True
+)
+
+# Now create spheres ...
+
+cube_width = 400
+numbers_per_side = 5
+sphere_radius = (cube_width / numbers_per_side) * 0.8 * 0.4
+step_size = 1.0 / numbers_per_side
+
+geometry = gfx.sphere_geometry(sphere_radius, 32, 16)
+
+index = 0
+alpha = 0.0
+alpha_index = 0
+while alpha <= 1.0:
+    colors = np.arange(alpha_index + 2) / (alpha_index + 1) * 255
+    gradient_map_data = np.array(colors, dtype=np.uint8).reshape(1, -1, 1)  # H,W,C
+    gradient_map = gfx.Texture(gradient_map_data, dim=2)
+
+    beta = 0.0
+    while beta <= 1.0:
+        gamma = 0.0
+        while gamma <= 1.0:
+            material = gfx.MeshPhysicalMaterial(
+                iridescence_ior=1.0 + gamma,  # from 1.0 to 2.0
+                iridescence_thickness_range=(
+                    100,
+                    beta * 600 + 100,
+                ),  # film thickness from 100 to 700
+                ior=1.0 + alpha,  # from 1.0 to 2.0
+                env_map=env_tex,
+                iridescence=1.0,
+                roughness=0.2,
+                metalness=0.3,
+            )
+
+            mesh = gfx.Mesh(geometry, material)
+
+            mesh.local.position = (
+                alpha * 400 - 200,
+                beta * 400 - 200,
+                gamma * 400 - 200,
+            )
+            scene.add(mesh)
+            index += 1
+
+            gamma += step_size
+        beta += step_size
+    alpha += step_size
+    alpha_index += 1
+
+
+# Create camera and controls
+camera = gfx.PerspectiveCamera(45, 640 / 480)
+camera.show_object(scene, view_dir=(-2, -1.5, -3), scale=1.2)
+
+controller = gfx.OrbitController(camera, register_events=renderer)
+
+t0 = perf_counter()
+
+
+def animate():
+    renderer.render(scene, camera)
+    renderer.request_draw()
+
+
+if __name__ == "__main__":
+    renderer.request_draw(animate)
+    run()

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -1091,7 +1091,7 @@ class MeshPhysicalMaterial(MeshStandardMaterial):
         Typical ranges are 0-1. Default is (1,1).
     iridescence : float
         The intensity of the iridescence layer, simulating RGB color shift based on the angle
-        between the surface and the viewer,from 0.0 to 1.0. Default is 0.0.
+        between the surface and the viewer, from 0.0 to 1.0. Default is 0.0.
     iridescence_ior : float
         The strength of the iridescence RGB color shift effect, represented by an index-of-refraction.
         Default is 1.3.

--- a/pygfx/renderers/wgpu/shaders/meshshader.py
+++ b/pygfx/renderers/wgpu/shaders/meshshader.py
@@ -609,7 +609,7 @@ class MeshStandardShader(MeshShader):
         return result
 
 
-@register_wgpu_render_function(Mesh, MeshPhysicalMaterial)
+@register_wgpu_render_function(WorldObject, MeshPhysicalMaterial)
 class MeshPhysicalShader(MeshStandardShader):
     def __init__(self, wobject):
         super().__init__(wobject)
@@ -633,34 +633,57 @@ class MeshPhysicalShader(MeshStandardShader):
             )
             self["use_specular_intensity_map"] = True
 
+        # clearcoat
         if material.clearcoat:
             self["USE_CLEARCOAT"] = True
 
-        if material.clearcoat_map is not None:
-            bindings.extend(
-                self._define_texture_map(
-                    geometry, material.clearcoat_map, "clearcoat_map"
+            if material.clearcoat_map is not None:
+                bindings.extend(
+                    self._define_texture_map(
+                        geometry, material.clearcoat_map, "clearcoat_map"
+                    )
                 )
-            )
-            self["use_clearcoat_map"] = True
+                self["use_clearcoat_map"] = True
 
-        if material.clearcoat_roughness_map is not None:
-            bindings.extend(
-                self._define_texture_map(
-                    geometry,
-                    material.clearcoat_roughness_map,
-                    "clearcoat_roughness_map",
+            if material.clearcoat_roughness_map is not None:
+                bindings.extend(
+                    self._define_texture_map(
+                        geometry,
+                        material.clearcoat_roughness_map,
+                        "clearcoat_roughness_map",
+                    )
                 )
-            )
-            self["use_clearcoat_roughness_map"] = True
+                self["use_clearcoat_roughness_map"] = True
 
-        if material.clearcoat_normal_map is not None:
-            bindings.extend(
-                self._define_texture_map(
-                    geometry, material.clearcoat_normal_map, "clearcoat_normal_map"
+            if material.clearcoat_normal_map is not None:
+                bindings.extend(
+                    self._define_texture_map(
+                        geometry, material.clearcoat_normal_map, "clearcoat_normal_map"
+                    )
                 )
-            )
-            self["use_clearcoat_normal_map"] = True
+                self["use_clearcoat_normal_map"] = True
+
+        # iridescence
+        if material.iridescence:
+            self["USE_IRIDESCENCE"] = True
+
+            if material.iridescence_map is not None:
+                bindings.extend(
+                    self._define_texture_map(
+                        geometry, material.iridescence_map, "iridescence_map"
+                    )
+                )
+                self["use_iridescence_map"] = True
+
+            if material.iridescence_thickness_map is not None:
+                bindings.extend(
+                    self._define_texture_map(
+                        geometry,
+                        material.iridescence_thickness_map,
+                        "iridescence_thickness_map",
+                    )
+                )
+                self["use_iridescence_thickness_map"] = True
 
         # Define shader code for binding
         bindings = {i: binding for i, binding in enumerate(bindings)}

--- a/pygfx/renderers/wgpu/wgsl/iridescence.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/iridescence.wgsl
@@ -1,0 +1,102 @@
+$$ if USE_IRIDESCENCE is defined
+
+// XYZ to linear-sRGB color space
+const XYZ_TO_REC709 = mat3x3f(
+     3.2404542, -0.9692660,  0.0556434,
+    -1.5371385,  1.8760108, -0.2040259,
+    -0.4985314,  0.0415560,  1.0572252
+);
+
+// Assume air interface for top
+// Note: We don't handle the case fresnel0 == 1
+fn Fresnel0ToIor( fresnel0: vec3<f32> ) -> vec3<f32> {
+    let sqrt_f0 = sqrt( fresnel0 );
+    return ( vec3<f32>( 1.0 ) + sqrt_f0 ) / ( vec3<f32>( 1.0 ) - sqrt_f0 );
+}
+
+// Conversion FO/IOR
+fn IorToFresnel0_v( transmitted_ior: vec3<f32>, incident_ior: vec3<f32> ) -> vec3<f32> {
+    let p = ( transmitted_ior - incident_ior ) / ( transmitted_ior + incident_ior );
+    return p * p;
+}
+
+// ior is a value between 1.0 and 3.0. 1.0 is air interface
+fn IorToFresnel0( transmitted_ior: f32, incident_ior: f32 ) -> f32 {
+    return pow2( ( transmitted_ior - incident_ior ) / ( transmitted_ior + incident_ior ) );
+}
+
+// Fresnel equations for dielectric/dielectric interfaces.
+// Ref: https://belcour.github.io/blog/research/2017/05/01/brdf-thin-film.html
+// Evaluation XYZ sensitivity curves in Fourier space
+
+fn evalSensitivity( OPD: f32, shift: vec3<f32> ) -> vec3<f32> {
+    let phase = 2.0 * PI * OPD * 1.0e-9;
+    let val = vec3<f32>( 5.4856e-13, 4.4201e-13, 5.2481e-13 );
+    let pos = vec3<f32>( 1.6810e+06, 1.7953e+06, 2.2084e+06 );
+    let VAR = vec3<f32>( 4.3278e+09, 9.3046e+09, 6.6121e+09 );
+
+    var xyz = val * sqrt( 2.0 * PI * VAR ) * cos( pos * phase + shift ) * exp( - pow2( phase ) * VAR );
+    xyz.x += 9.7470e-14 * sqrt( 2.0 * PI * 4.5282e+09 ) * cos( 2.2399e+06 * phase + shift.x ) * exp( - 4.5282e+09 * pow2( phase ) );
+    xyz /= 1.0685e-7;
+
+    let rgb = XYZ_TO_REC709 * xyz;
+    return rgb;
+}
+
+fn evalIridescence( outside_ior: f32, eta2: f32, cos_theta1: f32, thin_film_thickness: f32, base_f0: vec3<f32> ) -> vec3<f32> {
+    // Force iridescenceIOR -> outsideIOR when thinFilmThickness -> 0.0
+    let iridescence_ior = mix( outside_ior, eta2, smoothstep( 0.0, 0.03, thin_film_thickness ) );
+    // Evaluate the cosTheta on the base layer (Snell law)
+    let sin_theta2_sq = pow2( outside_ior / iridescence_ior ) * ( 1.0 - pow2( cos_theta1 ) );
+
+    // Handle TIR:
+    let cos_theta2_sq = 1.0 - sin_theta2_sq;
+    if ( cos_theta2_sq < 0.0 ) {
+        return vec3<f32>( 1.0);
+    }
+
+    let cos_theta2 = sqrt( cos_theta2_sq );
+
+    // First interface
+    let R0 = IorToFresnel0( iridescence_ior, outside_ior );
+    let R12 = F_Schlick_f( R0, 1.0, cos_theta1 );
+    let T121 = 1.0 - R12;
+    var phi12 = 0.0;
+    if ( iridescence_ior < outside_ior ) { phi12 = PI; }
+    let phi21 = PI - phi12;
+
+    // Second interface
+    let base_ior = Fresnel0ToIor( clamp( base_f0, vec3f(0.0), vec3f(0.9999) ) ); // guard against 1.0
+    let R1 = IorToFresnel0_v( base_ior, vec3f(iridescence_ior) );
+    let R23 = F_Schlick( R1, 1.0, cos_theta2 );
+    var phi23 = vec3<f32>( 0.0 );
+    if ( base_ior.x < iridescence_ior ) { phi23.x = PI; }
+    if ( base_ior.y < iridescence_ior ) { phi23.y = PI; }
+    if ( base_ior.z < iridescence_ior ) { phi23.z = PI; }
+
+    // Phase shift
+    let OPD = 2.0 * iridescence_ior * thin_film_thickness * cos_theta2;
+    let phi = vec3<f32>( phi21 ) + phi23;
+
+    // Compound terms
+    let R123 = clamp( R12 * R23, vec3f(1e-5), vec3f(0.9999) );
+    let r123 = sqrt( R123 );
+    let Rs = pow2( T121 ) * R23 / ( vec3<f32>( 1.0 ) - R123 );
+
+    // Reflectance term for m = 0 (DC term amplitude)
+    let C0 = R12 + Rs;
+    var I = C0;
+
+    // Reflectance term for m > 0 (pairs of diracs)
+    var Cm = Rs - T121;
+    for ( var m = 1; m <= 2; m = m + 1 ) {
+        Cm *= r123;
+        let Sm = 2.0 * evalSensitivity( f32(m) * OPD, f32(m) * phi );
+        I += Cm * Sm;
+    }
+
+    // Since out of gamut colors might be produced, negative color values are clamped to 0.
+    return max( I, vec3<f32>( 0.0 ) );
+}
+
+$$ endif

--- a/pygfx/renderers/wgpu/wgsl/light_common.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/light_common.wgsl
@@ -92,6 +92,13 @@ fn F_Schlick(f0: vec3<f32>, f90: f32, dot_vh: f32,) -> vec3<f32> {
     return f0 * ( 1.0 - fresnel ) + ( f90 * fresnel );
 }
 
+fn F_Schlick_f(f0: f32, f90: f32, dot_vh: f32,) -> f32 {
+    // Optimized variant (presented by Epic at SIGGRAPH '13)
+    // https://cdn2.unrealengine.com/Resources/files/2013SiggraphPresentationsNotes-26915738.pdf
+    let fresnel = exp2( ( - 5.55473 * dot_vh - 6.98316 ) * dot_vh );
+    return f0 * ( 1.0 - fresnel ) + ( f90 * fresnel );
+}
+
 $$ if use_normal_map is defined or use_clearcoat_normal_map is defined
 fn perturbNormal2Arb( eye_pos: vec3<f32>, surf_norm: vec3<f32>, mapN: vec3<f32>, uv: vec2<f32>, is_front: bool) -> vec3<f32> {
     let q0 = dpdx( eye_pos.xyz );

--- a/pygfx/renderers/wgpu/wgsl/mesh.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/mesh.wgsl
@@ -17,6 +17,9 @@ $$ elif lighting == 'toon'
     {$ include 'pygfx.light_toon.wgsl' $}
 $$ endif
 
+$$ if USE_IRIDESCENCE is defined
+    {$ include 'pygfx.iridescence.wgsl' $}
+$$ endif
 
 struct VertexInput {
     @builtin(vertex_index) vertex_index : u32,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ examples = [
     "trimesh <4.6",
     "gltflib",
     "imgui-bundle>=1.2.1",
+    "httpx",
 ]
 docs = [
     "sphinx>7.2",
@@ -49,6 +50,7 @@ docs = [
     "trimesh <4.6",
     "gltflib",
     "imgui-bundle>=1.6.0",
+    "httpx",
 ]
 tests = ["pytest", "psutil", "trimesh <4.6", "httpx", "gltflib", "imageio"]
 dev = ["pygfx[lint,tests,examples,docs]"]


### PR DESCRIPTION
This PR introduces support for iridescence in MeshPhysicalMaterial.

It enables rendering effects where hue varies depending on the viewing and illumination angles, similar to phenomena observed in soap bubbles, oil films, and the wings of many insects.

Related glTF extension:  [KHR_materials_iridescence](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_iridescence/README.md).

![image](https://github.com/user-attachments/assets/88ee8935-6ce9-4460-9ee4-bfedfe14d6f0)
