### PR TITLE
Clamp coords when sampling from colormap

### DIFF
--- a/pygfx/renderers/wgpu/wgsl/colormap.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/colormap.wgsl
@@ -1,6 +1,8 @@
 // Colormap support
 
-fn sample_colormap(texcoord: {{ colormap_coord_type }}) -> vec4<f32> {
+fn sample_colormap(texcoord_in: {{ colormap_coord_type }}) -> vec4<f32> {
+
+    let texcoord = clamp(texcoord_in, {{ colormap_coord_type }}(0.0),  {{ colormap_coord_type }}(1.0));
 
     // Determine colormap texture dimensions
     $$ if colormap_dim == '1d'


### PR DESCRIPTION
I think this would fix #979. As I'm writing this I though of a possible better approach. Because sometimes repeating the colormap may be intentional!