### PR TITLE
Clamp colormap by default when texture is given.

### DIFF
--- a/pygfx/materials/_background.py
+++ b/pygfx/materials/_background.py
@@ -139,7 +139,7 @@ class BackgroundImageMaterial(BackgroundMaterial):
     def map(self, map):
         assert_type("map", map, None, Texture, TextureMap)
         if isinstance(map, Texture):
-            map = TextureMap(map)
+            map = TextureMap(map, filter="linear", wrap="clamp")
         self._store.map = map
 
 

--- a/pygfx/materials/_image.py
+++ b/pygfx/materials/_image.py
@@ -57,7 +57,7 @@ class ImageBasicMaterial(Material):
     def map(self, map):
         assert_type("map", map, None, Texture, TextureMap)
         if isinstance(map, Texture):
-            map = TextureMap(map, wrap="clamp")
+            map = TextureMap(map, filter="linear", wrap="clamp")
         self._store.map = map
 
     @property

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -179,7 +179,7 @@ class LineMaterial(Material):
     def map(self, map):
         assert_type("map", map, None, Texture, TextureMap)
         if isinstance(map, Texture):
-            map = TextureMap(map)
+            map = TextureMap(map, filter="linear", wrap="clamp")
         self._store.map = map
 
     @property

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -123,7 +123,7 @@ class MeshAbstractMaterial(Material):
     def map(self, map):
         assert_type("map", map, None, Texture, TextureMap)
         if isinstance(map, Texture):
-            map = TextureMap(map)
+            map = TextureMap(map, filter="linear", wrap="clamp")
         self._store.map = map
 
     @property

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -213,7 +213,7 @@ class PointsMaterial(Material):
     def map(self, map):
         assert_type("map", map, None, Texture, TextureMap)
         if isinstance(map, Texture):
-            map = TextureMap(map)
+            map = TextureMap(map, filter="linear", wrap="clamp")
         self._store.map = map
 
     # todo: sizeAttenuation

--- a/pygfx/materials/_volume.py
+++ b/pygfx/materials/_volume.py
@@ -58,7 +58,7 @@ class VolumeBasicMaterial(Material):
     def map(self, map):
         assert_type("map", map, None, Texture, TextureMap)
         if isinstance(map, Texture):
-            map = TextureMap(map)
+            map = TextureMap(map, filter="linear", wrap="clamp")
         self._store.map = map
 
     @property


### PR DESCRIPTION
Closes #979 (I think).

This makes the colormaps a bit more as expected for scientific users. However it also introduces inconsistency:
```py
mesh.map = some_texture  # clamp
mesh.map = gfx.TextureMap(some_texture)  # repeat
```

The thing is that from general 3D and games, "repeat" is the common default, whereas for scienctific applications "clamp" is more appropriate.

Maybe `fastplotlib` and co should just use colormaps using:
```py
mesh.map = gfx.TextureMap(some_texture, wrap="clamp")
``` 