### PR TITLE
Improve performance of wobject.world.position

### DIFF
--- a/pygfx/utils/transform.py
+++ b/pygfx/utils/transform.py
@@ -93,6 +93,7 @@ class AffineBase:
         "_scaling_signs",
         "_scaling_signs_view",
         "cache__decomposed_cache",
+        "cache__decomposed_position_cache",
         "cache__directions_cache",
         "cache__euler_cache",
         "cache__inverse_matrix_cache",
@@ -148,6 +149,12 @@ class AffineBase:
         return self._scaling_signs_view
 
     @cached
+    def _decomposed_position(self) -> np.ndarray:
+        position = la.mat_decompose_translation(self.matrix)
+        position.flags.writeable = False
+        return position
+
+    @cached
     def _decomposed(self) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
         try:
             decomposed = la.mat_decompose(self.matrix, scaling_signs=self.scaling_signs)
@@ -200,7 +207,7 @@ class AffineBase:
     @property
     def position(self) -> np.ndarray:
         """The origin of source."""
-        return self._decomposed[0]
+        return self._decomposed_position
 
     @property
     def rotation(self) -> np.ndarray:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">= 3.9"
 dependencies = [
     "rendercanvas >= 2",
     "wgpu >=0.19.0,<0.20.0",
-    "pylinalg >=0.6.3,<0.7.0",
+    "pylinalg >=0.6.4,<0.7.0",
     "numpy",
     "freetype-py",
     "uharfbuzz",


### PR DESCRIPTION
This PR makes it possible to get `wobject.world.position` without performing a full matrix decomposition.

This also pulls in the changes from https://github.com/pygfx/pylinalg/pull/101