### PR TITLE
Implement PMREM Generator

### DIFF
--- a/examples/feature_demo/pmrem_test.py
+++ b/examples/feature_demo/pmrem_test.py
@@ -1,0 +1,102 @@
+"""
+PMREM Generator Test
+====================
+
+Test the PMREM generator by showing the cube texture of each mip level.
+"""
+
+# sphinx_gallery_pygfx_docs = 'code'
+# sphinx_gallery_pygfx_test = 'off'
+
+import imageio as iio
+import cv2
+import numpy as np
+import pygfx as gfx
+import wgpu
+from pygfx.utils.pmrem_generator import generate_pmrem
+from pygfx.renderers.wgpu.engine.shared import get_shared
+
+
+def show_cube_texture(
+    texture: gfx.Texture, mip_level, title: str = "Image", size=(1024, 768)
+):
+    """
+    The layout of the cubemap looks like this:
+    ┌────┬────┬────┬────┐
+    │    │ +Y │    │    │
+    ├────┼────┼────┼────┤
+    │ -X │ +Z │ +X │ -Z │
+    ├────┼────┼────┼────┤
+    │    │ -Y │    │    │
+    └────┴────┴────┴────┘
+    """
+
+    device = get_shared().device
+    bytes_per_pixel = 8  # rgba16float
+    mip_size = texture.size[0] // (2**mip_level)
+
+    data = device.queue.read_texture(
+        {
+            "texture": texture._wgpu_object,
+            "mip_level": mip_level,
+            "origin": (0, 0, 0),
+        },
+        {
+            "offset": 0,
+            "bytes_per_row": bytes_per_pixel * mip_size,
+            "rows_per_image": mip_size,
+        },
+        (mip_size, mip_size, 6),
+    )
+    data = np.frombuffer(data, np.float16).reshape(6, mip_size, mip_size, 4)
+
+    # linear -> sRGB
+    data = np.where(
+        data <= 0.0031308, data * 12.92, 1.055 * np.power(data, 1 / 2.4) - 0.055
+    )
+
+    # to unit8
+    data = (data * 255).astype(np.uint8)
+
+    posx, negx, posy, negy, posz, negz = data
+
+    h, w, c = posx.shape[:3]
+
+    big_image = np.zeros((3 * h, 4 * w, c), dtype=data.dtype)
+
+    big_image[0:h, w : 2 * w] = posy
+    big_image[h : 2 * h, 0:w] = negx
+    big_image[h : 2 * h, w : 2 * w] = posz
+    big_image[h : 2 * h, 2 * w : 3 * w] = posx
+    big_image[h : 2 * h, 3 * w : 4 * w] = negz
+    big_image[2 * h : 3 * h, w : 2 * w] = negy
+
+    big_image = cv2.resize(big_image, size)
+
+    # rgba -> bgra
+    big_image = big_image[..., [2, 1, 0, 3]]
+    cv2.imshow(title, big_image)
+
+
+if __name__ == "__main__":
+    # Read cube image and turn it into a 3D image (a 4d array)
+    env_img = iio.imread("imageio:meadow_cube.jpg")
+    cube_size = env_img.shape[1]
+    env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+
+    # Create environment map
+    env_tex = gfx.Texture(
+        env_img,
+        dim=2,
+        size=(cube_size, cube_size, 6),
+        usage=wgpu.TextureUsage.COPY_SRC,
+        colorspace="srgb",
+        generate_mipmaps=False,
+    )
+
+    pmrem_texture, cube_texture = generate_pmrem(env_tex)
+
+    for i in range(6):
+        show_cube_texture(pmrem_texture, i, f"mip_{i}", size=(512, 384))
+
+    cv2.waitKey(0)

--- a/pygfx/renderers/wgpu/engine/update.py
+++ b/pygfx/renderers/wgpu/engine/update.py
@@ -173,7 +173,14 @@ def ensure_wgpu_object(resource):
             resource._wgpu_object = wgpu_texture.create_view()
         else:
             fmt = to_texture_format(resource.format)
-            fmt = ALTTEXFORMAT.get(fmt, [fmt])[0]
+            if fmt in ALTTEXFORMAT:
+                fmt = ALTTEXFORMAT[fmt][0]
+            if resource.texture.colorspace == "tex-srgb" and not fmt.endswith("-srgb"):
+                fmt += "-srgb"
+            elif resource.texture.colorspace == "srgb" and fmt.endswith("-srgb"):
+                logger.warning(
+                    "Using texture.format 'xx-srgb' AND texture.colorspace 'srgb'."
+                )
             resource._wgpu_object = wgpu_texture.create_view(
                 format=fmt,
                 dimension=resource.view_dim,

--- a/pygfx/utils/pmrem_generator.py
+++ b/pygfx/utils/pmrem_generator.py
@@ -1,0 +1,263 @@
+import numpy as np
+import wgpu
+import pygfx as gfx
+from pygfx.renderers.wgpu.engine.shared import get_shared
+from pygfx.utils.cube_camera import CubeCamera
+
+# Reference: https://learnopengl.com/PBR/IBL/Specular-IBL
+
+prefilter_shader = """
+struct Params {
+  roughness: f32,
+  resolution: f32,
+};
+
+@group(0) @binding(0)
+var srcTex: texture_cube<f32>;
+
+@group(0) @binding(1)
+var s: sampler;
+
+@group(0) @binding(2)
+var<uniform> params: Params;
+
+@group(1) @binding(0)
+var destTex: texture_storage_2d_array<rgba16float, write>;
+
+const PI: f32 = 3.141592653589793;
+const SAMPLE_COUNT: u32 = 4096;
+
+//compute the direction vector for a given cube map face and texel coordinate
+fn getCubeDirection(face: u32, uv_: vec2<f32>) -> vec3<f32> {
+  let uv = 2.0 * uv_ - 1.0;
+  switch (face) {
+    case 0u: {
+        return vec3f(1.0, -uv.y, -uv.x);  // +X
+    }
+    case 1u: {
+        return vec3f(-1.0, -uv.y, uv.x);  // -X
+    }
+    case 2u: {
+        return vec3f(uv.x, 1.0, uv.y);    // +Y
+    }
+    case 3u: {
+        return vec3f(uv.x, -1.0, -uv.y);  // -Y
+    }
+    case 4u: {
+        return vec3f(uv.x, -uv.y, 1.0);   // +Z
+    }
+    case 5u: {
+        return vec3f(-uv.x, -uv.y, -1.0); // -Z
+    }
+    default: {
+        return vec3f(0.0);
+    }
+  }
+}
+
+// Hammersley sequence
+fn hammersley(i: u32, N: u32) -> vec2<f32> {
+    var bits = (i << 16u) | (i >> 16u);
+    bits = ((bits & 0x55555555u) << 1u) | ((bits & 0xAAAAAAAAu) >> 1u);
+    bits = ((bits & 0x33333333u) << 2u) | ((bits & 0xCCCCCCCCu) >> 2u);
+    bits = ((bits & 0x0F0F0F0Fu) << 4u) | ((bits & 0xF0F0F0F0u) >> 4u);
+    bits = ((bits & 0x00FF00FFu) << 8u) | ((bits & 0xFF00FF00u) >> 8u);
+    let radicalInverse = f32(bits) * 2.3283064365386963e-10;
+    return vec2f(f32(i)/f32(N), radicalInverse);
+}
+
+// GGX importance sampling
+fn importanceSampleGGX(xi: vec2<f32>, N: vec3<f32>, roughness: f32) -> vec3<f32> {
+  let a = roughness * roughness;
+  
+  let phi = 2.0 * PI * xi.x;
+  let cosTheta = sqrt((1.0 - xi.y) / (1.0 + (a*a - 1.0) * xi.y));
+  let sinTheta = sqrt(1.0 - cosTheta * cosTheta);
+  
+  let H = vec3f(
+    cos(phi) * sinTheta,
+    sin(phi) * sinTheta,
+    cosTheta
+  );
+  
+  let up = select(vec3f(1.0, 0.0, 0.0), vec3f(0.0, 0.0, 1.0), abs(N.z) < 0.999);
+  let tangent = normalize(cross(up, N));
+  let bitangent = cross(N, tangent);
+  
+  let sampleVec = tangent * H.x + bitangent * H.y + N * H.z;
+  return normalize(sampleVec);
+}
+
+// GGX normal distribution function
+fn distributionGGX(NdotH: f32, roughness: f32) -> f32 {
+  let a = roughness * roughness;
+  let a2 = a * a;
+  let denom = NdotH * NdotH * (a2 - 1.0) + 1.0;
+  return a2 / (PI * denom * denom);
+}
+
+// todo: override workgroup_size
+const workgroup_size: u32 = 8u;
+
+@compute
+@workgroup_size(workgroup_size, workgroup_size)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+  let face = id.z;
+
+  let uv = (vec2<f32>(id.xy) + 0.5) / vec2<f32>(params.resolution);
+  
+  let N = normalize(getCubeDirection(face, uv));
+  let R = N;
+  let V = R;
+  
+  var prefilteredColor = vec3<f32>(0.0);
+  var totalWeight = 0.0;
+  
+  for (var i: u32 = 0u; i < SAMPLE_COUNT; i = i + 1u) {
+    let xi = hammersley(i, SAMPLE_COUNT);
+    let H = importanceSampleGGX(xi, N, params.roughness);
+    let L = normalize(2.0 * dot(V, H) * H - V);
+    
+    // let NdotL = max(dot(N, L), 0.0);
+    // let NdotL = clamp(dot(N, L), 0.0, 1.0);
+    let NdotL = saturate(dot(N, L));
+    if (NdotL > 0.0) {
+      let NdotH = clamp(dot(N, H), 0.0, 1.0);
+      let HdotV = clamp(dot(H, V), 0.0, 1.0);
+      
+      let D = distributionGGX(NdotH, params.roughness);
+      let pdf = D * NdotH / (4.0 * HdotV) + 0.0001;
+      let texSize = textureDimensions(srcTex).x;
+      let saTexel = 4.0 * PI / (6.0 * f32(texSize) * f32(texSize));
+      let saSample = 1.0 / (f32(SAMPLE_COUNT) * pdf + 0.0001);
+      let mipLevel = select(0.5 * log2(saSample / saTexel), 0.0, params.roughness == 0.0);
+
+      prefilteredColor += textureSampleLevel(srcTex, s, L, mipLevel).rgb * NdotL;
+      totalWeight += NdotL;
+    }
+  }
+
+  prefilteredColor = prefilteredColor / totalWeight;
+  textureStore(destTex, vec2<u32>(id.xy), face, vec4<f32>(prefilteredColor, 1.0));
+}
+"""  # noqa
+
+
+def generate_pmrem(env_texture):
+    size = env_texture.size[0]
+
+    cube_texture = gfx.Texture(
+        dim=2,
+        size=(size, size, 6),
+        format="rgba16float",
+        generate_mipmaps=True,
+        usage=wgpu.TextureUsage.COPY_DST | wgpu.TextureUsage.COPY_SRC,
+    )
+
+    cube_camera = CubeCamera(cube_texture)
+    device = cube_camera.renderer.device
+    scene = gfx.Scene()
+    background = gfx.Background(None, gfx.BackgroundSkyboxMaterial(map=env_texture))
+    scene.add(background)
+    cube_camera.render(scene)
+
+    device = get_shared().device
+    # Generate mip chain
+    return _generate_mip_chain(device, cube_texture)
+
+
+def _generate_mip_chain(device, cube_texture):
+    pipeline = device.create_compute_pipeline(
+        layout="auto",
+        compute={
+            "module": device.create_shader_module(code=prefilter_shader),
+            "entry_point": "main",
+        },
+    )
+
+    params_buffer = device.create_buffer(
+        size=8, usage=wgpu.BufferUsage.UNIFORM | wgpu.BufferUsage.COPY_DST
+    )
+
+    sampler = device.create_sampler(
+        mag_filter="linear",
+        min_filter="linear",
+        mipmap_filter="linear",
+        address_mode_u="clamp-to-edge",
+        address_mode_v="clamp-to-edge",
+    )
+
+    size = cube_texture.size[0]
+
+    cube_texture_gpu = cube_texture._wgpu_object
+
+    num_mip_levels = int(np.log2(size)) + 1
+
+    # Create a temp texture
+    pmrem_texture_gpu = device.create_texture(
+        size=(size, size, 6),
+        mip_level_count=num_mip_levels,
+        sample_count=1,
+        dimension=wgpu.TextureDimension.d2,
+        format=wgpu.TextureFormat.rgba16float,
+        usage=wgpu.TextureUsage.TEXTURE_BINDING
+        | wgpu.TextureUsage.STORAGE_BINDING
+        | wgpu.TextureUsage.COPY_SRC,
+    )
+
+    bind_group_0 = device.create_bind_group(
+        layout=pipeline.get_bind_group_layout(0),
+        entries=[
+            {
+                "binding": 0,
+                "resource": cube_texture_gpu.create_view(
+                    base_mip_level=0, mip_level_count=num_mip_levels, dimension="cube"
+                ),
+            },
+            {"binding": 1, "resource": sampler},
+            {
+                "binding": 2,
+                "resource": {"buffer": params_buffer, "offset": 0, "size": 8},
+            },
+        ],
+    )
+
+    for mip in range(0, num_mip_levels):
+        roughness = mip / (num_mip_levels - 1)
+        mip_size = size >> mip
+        pmrem_view = pmrem_texture_gpu.create_view(
+            base_mip_level=mip, mip_level_count=1, dimension="2d-array"
+        )
+        device.queue.write_buffer(
+            params_buffer, 0, np.array([roughness, mip_size], dtype=np.float32)
+        )
+
+        bind_group_1 = device.create_bind_group(
+            layout=pipeline.get_bind_group_layout(1),
+            entries=[
+                {"binding": 0, "resource": pmrem_view},
+            ],
+        )
+
+        encoder = device.create_command_encoder()
+        pass_ = encoder.begin_compute_pass()
+        pass_.set_pipeline(pipeline)
+        pass_.set_bind_group(0, bind_group_0)
+        pass_.set_bind_group(1, bind_group_1)
+        pass_.dispatch_workgroups(mip_size // 8, mip_size // 8, 6)
+        pass_.end()
+
+        device.queue.submit([encoder.finish()])
+
+    pmrem_texture = gfx.Texture(
+        format="rgba16float",
+        dim=2,
+        size=(size, size, 6),
+        generate_mipmaps=True,
+        colorspace="physical",
+        usage=wgpu.TextureUsage.TEXTURE_BINDING,
+    )
+    pmrem_texture._wgpu_object = pmrem_texture_gpu
+    pmrem_texture._wgpu_mip_level_count = num_mip_levels
+
+    return pmrem_texture, cube_texture


### PR DESCRIPTION
Implement a PMREM(Prefiltered, Mipmapped Radiance Environment Map) generator.

Reference: https://learnopengl.com/PBR/IBL/Specular-IBL

Uh, I tested myself and it seems to be correct.

This is a map corresponding to different roughness levels, with prefiltered mipmap levels ranging from 0 to 5.

![pm](https://github.com/user-attachments/assets/1e817418-914a-427d-ba53-4d1bc18a1366)

As a comparison, this is normal mipmap level from 0 to 5. 

![mip](https://github.com/user-attachments/assets/86a35900-c61c-44b2-b0b6-a916f4b81825)

The original texture has a resolution of 2048x2048, so even at mip level 5, the mipmapped texture remains relatively sharp. In contrast, PMREM exhibits a more gradual reduction in blur intensity across mip levels, and this progression depends solely on the mip level rather than the original texture's dimensions.

- [ ] Record here for now, and after completing the relevant work on texture format, update the IBL algorithm and use the PMREM generator.