### PR TITLE
Text performance tweaks

### DIFF
--- a/examples/feature_demo/test_big.py
+++ b/examples/feature_demo/test_big.py
@@ -1,0 +1,70 @@
+"""
+Big static text
+===============
+
+Render 10 paragraphs of Lorem ipsum.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+from rendercanvas.auto import RenderCanvas, loop
+
+import pygfx as gfx
+
+
+canvas = RenderCanvas(
+    size=(800, 600), title="Big static text $fps", update_mode="fastest"
+)
+renderer = gfx.renderers.WgpuRenderer(canvas)
+
+scene = gfx.Scene()
+
+
+scene.add(gfx.Background.from_color("#fff"))
+
+text = """
+Lorem ipsum odor amet, consectetuer adipiscing elit. Congue aliquet fusce hendrerit leo fames ac. Proin nec sit mauris lobortis quam ultrices. Senectus habitasse ad orci posuere fusce. Ut lectus inceptos commodo taciti porttitor a habitasse. Vulputate tempus ullamcorper aptent molestie vestibulum massa. Tristique nec ac sagittis morbi; egestas nisl donec morbi. Et nisi donec conubia duis rutrum tellus?
+
+Amet praesent proin leo morbi dignissim eu et sagittis. Finibus dictum parturient eleifend in interdum class mauris. Nisi mollis est per; aliquet primis interdum. Semper torquent sem aliquam eleifend id malesuada. Magnis tincidunt suspendisse sapien massa etiam aptent libero morbi. Commodo montes ac torquent quam rutrum. Ante dis potenti nostra maximus non mattis. Interdum fringilla suspendisse parturient accumsan habitant ridiculus proin. Cursus dolor facilisis arcu ultricies facilisi velit habitasse natoque.
+
+Netus libero nascetur senectus habitant viverra cras euismod maximus. Mattis praesent ornare morbi donec commodo. Natoque ante taciti primis habitasse malesuada montes euismod. Quisque id faucibus, condimentum vehicula montes fusce sem. Eu congue malesuada justo a nulla suscipit. Aplatea curabitur et eget felis, at aptent velit. Ultricies id viverra vestibulum eleifend, massa sed nec. Magnis nullam curae urna quam condimentum facilisis eu. Euismod euismod phasellus, tempus inceptos risus accumsan morbi. Curae metus libero volutpat nisi quis facilisi montes.
+
+Netus egestas magnis cras habitasse porta egestas fringilla. Tortor lectus tortor iaculis eu arcu ex sollicitudin quis. Nascetur dis malesuada ad dapibus, lobortis maximus leo inceptos eros. Vel auctor libero iaculis aliquet fringilla leo donec; curabitur eleifend. Quis laoreet placerat cursus dui sapien finibus. Mi gravida dapibus ante libero tristique auctor lobortis. Primis litora vivamus enim blandit sed.
+
+Nisl eleifend ante mus fusce; feugiat habitasse montes? Volutpat convallis ullamcorper viverra quisque neque porttitor sit? Tempus ut ligula ex maximus ultricies justo erat tempus. Risus bibendum malesuada vitae nulla erat fermentum luctus. Viverra enim nisi cursus sodales tortor volutpat eu? Porta libero mauris ligula elementum facilisi fermentum dignissim. Himenaeos convallis nunc viverra ligula litora mauris tempor etiam? Sem accumsan nibh adipiscing proin sagittis hendrerit suscipit dignissim.
+
+Sapien fringilla facilisis nisl neque leo justo natoque quam. Integer vehicula suspendisse vehicula metus hac rhoncus sed. Lectus felis torquent suspendisse ullamcorper sem est tellus habitasse cras. Dictumst justo nunc vitae quisque facilisis. Vitae bibendum habitant semper nullam purus tellus phasellus faucibus. Arcu nascetur penatibus efficitur ridiculus nullam elit. Mauris nostra ridiculus nibh bibendum tempus sollicitudin ipsum non eleifend.
+
+Ultrices himenaeos litora cubilia risus magna hac. Nisi donec sit praesent pellentesque molestie taciti dui. Laoreet tristique odio natoque elementum duis platea posuere. Dolor adipiscing ligula posuere sodales cubilia, taciti condimentum dignissim. Viverra eget class torquent fusce condimentum. Conubia laoreet viverra dictumst habitant, natoque potenti senectus. Sem leo diam suscipit massa faucibus congue. Faucibus cras ad leo pretium augue iaculis ex mus. Quisque malesuada torquent elit curabitur mauris eleifend? Viverra interdum enim dictum curae fringilla potenti felis dolor duis.
+
+Vitae maecenas varius justo egestas eleifend finibus congue. Orci eu taciti sagittis mus nibh congue urna conubia. Habitant duis nec vulputate orci congue quam. Est sem amet nulla blandit eget. Litora ut est lobortis natoque commodo; eros molestie rhoncus. Inceptos commodo lectus ante porttitor primis duis libero inceptos. Ipsum convallis libero torquent mattis etiam sed finibus. Hac leo ligula; dis fames molestie elit. Cras ridiculus euismod sollicitudin sodales nec ante fusce tristique.
+
+Elit curabitur condimentum eros faucibus rhoncus faucibus taciti. Congue enim consequat venenatis torquent ante senectus neque tortor tincidunt. Odio litora nisl pharetra magnis arcu lacus. Vulputate amet velit nascetur arcu sociosqu erat scelerisque. Habitant ipsum dis faucibus eros tempor tellus. Eleifend class ex non consequat nunc conubia et hendrerit ligula. Porttitor vulputate dolor phasellus efficitur nisi viverra. Orci ridiculus senectus sit nostra conubia purus sociosqu mauris. Elementum nisl tristique magnis vulputate enim efficitur. Dignissim phasellus integer quisque dapibus sollicitudin conubia montes risus.
+
+Eleifend imperdiet primis quam conubia sapien lacus nec sagittis curabitur. Dapibus ante laoreet integer euismod sit ad nulla ultricies. Aenean neque libero lacus ut mollis mus? Cubilia nascetur tempus ultrices vel cursus ipsum egestas vivamus varius. Tellus nostra tristique quis ante felis. Per maximus odio eget nisl ornare; faucibus risus natoque. Curae dapibus interdum finibus adipiscing dui duis convallis eleifend. Ligula ornare himenaeos dictumst felis nam tempor tempor. Curae penatibus tortor vel adipiscing quam nec penatibus himenaeos.
+"""
+
+material = gfx.TextMaterial(color="#000")
+
+tob = gfx.Text(gfx.TextGeometry(text=text, max_width=1000), material)
+scene.add(tob)
+
+camera = gfx.OrthographicCamera(900, 900)
+controller = gfx.PanZoomController(camera, register_events=renderer)
+
+stats = gfx.Stats(viewport=renderer)
+
+
+def animate():
+    renderer.render(scene, camera, flush=False)
+    with stats:
+        renderer.render(scene, camera, flush=False)
+    stats.render()
+
+
+renderer.request_draw(animate)
+
+
+if __name__ == "__main__":
+    loop.run()

--- a/examples/feature_demo/text_big.py
+++ b/examples/feature_demo/text_big.py
@@ -14,7 +14,7 @@ import pygfx as gfx
 
 
 canvas = RenderCanvas(
-    size=(800, 600), title="Big static text $fps", update_mode="fastest"
+    size=(800, 600), title="Big static text $fps", update_mode="continuous"
 )
 renderer = gfx.renderers.WgpuRenderer(canvas)
 

--- a/examples/feature_demo/text_big.py
+++ b/examples/feature_demo/text_big.py
@@ -55,7 +55,7 @@ controller = gfx.PanZoomController(camera, register_events=renderer)
 
 
 def animate():
-    renderer.render(scene, camera, flush=False)
+    renderer.render(scene, camera)
 
 
 renderer.request_draw(animate)

--- a/examples/feature_demo/text_big.py
+++ b/examples/feature_demo/text_big.py
@@ -53,14 +53,9 @@ scene.add(tob)
 camera = gfx.OrthographicCamera(900, 900)
 controller = gfx.PanZoomController(camera, register_events=renderer)
 
-stats = gfx.Stats(viewport=renderer)
-
 
 def animate():
     renderer.render(scene, camera, flush=False)
-    with stats:
-        renderer.render(scene, camera, flush=False)
-    stats.render()
 
 
 renderer.request_draw(animate)

--- a/pygfx/geometries/_base.py
+++ b/pygfx/geometries/_base.py
@@ -135,11 +135,11 @@ class Geometry(Trackable):
                     # Construct aabb
                     pos_finite = pos[finite_mask]
                     aabb = np.array(
-                        [pos_finite.min(axis=0), pos_finite.max(axis=0)], np.float32
+                        [pos_finite.min(axis=0), pos_finite.max(axis=0)], "f4"
                     )
                     # If positions contains xy, but not z, assume z=0
                     if aabb.shape[1] == 2:
-                        aabb = np.column_stack([aabb, np.zeros((2, 1), np.float32)])
+                        aabb = np.column_stack([aabb, np.zeros((2, 1), "f4")])
             self._aabb = aabb
             self._aabb_rev = self.positions.rev
             return self._aabb
@@ -200,12 +200,10 @@ class Geometry(Trackable):
                     distances = np.linalg.norm(pos_finite - center, axis=0)
                     radius = float(distances.max())
                     if len(center) == 2:
-                        bsphere = np.array(
-                            [center[0], center[1], 0.0, radius], np.float32
-                        )
+                        bsphere = np.array([center[0], center[1], 0.0, radius], "f4")
                     else:
                         bsphere = np.array(
-                            [center[0], center[1], center[2], radius], np.float32
+                            [center[0], center[1], center[2], radius], "f4"
                         )
             self._bsphere = bsphere
             self._bsphere_rev = positions.rev

--- a/pygfx/geometries/_text.py
+++ b/pygfx/geometries/_text.py
@@ -1284,22 +1284,30 @@ class TextItem:
     def _sync_data(self, geometry, block_index):
         indices = self.glyph_indices
 
+        # TODO: I think we may optimize by combining arrays from multiple glyphs
+
         # Make the positioning absolute
         scale, dx, dy = self.offset
         positions = self.positions * scale + (dx, dy)
         sizes = self.sizes * scale
 
+        # Get buffers from geometry (the getattr is a bit expensive)
+        glyph_block_indices = geometry.glyph_block_indices
+        glyph_atlas_indices = geometry.glyph_atlas_indices
+        glyph_positions = geometry.glyph_positions
+        glyph_sizes = geometry.glyph_sizes
+
         # Write glyph data
-        geometry.glyph_block_indices.data[indices] = block_index
-        geometry.glyph_atlas_indices.data[indices] = self.atlas_indices
-        geometry.glyph_positions.data[indices] = positions
-        geometry.glyph_sizes.data[indices] = sizes
+        glyph_block_indices.data[indices] = block_index
+        glyph_atlas_indices.data[indices] = self.atlas_indices
+        glyph_positions.data[indices] = positions
+        glyph_sizes.data[indices] = sizes
 
         # Trigger sync
-        geometry.glyph_block_indices.update_indices(indices)
-        geometry.glyph_atlas_indices.update_indices(indices)
-        geometry.glyph_positions.update_indices(indices)
-        geometry.glyph_sizes.update_indices(indices)
+        glyph_block_indices.update_indices(indices)
+        glyph_atlas_indices.update_indices(indices)
+        glyph_positions.update_indices(indices)
+        glyph_sizes.update_indices(indices)
 
     def clear(self, geometry):
         if len(self.glyph_indices):

--- a/pygfx/geometries/_text.py
+++ b/pygfx/geometries/_text.py
@@ -1154,6 +1154,10 @@ class TextItem:
     def render_glyphs(self, geometry):
         """Update the item's arrays."""
 
+        # TODO: The methods on this class are hot code. They access
+        # attributes fromgeometry quite a few times. Unfortunately this access
+        # is expensive, because of the custom __getattr__. Would be good to store
+        # less stuff on the geometry, and more on another object.
         self.need_render_glyphs = False
         self.need_sync_with_geometry = True
 

--- a/pygfx/utils/text/_fontmanager.py
+++ b/pygfx/utils/text/_fontmanager.py
@@ -270,6 +270,9 @@ class FontManager:
                 last_i = i = 0
                 for i in range(1, len(text)):
                     codepoint = ord(text[i])
+                    # Quick continue for default font
+                    if len(fonts) == 1 and fonts[0].has_codepoint(codepoint):
+                        continue
                     new_fonts = [ff for ff in fonts if ff.has_codepoint(codepoint)]
                     if new_fonts:
                         # Our selection of fonts is still nonzero
@@ -287,7 +290,10 @@ class FontManager:
                         text_pieces2.append((text[last_i:i], last_font))
                         last_i = i
                 last_font = fonts[0] if fonts else fallback_font
-                text_pieces2.append((text[last_i : i + 1], last_font))
+                if last_i == 0:
+                    text_pieces2.append((text, last_font))
+                else:
+                    text_pieces2.append((text[last_i : i + 1], last_font))
 
         # Did we encounter characters that we cannot render?
         failed_texts = [text for text, font in text_pieces2 if font is fallback_font]

--- a/pygfx/utils/text/_sdf.py
+++ b/pygfx/utils/text/_sdf.py
@@ -40,7 +40,7 @@ def generate_glyph(glyph_indices, font_filename):
     # we keep the face alive in the cache.
     face = CACHE_FT[font_filename]
 
-    atlas_indices = np.zeros((len(glyph_indices),), np.uint32)
+    atlas_indices = np.empty((len(glyph_indices),), "u4")
     for i in range(len(glyph_indices)):
         glyph_index = int(glyph_indices[i])
         glyph_hash = (font_index, glyph_index)

--- a/pygfx/utils/text/_shaper.py
+++ b/pygfx/utils/text/_shaper.py
@@ -58,6 +58,7 @@ class TemporalCache:
         """
         # Make subsequent calls *really* fast
         if key == self._last_key:
+            self._lifetimes[key] = time.time()
             return self._last_val
 
         # Get result

--- a/pygfx/utils/text/_shaper.py
+++ b/pygfx/utils/text/_shaper.py
@@ -178,8 +178,8 @@ def shape_text_hb(text, font_filename, direction=None):
 
     # Get glyph indices (these can be different from the text's Unicode
     # code points) and convert advances to positions.
-    glyph_indices = np.empty((n_glyphs,), np.uint32)
-    positions = np.empty((n_glyphs, 2), np.float32)
+    glyph_indices = np.empty((n_glyphs,), "u4")
+    positions = np.empty((n_glyphs, 2), "f4")
     pen_x = pen_y = 0
     for i in range(n_glyphs):
         glyph_indices[i] = glyph_infos[i].codepoint
@@ -232,7 +232,7 @@ def shape_text_ft(text, font_filename, direction=None):
     advances = [(x / 65536 if x > 65536 * 10 else x) for x in advances]
 
     # Convert advances to positions
-    positions = np.zeros((n_glyphs, 2), np.float32)
+    positions = np.empty((n_glyphs, 2), "f4")
     pen_x = 0
     prev = " "
     for i in range(n_glyphs):

--- a/pygfx/utils/text/_tokenizers.py
+++ b/pygfx/utils/text/_tokenizers.py
@@ -31,23 +31,16 @@ def _tokenze(text, groups, prog):
     pos = 0
     while True:
         match = prog.search(text, pos)
-
-        if not match:
-            other = text[pos:]
-            if other:
-                yield "other", other
+        if match is None:
             break
 
-        other = text[pos : match.start()]
-        if other:
-            yield "other", other
+        start = match.start()
+        if start > pos:
+            yield "other", text[pos : match.start()]
 
-        s = match.group()
-        for group_index, group_name in enumerate(groups, 1):
-            if match.group(group_index):
-                yield group_name, s
-                break
-        else:
-            yield "other", s
-
+        yield groups[match.lastindex - 1], match.group()
         pos = match.end()
+
+    other = text[pos:]
+    if other:
+        yield "other", other

--- a/tests/geometries/test_text_geometry.py
+++ b/tests/geometries/test_text_geometry.py
@@ -118,6 +118,7 @@ def test_text_geometry_blocks():
 def test_text_geometry_blocks_buffer():
     class MyTextGeometry(MultiTextGeometry):
         allocation_count = 0
+
         def _allocate_block_buffers(self, n):
             super()._allocate_block_buffers(n)
             self.allocation_count += 1

--- a/tests/geometries/test_text_geometry.py
+++ b/tests/geometries/test_text_geometry.py
@@ -116,20 +116,52 @@ def test_text_geometry_blocks():
 
 
 def test_text_geometry_blocks_buffer():
-    geo = MultiTextGeometry()
+    class MyTextGeometry(MultiTextGeometry):
+        allocation_count = 0
+        def _allocate_block_buffers(self, n):
+            super()._allocate_block_buffers(n)
+            self.allocation_count += 1
+
+    geo = MyTextGeometry()
+
     assert geo.positions.nitems == 8
+    assert geo.allocation_count == 0
+
+    # Note that the minimum is 8
+
+    geo.set_text_block_count(1)
+    assert geo.positions.nitems == 8
+    assert geo.allocation_count == 0
+
+    geo.set_text_block_count(1)
+    assert geo.positions.nitems == 8
+    assert geo.allocation_count == 0
+
+    geo.set_text_block_count(2)
+    assert geo.positions.nitems == 8
+    assert geo.allocation_count == 0
 
     geo.set_text_block_count(8)
     assert geo.positions.nitems == 8
+    assert geo.allocation_count == 0
+
+    # Now we bump
 
     geo.set_text_block_count(9)
     assert geo.positions.nitems == 16
+    assert geo.allocation_count == 1
+
+    geo.set_text_block_count(9)
+    assert geo.positions.nitems == 16
+    assert geo.allocation_count == 1
 
     geo.set_text_block_count(16)
     assert geo.positions.nitems == 16
+    assert geo.allocation_count == 1
 
     geo.set_text_block_count(17)
     assert geo.positions.nitems == 32
+    assert geo.allocation_count == 2
 
     geo.set_text_block_count(33)
     assert geo.positions.nitems == 64

--- a/tests/utils/test_text_shaping.py
+++ b/tests/utils/test_text_shaping.py
@@ -25,6 +25,7 @@ def test_cache():
     assert c["bar"] == hash("bar")
     assert "foo" in c
     assert "bar" in c
+    assert c["spam"]  # make "bar" not the last lookup
 
     # Wait again, now get a previously nonexistent item to trigger removing foo
     time.sleep(0.11)


### PR DESCRIPTION
## Benchmarks

I've written a few benchmarks in https://github.com/pygfx/pygfx-benchmarks/pull/7.

Before new text:
```
               large_static_text (10x) - cpu:  2.58 ms
   changing_one_word_in_big_text (10x) - cpu: 17.85 ms
 changing_one_word_in_small_text (1000x) - cpu:  0.08 ms
           multiple_text_objects (10x) - cpu: 20.05 ms
              multitext_geometry (10x) - cpu:  -
```

After new text (#834):
```
              large_static_text (10x) - cpu:  2.52 ms
  changing_one_word_in_big_text (10x) - cpu:  0.66 ms
changing_one_word_in_small_text (1000x) - cpu:  0.12 ms
          multiple_text_objects (10x) - cpu: 22.16 ms
             multitext_geometry (10x) - cpu:  2.86 ms
```

We can see that rendering a big static text does not make a significant difference.
The extra lookup in the positions buffer does not seem to affect the rendering performance.

Changing a single word in a big text is now *much* more efficient, because of how text blocks and text items are re-used, and re-layout mostly confined to the changed paragraph. And this is with improved layout (e.g. `line_width`).

Updating a short piece of text is measurable slower. This is one of the things I try to improve in this PR.

Using `MultiTextGeometry` is a lot faster than rendering separate text objects, as expected. (Tested with 1000, but the improvement is likely observable with much smaller numbers.)

After this PR:
```
changing_one_word_in_small_text (1000x) - cpu:  0.07 ms
```
A tiny number but (with this number of iters) quite stable, so a 40% speedup.


## What I did

I ran one of the benchmarks in isolation to test the performance as I tweaked the code, and used cprofile to identify bottlenecks: 
```
python -m cProfile -o program.prof my_little_benchmark_script.py && python -m snakeviz program.prof
```

## Tasks

In this PR I focus on optimizing the setting of text. 

* [x] Added an example to render a large piece of text.
* [x] Tweaks for performance related to setting text:
  * [x] tokenizer
  * [x] shaping
  * [x] font selection    
  * [x] some general tweaks
  * [x] text item syncing
  * [x] layout 

Directions for future optimizations:
* Avoid attribute access of geometry, which is expensive due to the custom `__getattr__`.
* Pack per-glyph info into a single buffer.