### PR TITLE
Use single buffer to store per-glyph data

### DIFF
--- a/pygfx/geometries/_text.py
+++ b/pygfx/geometries/_text.py
@@ -53,9 +53,8 @@ WHITESPACE_EXTENTS = {}
 
 GLYPH_DTYPE = np.dtype(
     [
-        ("x", "f4"),
-        ("y", "f4"),
-        ("s", "f4"),
+        ("pos", "f4", 2),
+        ("size", "f4"),
         ("atlas_index", "u4"),
         ("block_index", "u2"),
         ("format", "u2"),  # bitmask encoding relative weight and more
@@ -1322,9 +1321,8 @@ class TextItem:
         glyph_data_array = glyph_data.data
 
         # Write data
-        glyph_data_array["x"][indices] = positions[:, 0]
-        glyph_data_array["y"][indices] = positions[:, 1]
-        glyph_data_array["s"][indices] = sizes
+        glyph_data_array["pos"][indices] = positions
+        glyph_data_array["size"][indices] = sizes
         glyph_data_array["atlas_index"][indices] = self.atlas_indices
         glyph_data_array["block_index"][indices] = block_index
         glyph_data_array["format"][indices] = self.formats

--- a/pygfx/geometries/_text.py
+++ b/pygfx/geometries/_text.py
@@ -55,8 +55,8 @@ GLYPH_DTYPE = np.dtype(
     [
         ("pos", "f4", 2),
         ("size", "f4"),
-        ("atlas_index", "u4"),
-        ("block_index", "u2"),
+        ("block_index", "u4"),
+        ("atlas_index", "u2"),
         ("format", "u2"),  # bitmask encoding relative weight and more
     ]
 )

--- a/pygfx/geometries/_text.py
+++ b/pygfx/geometries/_text.py
@@ -51,6 +51,9 @@ ANCHOR_ALIASES["center"] = ANCHOR_ALIASES["middle"] = "middle-center"
 # We cache the extents of small whitespace strings to improve performance
 WHITESPACE_EXTENTS = {}
 
+# This is the dtype for per-glyph data. In the shader we can only use 32bit datatypes (maybe f16 in a future version).
+# To safe memory, we combine the atlas_index and format mask into a single u32. Here they look like two uint16 but
+# in the shader they're interpreted as a single word, and decomposed.
 GLYPH_DTYPE = np.dtype(
     [
         ("pos", "f4", 2),

--- a/pygfx/renderers/wgpu/shaders/textshader.py
+++ b/pygfx/renderers/wgpu/shaders/textshader.py
@@ -38,14 +38,6 @@ class TextShader(BaseShader):
             Binding("u_wobject", "buffer/uniform", wobject.uniform_buffer),
             Binding("u_material", "buffer/uniform", material.uniform_buffer),
             Binding("s_positions", sbuffer, geometry.positions, "VERTEX"),
-            Binding(
-                "s_glyph_block_indices", sbuffer, geometry.glyph_block_indices, "VERTEX"
-            ),
-            Binding(
-                "s_glyph_atlas_indices", sbuffer, geometry.glyph_atlas_indices, "VERTEX"
-            ),
-            Binding("s_glyph_positions", sbuffer, geometry.glyph_positions, "VERTEX"),
-            Binding("s_glyph_sizes", sbuffer, geometry.glyph_sizes, "VERTEX"),
         ]
 
         tex = shared.glyph_atlas_texture
@@ -60,8 +52,9 @@ class TextShader(BaseShader):
 
         bindings1 = {}
         bindings1[0] = Binding(
-            "s_glyph_infos", sbuffer, shared.glyph_atlas_info_buffer, "VERTEX"
+            "s_glyph_info", sbuffer, shared.glyph_atlas_info_buffer, "VERTEX"
         )
+        bindings1[1] = Binding("s_glyph_data", sbuffer, geometry.glyph_data, "VERTEX")
 
         return {
             0: bindings,
@@ -76,7 +69,7 @@ class TextShader(BaseShader):
 
     def get_render_info(self, wobject, shared):
         material = wobject.material
-        n = wobject.geometry.glyph_positions.draw_range[1] * 6
+        n = wobject.geometry.glyph_data.draw_range[1] * 6
 
         render_mask = 0
         if wobject.render_mask:

--- a/pygfx/renderers/wgpu/wgsl/text.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/text.wgsl
@@ -17,8 +17,21 @@ struct GlyphInfo {
     offset: vec2<f32>,  // positional offset of the glyph
 };
 
+// The per-glyph struct. Should match text's GLYPH_DTYPE
+struct GlyphData {
+    x: f32,
+    y: f32,
+    s: f32,  // f16 is plenty precise, but is unknown type, I think our current wgsl is not recent enoug    h to support it
+    atlas_index: u32,
+    block_index_and_format: u32,
+}
+
+
 @group(1) @binding(0)
-var<storage,read> s_glyph_infos: array<GlyphInfo>;
+var<storage,read> s_glyph_info: array<GlyphInfo>;
+
+@group(1) @binding(1)
+var<storage,read> s_glyph_data: array<GlyphData>;
 
 
 @vertex
@@ -30,25 +43,27 @@ fn vs_main(in: VertexInput) -> Varyings {
     let index = raw_index / 6;
     let sub_index = raw_index % 6;
 
-    // Load glyph info
-    let block_index = i32(load_s_glyph_block_indices(index));
-    let glyph_index_raw = u32(load_s_glyph_atlas_indices(index));
-    let font_size = load_s_glyph_sizes(index);
-    let glyph_pos = load_s_glyph_positions(index);
+    // Load glyph data
+    let glyph_data = s_glyph_data[index];
+    let block_index  = i32(glyph_data.block_index_and_format & 0xFFFFu);
+    let format_bitmask = (glyph_data.block_index_and_format & 0xFFFF0000u) >> 16u;
+    let atlas_index  = i32(glyph_data.atlas_index);
+    let glyph_pos = vec2<f32>(glyph_data.x, glyph_data.y);
+    let font_size = f32(glyph_data.s);
 
+    // Get position of the current block
     let block_pos: vec3<f32> = load_s_positions(block_index);
 
-
     // Extract actual glyph index and the encoded font props
-    let atlas_index = u32(glyph_index_raw & 0x00FFFFFFu);
-    let weight_0_15 = (glyph_index_raw & 0xF0000000u) >> 28u;  // highest 4 bits
-    let is_slanted = bool(glyph_index_raw & 0x08000000u);
-    //let reserved1 = bool(glyph_index_raw & 0x04000000u);
-    //let reserved2 = bool(glyph_index_raw & 0x02000000u);
-    //let reserved3 = bool(glyph_index_raw & 0x01000000u);
+    let weight_0_15 = (format_bitmask & 0xF000u) >> 12u;  // 4 bits encode -250 .. 500 in steps of 50
+    let weight_offset = f32(weight_0_15) * 50.0 - 250.0;
+    let slant_0_15 = (format_bitmask & 0x0F00u) >> 8u;  // 4 bits encode -1.75 .. 2 in steps of 0.25
+    let slant_offset = f32(slant_0_15) / 4.0 - 1.75;
+    //let reserved1 = (format_bitmask & 0x00F0u) >> 4u;
+    //let reserved2 = (format_bitmask & 0x000Fu);
 
     // Load meta-data of the glyph in the atlas
-    let glyph_info = s_glyph_infos[atlas_index];
+    let glyph_info = s_glyph_info[atlas_index];
     let bitmap_rect = vec4<i32>(glyph_info.origin, glyph_info.size );
 
     // Prep correction vectors
@@ -64,7 +79,7 @@ fn vs_main(in: VertexInput) -> Varyings {
     let corner = corners[sub_index];
 
     // Apply slanting, a.k.a. automated obliques, a.k.a. fake italics
-    let slant_factor = f32(is_slanted) * 0.23;  // empirically selected based on NotoSans-Italic
+    let slant_factor = slant_offset * 0.23;  // empirically selected based on NotoSans-Italic
     let slant = vec2<f32>(0.5 - corner.y, 0.0) * slant_factor;
 
     let pos_corner_factor = corner * vec2<f32>(1.0, -1.0);
@@ -148,7 +163,7 @@ fn vs_main(in: VertexInput) -> Varyings {
     varyings.world_pos = vec3<f32>(world_pos.xyz / world_pos.w);
     varyings.atlas_pixel_scale = f32(atlas_pixel_scale);
     varyings.texcoord_in_pixels = vec2<f32>(texcoord_in_pixels);
-    varyings.weight_offset = f32(f32(weight_0_15) * 50.0 - 250.0);  // encodes -250..500 in steps of 50
+    varyings.weight_offset = f32(weight_offset);
 
     // Picking
     varyings.pick_idx = u32(index);

--- a/pygfx/renderers/wgpu/wgsl/text.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/text.wgsl
@@ -22,8 +22,8 @@ struct GlyphData {
     x: f32,
     y: f32,
     s: f32,  // f16 is plenty precise, but is unknown type, I think our current wgsl is not recent enoug    h to support it
-    atlas_index: u32,
-    block_index_and_format: u32,
+    block_index: u32,
+    atlas_index_and_format: u32,
 }
 
 
@@ -45,9 +45,9 @@ fn vs_main(in: VertexInput) -> Varyings {
 
     // Load glyph data
     let glyph_data = s_glyph_data[index];
-    let block_index  = i32(glyph_data.block_index_and_format & 0xFFFFu);
-    let format_bitmask = (glyph_data.block_index_and_format & 0xFFFF0000u) >> 16u;
-    let atlas_index  = i32(glyph_data.atlas_index);
+    let block_index  = i32(glyph_data.block_index);
+    let atlas_index = i32(glyph_data.atlas_index_and_format & 0xFFFFu);
+    let format_bitmask = (glyph_data.atlas_index_and_format & 0xFFFF0000u) >> 16u;
     let glyph_pos = vec2<f32>(glyph_data.x, glyph_data.y);
     let font_size = f32(glyph_data.s);
 

--- a/tests/geometries/test_text_geometry.py
+++ b/tests/geometries/test_text_geometry.py
@@ -23,21 +23,21 @@ def test_text_geometry_text():
     assert len(geo._text_blocks) == 0
     assert geo._glyph_count == 0
     assert geo.positions.nitems == min_blocks
-    assert geo.glyph_atlas_indices.nitems == min_glyphs
+    assert geo.glyph_data.nitems == min_glyphs
 
     # Only a newline
     geo = TextGeometry("\n")  # also test that text is a positional arg
     assert len(geo._text_blocks) == 1
     assert geo._glyph_count == 0
     assert geo.positions.nitems == min_blocks
-    assert geo.glyph_atlas_indices.nitems == min_glyphs
+    assert geo.glyph_data.nitems == min_glyphs
 
     # Only a space
     geo = TextGeometry(" ")  # also test that text is a positional arg
     assert len(geo._text_blocks) == 1
     assert geo._glyph_count == 0
     assert geo.positions.nitems == min_blocks
-    assert geo.glyph_atlas_indices.nitems == min_glyphs
+    assert geo.glyph_data.nitems == min_glyphs
 
     # One char
     geo = TextGeometry(text="a")
@@ -45,7 +45,7 @@ def test_text_geometry_text():
     assert len(geo._text_blocks[0]._text_items) == 1
     assert geo._glyph_count == 1
     assert geo.positions.nitems == min_blocks
-    assert geo.glyph_atlas_indices.nitems == min_glyphs
+    assert geo.glyph_data.nitems == min_glyphs
 
     # Two words with 3 chars in total
     geo = TextGeometry(text="a bc")
@@ -53,31 +53,31 @@ def test_text_geometry_text():
     assert len(geo._text_blocks[0]._text_items) == 2
     assert geo._glyph_count == 3
     assert geo.positions.nitems == min_blocks
-    assert geo.glyph_atlas_indices.nitems == min_glyphs
+    assert geo.glyph_data.nitems == min_glyphs
 
     # Can set new text, buffers are recreated
     geo.set_text("foo\nbar")
     assert len(geo._text_blocks) == 2
     assert geo._glyph_count == 6
     assert geo.positions.nitems == min_blocks
-    assert geo.glyph_atlas_indices.nitems == min_glyphs
+    assert geo.glyph_data.nitems == min_glyphs
 
     # Mo text
     geo.set_text("foo bar spam eggs\naap noot mies")
     assert len(geo._text_blocks) == 2
     assert geo._glyph_count == 25
     assert geo.positions.nitems == min_blocks
-    assert geo.glyph_atlas_indices.nitems == 32
+    assert geo.glyph_data.nitems == 32
 
     # If setting smaller text, buffer size is oversized
     geo.set_text("x")
     assert len(geo._text_blocks) == 1
     assert geo._glyph_count == 1
     assert geo.positions.nitems == min_blocks
-    assert geo.glyph_atlas_indices.nitems == 32
+    assert geo.glyph_data.nitems == 32
 
     # Sizes are used to invalidate unused slots
-    assert np.all(geo.glyph_sizes.data[1:] == 0)
+    assert np.all(geo.glyph_data.data["size"][1:] == 0)
 
 
 def test_text_geometry_blocks():
@@ -225,10 +225,10 @@ def test_text_geometry_whitespace():
     t3 = TextGeometry(text=" abc def", anchor="baseline-left")
     t4 = TextGeometry(text="abc def ", anchor="baseline-left")
 
-    x1 = t1.glyph_positions.data[t1._glyph_count - 1, 0]
-    x2 = t2.glyph_positions.data[t2._glyph_count - 1, 0]
-    x3 = t3.glyph_positions.data[t3._glyph_count - 1, 0]
-    x4 = t4.glyph_positions.data[t4._glyph_count - 1, 0]
+    x1 = t1.glyph_data.data["pos"][t1._glyph_count - 1, 0]
+    x2 = t2.glyph_data.data["pos"][t2._glyph_count - 1, 0]
+    x3 = t3.glyph_data.data["pos"][t3._glyph_count - 1, 0]
+    x4 = t4.glyph_data.data["pos"][t4._glyph_count - 1, 0]
 
     assert x2 > x1  # Extra spaces in between words are preserved
     assert x3 > x1  # Extra space at the start is also preserved
@@ -241,10 +241,10 @@ def test_text_geometry_whitespace():
     t3 = TextGeometry(text=" abc def", anchor="baseline-right")
     t4 = TextGeometry(text="abc def ", anchor="baseline-right")
 
-    x1 = t1.glyph_positions.data[0, 0]
-    x2 = t2.glyph_positions.data[0, 0]
-    x3 = t3.glyph_positions.data[0, 0]
-    x4 = t4.glyph_positions.data[0, 0]
+    x1 = t1.glyph_data.data["pos"][0, 0]
+    x2 = t2.glyph_data.data["pos"][0, 0]
+    x3 = t3.glyph_data.data["pos"][0, 0]
+    x4 = t4.glyph_data.data["pos"][0, 0]
 
     x1 += t1.positions.data[0, 0]
     x2 += t2.positions.data[0, 0]
@@ -302,11 +302,11 @@ def test_text_geometry_anchor():
 
 def test_text_geometry_direction_ttb():
     t1 = TextGeometry("abc def", direction="ltr")
-    x1, y1 = t1.glyph_positions.data[:, 0], t1.glyph_positions.data[:, 1]
+    x1, y1 = t1.glyph_data.data["pos"][:, 0], t1.glyph_data.data["pos"][:, 1]
     assert (x1.max() - x1.min()) > (y1.max() - y1.min())
 
     t2 = TextGeometry("abc def", direction="ttb")
-    x2, y2 = t2.glyph_positions.data[:, 0], t2.glyph_positions.data[:, 1]
+    x2, y2 = t2.glyph_data.data["pos"][:, 0], t2.glyph_data.data["pos"][:, 1]
     assert (x2.max() - x2.min()) < (y2.max() - y2.min())
 
 
@@ -407,10 +407,10 @@ def test_geometry_text_align_1():
     text = [ref_text]
 
     def xpos(geo, block_i, glyph_i):
-        return geo.positions.data[block_i, 0] + geo.glyph_positions.data[glyph_i, 0]
+        return geo.positions.data[block_i, 0] + geo.glyph_data.data["pos"][glyph_i, 0]
 
     def ypos(geo, block_i, glyph_i):
-        return geo.positions.data[block_i, 1] + geo.glyph_positions.data[glyph_i, 1]
+        return geo.positions.data[block_i, 1] + geo.glyph_data.data["pos"][glyph_i, 1]
 
     # Setting text to list of text, to make sure to use a single block.
     geometry_left = TextGeometry(
@@ -490,10 +490,10 @@ def test_geometry_text_align_2():
     text = ref_text
 
     def xpos(geo, block_i, glyph_i):
-        return geo.positions.data[block_i, 0] + geo.glyph_positions.data[glyph_i, 0]
+        return geo.positions.data[block_i, 0] + geo.glyph_data.data["pos"][glyph_i, 0]
 
     def ypos(geo, block_i, glyph_i):
-        return geo.positions.data[block_i, 1] + geo.glyph_positions.data[glyph_i, 1]
+        return geo.positions.data[block_i, 1] + geo.glyph_data.data["pos"][glyph_i, 1]
 
     # Setting text to list of text, to make sure to use a single block.
     geometry_left = TextGeometry(
@@ -583,7 +583,7 @@ def test_geometry_text_with_new_lines():
     )
 
     def ypos(geo, block_i, glyph_i):
-        return geo.positions.data[block_i, 1] + geo.glyph_positions.data[glyph_i, 1]
+        return geo.positions.data[block_i, 1] + geo.glyph_data.data["pos"][glyph_i, 1]
 
     assert ypos(geo1, 0, 0) == ypos(geo2, 0, 0)
     assert ypos(geo1, 0, 9) > ypos(geo2, 0, 9)
@@ -607,14 +607,14 @@ def test_alignment_with_spaces():
     i1 = 0
     i2 = 10
     i3 = 20
-    assert geo.glyph_positions.data[i1, 0] < geo.glyph_positions.data[i2, 0]
-    assert geo.glyph_positions.data[i1, 0] == geo.glyph_positions.data[i3, 0]
+    assert geo.glyph_data.data["pos"][i1, 0] < geo.glyph_data.data["pos"][i2, 0]
+    assert geo.glyph_data.data["pos"][i1, 0] == geo.glyph_data.data["pos"][i3, 0]
 
     geo.text_align = "right"
     geo._on_update_object()
 
-    assert geo.glyph_positions.data[i1, 0] > geo.glyph_positions.data[i3, 0]
-    assert geo.glyph_positions.data[i1, 0] == geo.glyph_positions.data[i2, 0]
+    assert geo.glyph_data.data["pos"][i1, 0] > geo.glyph_data.data["pos"][i3, 0]
+    assert geo.glyph_data.data["pos"][i1, 0] == geo.glyph_data.data["pos"][i2, 0]
 
 
 def test_geometry_text_align_last():
@@ -644,21 +644,21 @@ def test_geometry_text_align_last():
     )
     i = geometry_default._glyph_count - 1
     assert (
-        geometry_default.glyph_positions.data[i, 0]
-        == geometry_left.glyph_positions.data[i, 0]
+        geometry_default.glyph_data.data["pos"][i, 0]
+        == geometry_left.glyph_data.data["pos"][i, 0]
     )
     assert (
-        geometry_left.glyph_positions.data[i, 0]
-        < geometry_center.glyph_positions.data[i, 0]
+        geometry_left.glyph_data.data["pos"][i, 0]
+        < geometry_center.glyph_data.data["pos"][i, 0]
     )
     assert (
-        geometry_center.glyph_positions.data[i, 0]
-        < geometry_right.glyph_positions.data[i, 0]
+        geometry_center.glyph_data.data["pos"][i, 0]
+        < geometry_right.glyph_data.data["pos"][i, 0]
     )
     # unless you specify justify-all
     assert (
-        geometry_right.glyph_positions.data[i, 0]
-        == geometry_justify.glyph_positions.data[i, 0]
+        geometry_right.glyph_data.data["pos"][i, 0]
+        == geometry_justify.glyph_data.data["pos"][i, 0]
     )
 
 
@@ -668,12 +668,12 @@ def test_text_geometry_leading_spaces():
     with_3whitespace = TextGeometry([" \n   hello"], anchor="top-left")
     # The spaces should not be stripped at the front
     assert (
-        basic_text.glyph_positions.data[0, 0]
-        < with_1whitespace.glyph_positions.data[0, 0]
+        basic_text.glyph_data.data["pos"][0, 0]
+        < with_1whitespace.glyph_data.data["pos"][0, 0]
     )
     assert (
-        with_1whitespace.glyph_positions.data[0, 0]
-        < with_3whitespace.glyph_positions.data[0, 0]
+        with_1whitespace.glyph_data.data["pos"][0, 0]
+        < with_3whitespace.glyph_data.data["pos"][0, 0]
     )
 
 


### PR DESCRIPTION
This PR changes the text geometry to use a single buffer for per-glyph data, instead of 4 separate buffers. This makes the code cleaner, and easier to add more data if we want later. It's also faster on the CPU side, because only one call to `.update_indices()` instead of 4. And possibly faster on the GPU (could not measure that effect though).

