### PR TITLE
Reset shader state when update bindings

### DIFF
--- a/pygfx/renderers/wgpu/engine/pipeline.py
+++ b/pygfx/renderers/wgpu/engine/pipeline.py
@@ -358,6 +358,7 @@ class PipelineContainer:
         if "bindings" in changed:
             self.shader.unlock_hash()
             with tracker.track_usage("!bindings"):
+                self.shader.__init__(wobject)
                 self.bindings_dicts = self.shader.get_bindings(wobject, self.shared)
             self.shader.lock_hash()
             self._check_bindings()

--- a/pygfx/renderers/wgpu/shader/base.py
+++ b/pygfx/renderers/wgpu/shader/base.py
@@ -95,11 +95,11 @@ class BaseShader(ShaderInterface):
     type = "render"  # must be "compute" or "render"
     needs_bake_function = False
 
-    def __init__(self, wobject, **kwargs):
+    def __init__(self, wobject):
         super().__init__()
 
         # The shader kwargs
-        self.kwargs = kwargs
+        self.kwargs = {}
 
         # The stored hash. If set, the hash is locked, and kwargs cannot
         # be set. This is to prevent the shader implementations setting

--- a/tests/renderers/test_shader_composer.py
+++ b/tests/renderers/test_shader_composer.py
@@ -28,11 +28,12 @@ def test_templating():
             """
 
     # Missing variables
-    shader = MyShader(foo=True)
+    shader = MyShader()
     with raises(ValueError):
         shader.generate_wgsl()
 
     # Fill in value
+    shader["foo"] = True
     shader["bar"] = 42
     assert shader["bar"] == 42
     assert shader.generate_wgsl().strip() == "x = 42"
@@ -50,7 +51,8 @@ def test_templating():
             {$ if foo $} 1 {$ else $} 2 {$ endif $}
             """
 
-    shader = MyShader(foo=True)
+    shader = MyShader()
+    shader["foo"] = True
     assert shader.generate_wgsl().strip() == "1"
     assert shader.generate_wgsl(foo=False).strip() == "2"
 
@@ -63,8 +65,9 @@ def test_logic_beyond_templating():
             else:
                 return "x = {{bar}}"
 
-    shader = MyShader(foo=False, bar=24)
-
+    shader = MyShader()
+    shader["foo"] = False
+    shader["bar"] = 24
     assert shader.generate_wgsl().strip() == "x = 24"
     shader["foo"] = True
     assert shader.generate_wgsl().strip() == "x = 25"


### PR DESCRIPTION
Fix #1005 

This seems to be the simplest way to fix it.

It seems that there is no situation where `kwargs` are passed in the initialization of the shader in our actual code. In order to keep the `kwargs` state consistent, I deleted it in the initialization.