### PR TITLE
Fix TransformGizmo.set_object when object is `None`

### DIFF
--- a/pygfx/helpers/_gizmo.py
+++ b/pygfx/helpers/_gizmo.py
@@ -88,7 +88,7 @@ class TransformGizmo(WorldObject):
 
         """
 
-        if not isinstance(object, (WorldObject, None)):
+        if not isinstance(object, (WorldObject, type(None))):
             raise ValueError("The object must be None or a WorldObject instance.")
 
         self._object_to_control = object

--- a/pygfx/helpers/_gizmo.py
+++ b/pygfx/helpers/_gizmo.py
@@ -22,6 +22,8 @@ BLUE = "#007eb7"
 
 THICKNESS = 3
 
+NoneType = type(None)
+
 
 class TransformGizmo(WorldObject):
     """Gizmo to manipulate a WorldObject.
@@ -88,7 +90,7 @@ class TransformGizmo(WorldObject):
 
         """
 
-        if not isinstance(object, (WorldObject, type(None))):
+        if not isinstance(object, (WorldObject, NoneType)):
             raise ValueError("The object must be None or a WorldObject instance.")
 
         self._object_to_control = object


### PR DESCRIPTION
This is a tiny fix to allow instantiating `gfx.TransformGizmo` without immediately associating a world object.

The issue was a `isinstance(object, (WorldObject, None))` call that failed because `None` is not a type.