### PR TITLE
Improve clipping planes

### DIFF
--- a/docs/advanced_shaders.rst
+++ b/docs/advanced_shaders.rst
@@ -263,10 +263,9 @@ to unpack the picking info. See e.g. the picking of a mesh:
 Clipping planes
 ---------------
 
-For common features that apply to all/most objects, wgsl convenience functions
-are available. Take clipping planes. One can call ``apply_clipping_planes()`` to
-discard the fragment if it's outside of the clipping planes. Or use
-``check_clipping_planes()`` to get a boolean.
+For common features that apply to all/most objects, wgsl convenience shader chunks are provided.
+included in the shader code using the ``include`` directive. For example, to use clipping planes,
+you can include the wgsl code for clipping planes in your shader like this:
 
 .. code-block:: python
 
@@ -278,7 +277,9 @@ discard the fragment if it's outside of the clipping planes. Or use
             fn fs_main(varyings: Varyings) -> FragmentOutput {
                 ...
 
-                apply_clipping_planes(varyings.world_pos);
+                // clipping planes
+                {$ include 'pygfx.clipping_planes.wgsl' $}
+
                 var out = get_fragment_output(varyings.position, color);
                 ...
                 return out;

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -430,6 +430,7 @@ class ThinLineShader(LineShader):
 
         @fragment
         fn fs_main(varyings: Varyings) -> FragmentOutput {
+            {$ include 'pygfx.clipping_planes.wgsl' $}
 
             $$ if color_mode == 'vertex'
                 let color = varyings.color;
@@ -443,7 +444,6 @@ class ThinLineShader(LineShader):
             let opacity = color.a * u_material.opacity;
             let out_color = vec4<f32>(physical_color, opacity);
 
-            apply_clipping_planes(varyings.world_pos);
             return get_fragment_output(varyings.position, out_color);
         }
         """

--- a/pygfx/renderers/wgpu/wgsl/clipping_planes.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/clipping_planes.wgsl
@@ -1,0 +1,23 @@
+// ----- Clipping planes
+$$ if n_clipping_planes
+    $$ if clipping_mode == 'ANY'
+        for (var i=0; i<{{ n_clipping_planes }}; i=i+1) {
+            let plane = u_material.clipping_planes[i];
+            if (dot(varyings.world_pos, plane.xyz) < plane.w) {
+                discard;
+            } 
+        }
+    $$ else
+        var clipped: bool = true;
+        for (var i=0; i<{{ n_clipping_planes }}; i=i+1) {
+            let plane = u_material.clipping_planes[i];
+            if (dot(varyings.world_pos, plane.xyz) > plane.w) {
+                clipped = false;
+                break;  //at least one plane is outside, so we can keep the fragment
+            }
+        }
+        if (clipped) {
+            discard;
+        }
+    $$ endif
+$$ endif

--- a/pygfx/renderers/wgpu/wgsl/image.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/image.wgsl
@@ -37,6 +37,9 @@ fn vs_main(in: VertexInput) -> Varyings {
 
 @fragment
 fn fs_main(varyings: Varyings) -> FragmentOutput {
+    // clipping planes
+    {$ include 'pygfx.clipping_planes.wgsl' $}
+
     let sizef = vec2<f32>(textureDimensions(t_img));
     let value = sample_im(varyings.texcoord.xy, sizef);
     let color = sampled_value_to_color(value);
@@ -50,8 +53,6 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
     let opacity = color.a * u_material.opacity;
     let out_color = vec4<f32>(physical_color, opacity);
 
-    // Wrap up
-    apply_clipping_planes(varyings.world_pos);
     var out = get_fragment_output(varyings.position, out_color);
 
     $$ if write_pick

--- a/pygfx/renderers/wgpu/wgsl/line.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/line.wgsl
@@ -603,6 +603,9 @@ $$ endif
 @fragment
 fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> FragmentOutput {
 
+    // clipping planes
+    {$ include 'pygfx.clipping_planes.wgsl' $}
+    
     // Get the half-thickness in physical coordinates. This is the reference thickness.
     // If aa is used, the line is actually a bit thicker, leaving space to do aa.
     let half_thickness_p = 0.5 * varyings.thickness_pw / varyings.w;
@@ -837,8 +840,6 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
     let opacity = min(1.0, color.a) * alpha * u_material.opacity;
     let out_color = vec4<f32>(physical_color, opacity);
 
-    // Wrap up
-    apply_clipping_planes(varyings.world_pos);
     var out = get_fragment_output(varyings.position, out_color);
 
     // Set picking info.

--- a/pygfx/renderers/wgpu/wgsl/mesh.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/mesh.wgsl
@@ -320,6 +320,8 @@ struct ReflectedLight {
 
 @fragment
 fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> FragmentOutput {
+    // clipping planes
+    {$ include 'pygfx.clipping_planes.wgsl' $}
 
     // Get the surface normal from the geometry.
     // This is the unflipped normal, because thet NormalMaterial needs that.
@@ -566,9 +568,6 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
 
     let out_color = vec4<f32>(physical_color, diffuse_color.a);
 
-    // Wrap up
-
-    apply_clipping_planes(varyings.world_pos);
     var out = get_fragment_output(varyings.position, out_color);
 
     $$ if write_pick

--- a/pygfx/renderers/wgpu/wgsl/mesh_normal_lines.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/mesh_normal_lines.wgsl
@@ -53,6 +53,9 @@ fn vs_main(in: VertexInput) -> Varyings {
 @fragment
 fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> FragmentOutput {
 
+    // clipping planes
+    {$ include 'pygfx.clipping_planes.wgsl' $}
+
     let color_value = u_material.color;
     let albeido = color_value.rgb;
 
@@ -68,8 +71,6 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
     let out_color = vec4<f32>(physical_color, opacity);
 
     // Wrap up
-
-    apply_clipping_planes(varyings.world_pos);
     var out = get_fragment_output(varyings.position, out_color);
 
     $$ if write_pick

--- a/pygfx/renderers/wgpu/wgsl/mesh_slice.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/mesh_slice.wgsl
@@ -201,6 +201,9 @@ fn vs_main(in: VertexInput) -> Varyings {
 
 @fragment
 fn fs_main(varyings: Varyings) -> FragmentOutput {
+    // clipping planes
+    {$ include 'pygfx.clipping_planes.wgsl' $}
+
     // Discart fragments that are too far from the centerline. This makes round caps.
     // Note that we operate in physical pixels here.
     let distx = max(0.0, abs(varyings.dist2center.x) - 0.5 * varyings.segment_length);
@@ -228,8 +231,6 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
     let opacity = min(1.0, color_value.a) * alpha;
     let out_color = vec4<f32>(physical_color, opacity);
 
-    // Wrap up
-    apply_clipping_planes(varyings.world_pos);
     var out = get_fragment_output(varyings.position, out_color);
     $$ if write_pick
     // The wobject-id must be 20 bits. In total it must not exceed 64 bits.

--- a/pygfx/renderers/wgpu/wgsl/points.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/points.wgsl
@@ -218,6 +218,9 @@ fn vs_main(in: VertexInput) -> Varyings {
 @fragment
 fn fs_main(varyings: Varyings) -> FragmentOutput {
 
+    // clipping planes
+    {$ include 'pygfx.clipping_planes.wgsl' $}
+
     let l2p:f32 = u_stdinfo.physical_size.x / u_stdinfo.logical_size.x;
 
     let half_size_p: f32 = 0.5 * varyings.size_p;
@@ -349,8 +352,6 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
         let out_color = vec4<f32>(srgb2physical(the_color.rgb), the_color.a * u_material.opacity);
     $$ endif
 
-    // Wrap up
-    apply_clipping_planes(varyings.world_pos);
     var out = get_fragment_output(varyings.position, out_color);
 
     $$ if write_pick

--- a/pygfx/renderers/wgpu/wgsl/std.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/std.wgsl
@@ -117,40 +117,6 @@ fn srgb2physical(color: vec3<f32>) -> vec3<f32> {
 }
 
 
-// ----- Clipping planes
-// Use SDF for clipping planes
-// Negative means inside the volume, 0 is on the surface, positive is outside.
-$$ if not n_clipping_planes
-    fn check_clipping_planes(world_pos: vec3<f32>) -> f32 { return -0.5; }
-    fn apply_clipping_planes(world_pos: vec3<f32>) { }
-$$ else
-    fn check_clipping_planes(world_pos: vec3<f32>) -> f32 {
-        // var clipped: bool = {{ 'false' if clipping_mode == 'ANY' else 'true' }};
-        $$ if clipping_mode == 'ANY'
-        // float max
-        // https://github.com/gpuweb/gpuweb/issues/3431#issuecomment-1252519246
-        var clip : f32 = 3.40282e+38;
-        for (var i=0; i<{{ n_clipping_planes }}; i=i+1) {
-            let plane = u_material.clipping_planes[i];
-            clip = min(clip, dot(vec4(world_pos, -1.), plane));
-        }
-        $$ else
-        var clip : f32 = -3.40282e+38;
-        for (var i=0; i<{{ n_clipping_planes }}; i=i+1) {
-            let plane = u_material.clipping_planes[i];
-            clip = max(clip, dot(vec4(world_pos, -1.), plane));
-        }
-        $$ endif
-        // Use SDF convention
-        // Negative means inside the volume, 0 is on the surface, positive is outside.
-        return -clip;
-    }
-    fn apply_clipping_planes(world_pos: vec3<f32>) {
-        if (check_clipping_planes(world_pos) > 0) { discard; }
-    }
-$$ endif
-
-
 // ----- Picking
 
 var<private> p_pick_bits_used : i32 = 0;

--- a/pygfx/renderers/wgpu/wgsl/text.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/text.wgsl
@@ -175,6 +175,9 @@ fn vs_main(in: VertexInput) -> Varyings {
 @fragment
 fn fs_main(varyings: Varyings) -> FragmentOutput {
 
+    // clipping planes
+    {$ include 'pygfx.clipping_planes.wgsl' $}
+
     let l2p:f32 = u_stdinfo.physical_size.x / u_stdinfo.logical_size.x;
 
     let bitmap_rect = vec4<f32>(varyings.bitmap_rect);
@@ -295,8 +298,6 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
     // Debug
     //color_out = vec4<f32>(atlas_value, 0.0, 0.0, 1.0);
 
-    // Wrap up
-    apply_clipping_planes(varyings.world_pos);
     var out = get_fragment_output(varyings.position, color_out);
 
     // Move text closer to camera, since its often overlaid on something.

--- a/pygfx/renderers/wgpu/wgsl/volume_ray.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/volume_ray.wgsl
@@ -66,6 +66,9 @@ fn vs_main(in: VertexInput) -> Varyings {
 @fragment
 fn fs_main(varyings: Varyings) -> FragmentOutput {
 
+    // clipping planes
+    {$ include 'pygfx.clipping_planes.wgsl' $}
+
     // Get size of the volume
     let sizef = vec3<f32>(textureDimensions(t_img));
 
@@ -115,7 +118,6 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
     let ndc_pos = u_stdinfo.projection_transform * u_stdinfo.cam_transform * world_pos;
 
     // Maybe we did the work for nothing
-    apply_clipping_planes(world_pos.xyz);
 
     // Get fragment output. Note that the depth arg only affects the
     // blending - setting the depth attribute actually sets the fragment depth.

--- a/pygfx/renderers/wgpu/wgsl/volume_slice.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/volume_slice.wgsl
@@ -166,6 +166,10 @@ fn vs_main(in: VertexInput) -> Varyings {
 
 @fragment
 fn fs_main(varyings: Varyings) -> FragmentOutput {
+
+    // clipping planes
+    {$ include 'pygfx.clipping_planes.wgsl' $}
+
     let sizef = vec3<f32>(textureDimensions(t_img));
     let value = sample_vol(varyings.texcoord.xyz, sizef);
     let color = sampled_value_to_color(value);
@@ -179,8 +183,7 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
     let opacity = color.a * u_material.opacity;
     let out_color = vec4<f32>(physical_color, opacity);
 
-    // Wrap up
-    apply_clipping_planes(varyings.world_pos);
+
     var out = get_fragment_output(varyings.position, out_color);
 
     $$ if write_pick


### PR DESCRIPTION
This PR optimized Clipping Planes-related Code, while reviewing the use of `discard` in the shader, I identified several opportunities to optimize Clipping Planes:

- Modularized the code using our macro mechanism, eliminating the need for placeholder functions when Clipping Planes are not present.
- Simplified the logic with early exits, breaking the loop as soon as conditions are met instead of checking all planes.
- Prioritize clipping plane verification in fragment shaders to bypass shading calculations for discarded fragments.

