### PR TITLE
Rename internal define_colormap() func for clarity

### DIFF
--- a/pygfx/renderers/wgpu/shader/base.py
+++ b/pygfx/renderers/wgpu/shader/base.py
@@ -246,11 +246,14 @@ class BaseShader(ShaderInterface):
 
     # ----- Colormap stuff
 
-    def define_colormap(self, map, texcoords):
+    def define_generic_colormap(self, map, texcoords):
         """Define the given texture as the colormap to be used to
-        lookup the final color from the (per-vertex or per-face) texcoords.
-        In the WGSL the colormap can be sampled using ``sample_colormap()``.
+        lookup the final color from the (per-vertex or per-face) texcoords. In
+        the WGSL the colormap can be sampled using ``sample_colormap()``.
         Returns a list of bindings.
+
+        For colormaps in mesh, line, points. Supports 1D/2D/3D
+        textures, different texture formats.
         """
 
         filter_mode = f"{map.mag_filter}, {map.min_filter}, {map.mipmap_filter}"

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -204,7 +204,9 @@ class LineShader(BaseShader):
             bindings.append(
                 Binding("s_texcoords", rbuffer, geometry.texcoords, "VERTEX")
             )
-            bindings.extend(self.define_colormap(material.map, geometry.texcoords))
+            bindings.extend(
+                self.define_generic_colormap(material.map, geometry.texcoords)
+            )
 
         # Need a buffer for the cumdist?
         if hasattr(self, "line_distance_buffer"):
@@ -334,7 +336,9 @@ class ThinLineShader(LineShader):
             bindings.append(
                 Binding("s_texcoords", rbuffer, geometry.texcoords, "VERTEX")
             )
-            bindings.extend(self.define_colormap(material.map, geometry.texcoords))
+            bindings.extend(
+                self.define_generic_colormap(material.map, geometry.texcoords)
+            )
 
         bindings = {i: b for i, b in enumerate(bindings)}
         self.define_bindings(0, bindings)

--- a/pygfx/renderers/wgpu/shaders/meshshader.py
+++ b/pygfx/renderers/wgpu/shaders/meshshader.py
@@ -180,9 +180,11 @@ class MeshShader(BaseShader):
             )
 
             if not is_standard_map:
-                # It's a colormap
+                # It's a 'generic' colormap
                 self["use_colormap"] = True
-                bindings.extend(self.define_colormap(material.map, geometry.texcoords))
+                bindings.extend(
+                    self.define_generic_colormap(material.map, geometry.texcoords)
+                )
                 if 0 not in self["used_uv"]:
                     texcoords = getattr(geometry, "texcoords", None)
                     bindings.append(
@@ -193,6 +195,7 @@ class MeshShader(BaseShader):
                     else:
                         self["used_uv"][0] = texcoords.data.shape[-1]
             else:
+                # It's a classic mesh map
                 bindings.extend(self._define_texture_map(geometry, material.map, "map"))
 
             self["colorspace"] = material.map.texture.colorspace
@@ -797,7 +800,9 @@ class MeshSliceShader(BaseShader):
         if self["color_mode"] in ("vertex", "face"):
             bindings.append(Binding("s_colors", rbuffer, geometry.colors, "VERTEX"))
         elif self["color_mode"] in ("vertex_map", "face_map"):
-            bindings.extend(self.define_colormap(material.map, geometry.texcoords))
+            bindings.extend(
+                self.define_generic_colormap(material.map, geometry.texcoords)
+            )
 
         # Let the shader generate code for our bindings
         bindings = {i: binding for i, binding in enumerate(bindings)}

--- a/pygfx/renderers/wgpu/shaders/pointsshader.py
+++ b/pygfx/renderers/wgpu/shaders/pointsshader.py
@@ -114,7 +114,9 @@ class PointsShader(BaseShader):
             bindings.append(
                 Binding("s_texcoords", rbuffer, geometry.texcoords, "VERTEX")
             )
-            bindings.extend(self.define_colormap(material.map, geometry.texcoords))
+            bindings.extend(
+                self.define_generic_colormap(material.map, geometry.texcoords)
+            )
 
         if self["edge_color_mode"] == "vertex":
             bindings.append(

--- a/pygfx/renderers/wgpu/wgsl/mesh.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/mesh.wgsl
@@ -216,7 +216,7 @@ fn vs_main(in: VertexInput) -> Varyings {
     let tex_coord_index = i0;
     $$ endif
 
- 
+
     // used_uv
     $$ for uv, ndim in used_uv.items()
     $$ if ndim == 1
@@ -352,7 +352,7 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
         $$ if color_mode != 'uniform'
             $$ if use_map
                 $$ if use_colormap is defined
-                    // special case for colormap
+                    // special case for 'generic' colormap
                     var diffuse_map = sample_colormap(varyings.texcoord);
                 $$ else
                     var diffuse_map = textureSample(t_map, s_map, varyings.texcoord{{map_uv or ''}});
@@ -361,10 +361,10 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
                 $$ if colorspace == 'srgb'
                     diffuse_map = vec4f(srgb2physical(diffuse_map.rgb), diffuse_map.a);
                 $$ endif
-        
+
                 $$ if color_mode == 'vertex_map' or color_mode == 'face_map'
                     diffuse_color = diffuse_map;
-                $$ else  
+                $$ else
                     // default mode
                     diffuse_color *= diffuse_map;
                 $$ endif
@@ -381,7 +381,7 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
             $$ endif
 
         // uniform
-        $$ endif 
+        $$ endif
 
 
     $$ endif


### PR DESCRIPTION
Little naming tweak makes the special colormap support a bit more explicit, to (I hope) make the triage in the mesh shader more clear.

Ref #1008