### PR TITLE
Add Anisotropy support

### DIFF
--- a/examples/feature_demo/anisotropy_barn_lamp.py
+++ b/examples/feature_demo/anisotropy_barn_lamp.py
@@ -34,7 +34,7 @@ env_tex = gfx.Texture(
 
 gltf_path = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AnisotropyBarnLamp/glTF-Binary/AnisotropyBarnLamp.glb"
 
-gltf = gfx.load_gltf(gltf_path)
+gltf = gfx.load_gltf(gltf_path, quiet=True)
 
 # gfx.print_scene_graph(gltf.scene)  # Uncomment to see the tree structure
 scene.add(gltf.scene)

--- a/examples/feature_demo/anisotropy_barn_lamp.py
+++ b/examples/feature_demo/anisotropy_barn_lamp.py
@@ -1,0 +1,66 @@
+"""
+Anisotropy Barn Lamp
+====================
+
+This example demonstrates the anisotropy effect in a glTF model.
+The visually distinct feature is the elongated appearance of the specular reflection.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+import imageio.v3 as iio
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+
+# Init
+canvas = WgpuCanvas(size=(1280, 720), title="Anisotropy")
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+directional_light = gfx.DirectionalLight(intensity=2.5)
+directional_light.local.position = (0.5, 0, 0.866)
+scene.add(directional_light)
+
+# Read cube image and turn it into a 3D image (a 4d array)
+env_img = iio.imread("imageio:meadow_cube.jpg")
+cube_size = env_img.shape[1]
+env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+
+# Create environment map
+env_tex = gfx.Texture(
+    env_img, dim=2, size=(cube_size, cube_size, 6), generate_mipmaps=True
+)
+
+gltf_path = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/AnisotropyBarnLamp/glTF-Binary/AnisotropyBarnLamp.glb"
+
+gltf = gfx.load_gltf(gltf_path)
+
+# gfx.print_scene_graph(gltf.scene)  # Uncomment to see the tree structure
+scene.add(gltf.scene)
+
+
+def add_env_map(obj):
+    if isinstance(obj, gfx.Mesh) and isinstance(obj.material, gfx.MeshStandardMaterial):
+        obj.material.env_map = env_tex
+        obj.material.env_map_intensity = 0.5
+
+
+gltf.scene.traverse(add_env_map)
+
+scene.add(gfx.AmbientLight(intensity=0.1))
+
+# Create camera and controller
+camera = gfx.PerspectiveCamera(45, 640 / 480)
+camera.show_object(gltf.scene, view_dir=(1.8, -0.6, -2.7))
+controller = gfx.OrbitController(camera, register_events=renderer)
+
+
+def animate():
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    renderer.request_draw(animate)
+    run()

--- a/examples/feature_demo/gltf_unlit.py
+++ b/examples/feature_demo/gltf_unlit.py
@@ -84,7 +84,7 @@ scene.add(pbr_model)
 gui_renderer = ImguiRenderer(renderer.device, canvas)
 
 
-state = {"direct_light": True, "ambient_light": True, "ibl": True}
+state = {"ibl": True}
 
 
 def draw_imgui():
@@ -99,20 +99,16 @@ def draw_imgui():
         flags=imgui.WindowFlags_.no_move | imgui.WindowFlags_.no_resize,
     )
     if is_expand:
-        checked, state["direct_light"] = imgui.checkbox(
-            "Direct Lightt", state["direct_light"]
+        _, direct_light.visible = imgui.checkbox(
+            "Directional Light", direct_light.visible
         )
-        if checked:
-            direct_light.visible = state["direct_light"]
 
-        checked, state["ambient_light"] = imgui.checkbox(
-            "Ambient Lightt", state["ambient_light"]
+        _, ambient_light.visible = imgui.checkbox(
+            "Ambient Light", ambient_light.visible
         )
-        if checked:
-            ambient_light.visible = state["ambient_light"]
 
-        checked, state["ibl"] = imgui.checkbox("IBL", state["ibl"])
-        if checked:
+        changed, state["ibl"] = imgui.checkbox("IBL", state["ibl"])
+        if changed:
             if state["ibl"]:
                 pbr_model.traverse(lambda obj: add_env_map(obj, env_tex))
             else:

--- a/pygfx/renderers/wgpu/shaders/meshshader.py
+++ b/pygfx/renderers/wgpu/shaders/meshshader.py
@@ -695,6 +695,18 @@ class MeshPhysicalShader(MeshStandardShader):
                 )
                 self["use_iridescence_thickness_map"] = True
 
+        # anisotropy
+        if material.anisotropy:
+            self["USE_ANISOTROPY"] = True
+
+            if material.anisotropy_map is not None:
+                bindings.extend(
+                    self._define_texture_map(
+                        geometry, material.anisotropy_map, "anisotropy_map"
+                    )
+                )
+                self["use_anisotropy_map"] = True
+
         # Define shader code for binding
         bindings = {i: binding for i, binding in enumerate(bindings)}
         self.define_bindings(3, bindings)

--- a/pygfx/utils/load_gltf.py
+++ b/pygfx/utils/load_gltf.py
@@ -192,6 +192,7 @@ class _GLTF:
         self._register_plugin(GLTFMaterialsClearcoatExtension)
         self._register_plugin(GLTFMaterialsIridescenceExtension)
         self._register_plugin(GLTFMaterialsEmissiveStrengthExtension)
+        self._register_plugin(GLTFMaterialsAnisotropyExtension)
         self._register_plugin(GLTFMaterialsUnlitExtension)
         self._register_plugin(GLTFLightsExtension)
 
@@ -1243,6 +1244,31 @@ class GLTFMaterialsIridescenceExtension(GLTFBaseMaterialsExtension):
             material.iridescence_thickness_map = self._load_texture(
                 iridescence_thickness_texture
             )
+
+
+class GLTFMaterialsAnisotropyExtension(GLTFBaseMaterialsExtension):
+    EXTENSION_NAME = "KHR_materials_anisotropy"
+
+    def extend_material(self, material_def, material):
+        if (
+            not material_def.extensions
+            or self.EXTENSION_NAME not in material_def.extensions
+        ):
+            return
+
+        extension = material_def.extensions[self.EXTENSION_NAME]
+
+        anisotropy_factor = extension.get("anisotropyStrength", None)
+        if anisotropy_factor is not None:
+            material.anisotropy = anisotropy_factor
+
+        anisotropy_rotation = extension.get("anisotropyRotation", None)
+        if anisotropy_rotation is not None:
+            material.anisotropy_rotation = anisotropy_rotation
+
+        anisotropy_texture = extension.get("anisotropyTexture", None)
+        if anisotropy_texture is not None:
+            material.anisotropy_map = self._load_texture(anisotropy_texture)
 
 
 class GLTFMaterialsEmissiveStrengthExtension(GLTFBaseMaterialsExtension):


### PR DESCRIPTION
This PR introduces support for anisotropy in MeshPhysicalMaterial.

It's an ability to represent the anisotropic property of materials as observable with brushed metals.
An asymmetric specular lobe model is introduced to allow for such phenomena. The visually distinct feature of that lobe is the elongated appearance of the specular reflection.

As show in the example (`anisotropy_barn_lamp.py`):
![image](https://github.com/user-attachments/assets/ac9fd1e4-ddf5-44af-9a5a-ef3c5b7286bb)

Related glTF extension: [KHR_materials_anisotropy](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_anisotropy/README.md)

Test Case 1: [Anisotropy Disc Test](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/Models/AnisotropyDiscTest/README.md)
![image](https://github.com/user-attachments/assets/daf046fd-498a-408d-9046-4ec4c91d7c09)

Test Case 2: [Anisotropy Rotation Test](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/Models/AnisotropyRotationTest/README.md)
![image](https://github.com/user-attachments/assets/8fee7762-c0fe-420e-8bf0-eedb51c176d7)

Test Case 3: [Anisotropy Strength Test](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/Models/AnisotropyStrengthTest/README.md)
![image](https://github.com/user-attachments/assets/bacfb438-6403-4bbd-bde1-eb112abbae66)

