### PR TITLE
Add Sheen support

### DIFF
--- a/examples/feature_demo/picking_points.py
+++ b/examples/feature_demo/picking_points.py
@@ -33,7 +33,7 @@ camera = gfx.OrthographicCamera(120, 120)
 def offset_point(event):
     info = event.pick_info
     if "vertex_index" in info:
-        i = int(round(info["vertex_index"]))
+        i = round(info["vertex_index"])
         geometry.positions.data[i, 1] *= -1
         geometry.positions.update_range(i)
         canvas.request_draw()

--- a/examples/feature_demo/sheen_chair.py
+++ b/examples/feature_demo/sheen_chair.py
@@ -1,0 +1,65 @@
+"""
+Glam Velvet Sofa
+================
+
+This example demonstrates the sheen effect in a glTF model.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+import imageio.v3 as iio
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+
+# Init
+canvas = WgpuCanvas(size=(1280, 720), title="Sheen Chair")
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+directional_light = gfx.DirectionalLight(intensity=2.5)
+directional_light.local.position = (0.5, 0, 0.866)
+scene.add(directional_light)
+
+# Read cube image and turn it into a 3D image (a 4d array)
+env_img = iio.imread("imageio:meadow_cube.jpg")
+cube_size = env_img.shape[1]
+env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+
+# Create environment map
+env_tex = gfx.Texture(
+    env_img, dim=2, size=(cube_size, cube_size, 6), generate_mipmaps=True
+)
+
+gltf_path = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/SheenChair/glTF-Binary/SheenChair.glb"
+
+gltf = gfx.load_gltf(gltf_path, quiet=True)
+
+# gfx.print_scene_graph(gltf.scene)  # Uncomment to see the tree structure
+scene.add(gltf.scene)
+
+
+def add_env_map(obj):
+    if isinstance(obj, gfx.Mesh) and isinstance(obj.material, gfx.MeshStandardMaterial):
+        obj.material.env_map = env_tex
+        obj.material.env_map_intensity = 0.5
+
+
+gltf.scene.traverse(add_env_map)
+
+scene.add(gfx.AmbientLight(intensity=0.1))
+
+# Create camera and controller
+camera = gfx.PerspectiveCamera(45, 640 / 480)
+camera.show_object(gltf.scene, view_dir=(1.8, -0.6, -2.7))
+controller = gfx.OrbitController(camera, register_events=renderer)
+
+
+def animate():
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    renderer.request_draw(animate)
+    run()

--- a/examples/feature_demo/sheen_chair.py
+++ b/examples/feature_demo/sheen_chair.py
@@ -1,6 +1,6 @@
 """
-Glam Velvet Sofa
-================
+Sheen Chair
+===========
 
 This example demonstrates the sheen effect in a glTF model.
 """

--- a/examples/feature_demo/sheen_glam_velvet_sofa.py
+++ b/examples/feature_demo/sheen_glam_velvet_sofa.py
@@ -51,7 +51,7 @@ scene.add(gfx.AmbientLight(intensity=0.1))
 
 # Create camera and controller
 camera = gfx.PerspectiveCamera(45, 640 / 480)
-camera.show_object(gltf.scene, view_dir=(1.8, -0.6, -2.7))
+camera.show_object(gltf.scene, view_dir=(0, -0.6, -2.7))
 controller = gfx.OrbitController(camera, register_events=renderer)
 
 

--- a/examples/feature_demo/sheen_glam_velvet_sofa.py
+++ b/examples/feature_demo/sheen_glam_velvet_sofa.py
@@ -1,0 +1,65 @@
+"""
+Glam Velvet Sofa
+================
+
+This example demonstrates the sheen effect in a glTF model.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+import imageio.v3 as iio
+from wgpu.gui.auto import WgpuCanvas, run
+import pygfx as gfx
+
+# Init
+canvas = WgpuCanvas(size=(1280, 720), title="Sheen Glam Velvet Sofa")
+renderer = gfx.renderers.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+directional_light = gfx.DirectionalLight(intensity=2.5)
+directional_light.local.position = (0.5, 0, 0.866)
+scene.add(directional_light)
+
+# Read cube image and turn it into a 3D image (a 4d array)
+env_img = iio.imread("imageio:meadow_cube.jpg")
+cube_size = env_img.shape[1]
+env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+
+# Create environment map
+env_tex = gfx.Texture(
+    env_img, dim=2, size=(cube_size, cube_size, 6), generate_mipmaps=True
+)
+
+gltf_path = "https://raw.githubusercontent.com/KhronosGroup/glTF-Sample-Assets/main/Models/GlamVelvetSofa/glTF-Binary/GlamVelvetSofa.glb"
+
+gltf = gfx.load_gltf(gltf_path, quiet=True)
+
+# gfx.print_scene_graph(gltf.scene)  # Uncomment to see the tree structure
+scene.add(gltf.scene)
+
+
+def add_env_map(obj):
+    if isinstance(obj, gfx.Mesh) and isinstance(obj.material, gfx.MeshStandardMaterial):
+        obj.material.env_map = env_tex
+        obj.material.env_map_intensity = 0.5
+
+
+gltf.scene.traverse(add_env_map)
+
+scene.add(gfx.AmbientLight(intensity=0.1))
+
+# Create camera and controller
+camera = gfx.PerspectiveCamera(45, 640 / 480)
+camera.show_object(gltf.scene, view_dir=(1.8, -0.6, -2.7))
+controller = gfx.OrbitController(camera, register_events=renderer)
+
+
+def animate():
+    renderer.render(scene, camera)
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    renderer.request_draw(animate)
+    run()

--- a/examples/other/integration_pytorch.py
+++ b/examples/other/integration_pytorch.py
@@ -526,7 +526,7 @@ class SceneHandler:
     @staticmethod
     def _animate():
         try:
-            mesh_data = cast(MeshData, SceneHandler._in_queue.get_nowait())
+            mesh_data = cast("MeshData", SceneHandler._in_queue.get_nowait())
 
             # if that's the first mesh-data message, create meshes
             if SceneHandler._scene_state.first_data:

--- a/pygfx/materials/_mesh.py
+++ b/pygfx/materials/_mesh.py
@@ -1075,6 +1075,8 @@ class MeshPhysicalMaterial(MeshStandardMaterial):
 
     - **Anisotropy:** Ability to represent the anisotropic property of materials as observable with brushed metals.
 
+    - **Sheen:** A soft, satin-like sheen on the surface, simulating the effect of a thin layer of fabric or a soft coating.
+
 
     Parameters
     ----------
@@ -1105,6 +1107,15 @@ class MeshPhysicalMaterial(MeshStandardMaterial):
     anisotropy_rotation : float
         The rotation of the anisotropy in tangent, bitangent space, measured in radians counter-clockwise from the tangent.
         Default is 0.0.
+    sheen : float
+        The intensity of the sheen layer, simulating a soft, satin-like sheen on the surface.
+        Default is 0.0.
+    sheen_roughness : float
+        The roughness of the sheen layer. from 0.0 to 1.0.
+        Default is 1.0.
+    sheen_color : Color
+        The color of the sheen effect. Default is (0, 0, 0).
+
     kwargs : Any
         Additional kwargs will be passed to the :class:`base class
         <pygfx.MeshStandardMaterial>`.
@@ -1128,6 +1139,9 @@ class MeshPhysicalMaterial(MeshStandardMaterial):
         iridescence_ior="f4",
         iridescence_thickness_range="2xf4",
         anisotropy_vector="2xf4",
+        sheen="f4",
+        sheen_color="4xf4",
+        sheen_roughness="f4",
     )
 
     def __init__(
@@ -1151,6 +1165,11 @@ class MeshPhysicalMaterial(MeshStandardMaterial):
         anisotropy=0.0,
         anisotropy_map=None,
         anisotropy_rotation=0.0,
+        sheen=0.0,
+        sheen_roughness=1.0,
+        sheen_roughness_map=None,
+        sheen_color=(0, 0, 0),
+        sheen_color_map=None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -1177,6 +1196,12 @@ class MeshPhysicalMaterial(MeshStandardMaterial):
         self._anisotropy_rotation = anisotropy_rotation
         self._update_anisotropy_vector()
         self.anisotropy_map = anisotropy_map
+
+        self.sheen = sheen
+        self.sheen_roughness = sheen_roughness
+        self.sheen_roughness_map = sheen_roughness_map
+        self.sheen_color = sheen_color
+        self.sheen_color_map = sheen_color_map
 
     @property
     def ior(self):
@@ -1405,3 +1430,60 @@ class MeshPhysicalMaterial(MeshStandardMaterial):
         if isinstance(map, Texture):
             map = TextureMap(map)
         self._store.anisotropy_map = map
+
+    @property
+    def sheen(self):
+        """The intensity of the sheen layer, from 0.0 to 1.0. Default is 0.0"""
+        return float(self.uniform_buffer.data["sheen"])
+
+    @sheen.setter
+    def sheen(self, value):
+        self.uniform_buffer.data["sheen"] = value
+        self.uniform_buffer.update_full()
+
+    @property
+    def sheen_roughness(self):
+        """Roughness of the sheen layer, from 0.0 to 1.0. Default is 1.0."""
+        return float(self.uniform_buffer.data["sheen_roughness"])
+
+    @sheen_roughness.setter
+    def sheen_roughness(self, value):
+        self.uniform_buffer.data["sheen_roughness"] = value
+        self.uniform_buffer.update_full()
+
+    @property
+    def sheen_roughness_map(self):
+        """The alpha channel of this texture is multiplied against .sheenRoughness, for per-pixel control over sheen roughness.
+        Default is None."""
+        return self._store.sheen_roughness_map
+
+    @sheen_roughness_map.setter
+    def sheen_roughness_map(self, map):
+        assert_type("sheen_roughness_map", map, None, Texture, TextureMap)
+        if isinstance(map, Texture):
+            map = TextureMap(map)
+        self._store.sheen_roughness_map = map
+
+    @property
+    def sheen_color(self):
+        """The sheen tint. Default is (0, 0, 0), black."""
+        return Color(self.uniform_buffer.data["sheen_color"])
+
+    @sheen_color.setter
+    def sheen_color(self, color):
+        color = Color(color)
+        self.uniform_buffer.data["sheen_color"] = color
+        self.uniform_buffer.update_full()
+
+    @property
+    def sheen_color_map(self):
+        """The RGB channels of this texture are multiplied against .sheenColor, for per-pixel control over sheen tint.
+        Default is None."""
+        return self._store.sheen_color_map
+
+    @sheen_color_map.setter
+    def sheen_color_map(self, map):
+        assert_type("sheen_color_map", map, None, Texture, TextureMap)
+        if isinstance(map, Texture):
+            map = TextureMap(map)
+        self._store.sheen_color_map = map

--- a/pygfx/renderers/wgpu/shaders/meshshader.py
+++ b/pygfx/renderers/wgpu/shaders/meshshader.py
@@ -695,6 +695,26 @@ class MeshPhysicalShader(MeshStandardShader):
                 )
                 self["use_iridescence_thickness_map"] = True
 
+        # sheen
+        if material.sheen:
+            self["USE_SHEEN"] = True
+
+            if material.sheen_color_map is not None:
+                bindings.extend(
+                    self._define_texture_map(
+                        geometry, material.sheen_color_map, "sheen_color_map"
+                    )
+                )
+                self["use_sheen_color_map"] = True
+
+            if material.sheen_roughness_map is not None:
+                bindings.extend(
+                    self._define_texture_map(
+                        geometry, material.sheen_roughness_map, "sheen_roughness_map"
+                    )
+                )
+                self["use_sheen_roughness_map"] = True
+
         # anisotropy
         if material.anisotropy:
             self["USE_ANISOTROPY"] = True

--- a/pygfx/renderers/wgpu/wgsl/light_pbr.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/light_pbr.wgsl
@@ -27,6 +27,11 @@ struct PhysicalMaterial {
         iridescence_f0: vec3<f32>,
     $$ endif
 
+    $$ if USE_SHEEN is defined
+        sheen_color: vec3<f32>,
+        sheen_roughness: f32,
+    $$ endif
+
     $$ if USE_ANISOTROPY is defined
         anisotropy: f32,
         alpha_t: f32,
@@ -37,6 +42,8 @@ struct PhysicalMaterial {
 
 var<private> clearcoat_specular_direct: vec3f = vec3f(0.0);
 var<private> clearcoat_specular_indirect: vec3f = vec3f(0.0);
+var<private> sheen_specular_direct: vec3f = vec3f(0.0);
+var<private> sheen_specular_indirect: vec3f = vec3f(0.0);
 
 fn Schlick_to_F0( f: vec3<f32>, f90: f32, dot_vh: f32 ) -> vec3<f32> {
     let x = clamp( 1.0 - dot_vh, 0.0, 1.0 );
@@ -122,6 +129,52 @@ fn BRDF_GGX(light_dir: vec3<f32>, view_dir: vec3<f32>, normal: vec3<f32>, f0: ve
 
     return F * ( V * D );
 }
+
+$$ if USE_SHEEN is defined
+
+// https://github.com/google/filament/blob/main/shaders/src/surface_brdf.fs
+fn D_Charlie( roughness: f32, dot_nh: f32 ) -> f32 {
+    let alpha = pow2( roughness );
+
+    // Estevez and Kulla 2017, "Production Friendly Microfacet Sheen BRDF"
+    let inv_alpha = 1.0 / alpha;
+    let cos2h = dot_nh * dot_nh;
+    let sin2h = max( 1.0 - cos2h, 0.0078125 ); // 2^(-14/2), so sin2h^2 > 0 in fp16
+    return ( 2.0 + inv_alpha ) * pow( sin2h, inv_alpha * 0.5 ) / ( 2.0 * PI );
+}
+
+// https://github.com/google/filament/blob/main/shaders/src/surface_brdf.fs
+fn V_Neubelt( dot_nv: f32, dot_nl: f32 ) -> f32 {
+    // Neubelt and Pettineo 2013, "Crafting a Next-gen Material Pipeline for The Order: 1886"
+    return saturate( 1.0 / ( 4.0 * ( dot_nl + dot_nv - dot_nl * dot_nv ) ) );
+}
+
+fn BRDF_Sheen(light_dir: vec3<f32>, view_dir: vec3<f32>, normal: vec3<f32>, sheen_color: vec3<f32>, sheen_roughness: f32) -> vec3<f32> {
+    let half_dir = normalize( light_dir + view_dir );
+
+    let dot_nl = saturate( dot( normal, light_dir ) );
+    let dot_nv = saturate( dot( normal, view_dir ) );
+    let dot_nh = saturate( dot( normal, half_dir ) );
+
+    let D = D_Charlie( sheen_roughness, dot_nh );
+    let V = V_Neubelt( dot_nv, dot_nl );
+
+    return sheen_color * ( D * V );
+}
+
+// This is a curve-fit approximation to the "Charlie sheen" BRDF integrated over the hemisphere from
+// Estevez and Kulla 2017, "Production Friendly Microfacet Sheen BRDF". The analysis can be found
+// in the Sheen section of https://drive.google.com/file/d/1T0D1VSyR4AllqIJTQAraEIzjlb5h4FKH/view?usp=sharing
+fn IBLSheenBRDF(normal: vec3<f32>, view_dir: vec3<f32>, roughness: f32) -> f32 {
+    let dot_nv = saturate( dot( normal, view_dir ) );
+    let r2 = roughness * roughness;
+    let a = select( (-8.48 * r2 + 14.3 * roughness - 9.95), (-339.2 * r2 + 161.4 * roughness - 25.9), roughness < 0.25 );
+    let b = select( (1.97 * r2 - 3.27 * roughness + 0.72), (44.0 * r2 - 23.7 * roughness + 3.26), roughness < 0.25 );
+    let DG = exp( a * dot_nv + b ) + select( 0.1 * (roughness - 0.25), 0.0, roughness < 0.25 );
+    return saturate( DG * RECIPROCAL_PI );
+}
+
+$$ endif
 
 fn DFGApprox( normal: vec3<f32>, view_dir: vec3<f32>, roughness: f32 ) -> vec2<f32>{
     let dot_nv = saturate( dot( normal, view_dir ) );
@@ -211,6 +264,11 @@ fn RE_IndirectSpecular(radiance: vec3<f32>, irradiance: vec3<f32>, clearcoat_rad
     $$ if USE_CLEARCOAT is defined
         clearcoat_specular_indirect += clearcoat_radiance * EnvironmentBRDF( geometry.clearcoat_normal, geometry.view_dir, material.clearcoat_f0, material.clearcoat_f90, material.clearcoat_roughness );
     $$ endif
+
+    $$ if USE_SHEEN is defined
+        sheen_specular_indirect += irradiance * material.sheen_color * IBLSheenBRDF( geometry.normal, geometry.view_dir, material.sheen_roughness );
+    $$ endif
+
     let cosine_weighted_irradiance: vec3<f32> = irradiance * RECIPROCAL_PI;
     var single_scatter: vec3<f32>;
     var multi_scatter: vec3<f32>;
@@ -245,6 +303,10 @@ fn RE_Direct(
         let dot_nl_cc = saturate( dot( geometry.clearcoat_normal, direct_light.direction ));
         let clearcoat_irradiance = dot_nl_cc * direct_light.color;
         clearcoat_specular_direct += clearcoat_irradiance * BRDF_GGX_CC( direct_light.direction, geometry.view_dir, geometry.clearcoat_normal, material.specular_color, material.clearcoat_f90, material.clearcoat_roughness );
+    $$ endif
+
+    $$ if USE_SHEEN is defined
+        sheen_specular_direct += irradiance * BRDF_Sheen( direct_light.direction, geometry.view_dir, geometry.normal, material.sheen_color, material.sheen_roughness );
     $$ endif
 
     (*reflected_light).direct_specular += irradiance * BRDF_GGX( direct_light.direction, geometry.view_dir, geometry.normal, material.specular_color, material.specular_f90, material.roughness, material );

--- a/pygfx/renderers/wgpu/wgsl/light_pbr_fragment.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/light_pbr_fragment.wgsl
@@ -111,6 +111,21 @@ $$ if USE_IRIDESCENCE is defined
 $$ endif
 
 
+$$ if USE_SHEEN is defined
+
+    material.sheen_color = srgb2physical(u_material.sheen_color.rgb) * u_material.sheen;
+
+    $$ if use_sheen_color_map is defined
+        material.sheen_color *= textureSample( t_sheen_color_map, s_sheen_color_map, varyings.texcoord{{sheen_color_map_uv or ''}} ).rgb;
+    $$ endif
+
+    material.sheen_roughness = clamp( u_material.sheen_roughness, 0.07, 1.0 );
+    $$ if use_sheen_roughness_map is defined
+        material.sheen_roughness *= textureSample( t_sheen_roughness_map, s_sheen_roughness_map, varyings.texcoord{{sheen_roughness_map_uv or ''}} ).a;
+    $$ endif
+
+$$ endif
+
 $$ if USE_ANISOTROPY is defined
     let anisotropy_vector = u_material.anisotropy_vector;
     $$ if use_anisotropy_map is defined

--- a/pygfx/renderers/wgpu/wgsl/mesh.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/mesh.wgsl
@@ -245,7 +245,7 @@ fn vs_main(in: VertexInput) -> Varyings {
 
     $$ if instanced
         // this is in lieu of a per-instance normal-matrix
-	    // shear transforms in the instance matrix are not supported
+        // shear transforms in the instance matrix are not supported
         let im = mat3x3f( instance_info.transform[0].xyz, instance_info.transform[1].xyz, instance_info.transform[2].xyz );
         raw_normal /= vec3f(dot(im[0], im[0]), dot(im[1], im[1]), dot(im[2], im[2]));
         raw_normal = im * raw_normal;
@@ -584,7 +584,7 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
 
     $$ if USE_SHEEN is defined
         // Sheen energy compensation approximation calculation can be found at the end of
-		// https://drive.google.com/file/d/1T0D1VSyR4AllqIJTQAraEIzjlb5h4FKH/view?usp=sharing
+        // https://drive.google.com/file/d/1T0D1VSyR4AllqIJTQAraEIzjlb5h4FKH/view?usp=sharing
         let sheen_energy_comp = 1.0 - 0.157 * max(material.sheen_color.r, max(material.sheen_color.g, material.sheen_color.b));
         physical_color = physical_color * sheen_energy_comp + (sheen_specular_direct + sheen_specular_indirect);
     $$ endif

--- a/pygfx/utils/load_gltf.py
+++ b/pygfx/utils/load_gltf.py
@@ -191,8 +191,9 @@ class _GLTF:
         self._register_plugin(GLTFMaterialsSpecularExtension)
         self._register_plugin(GLTFMaterialsClearcoatExtension)
         self._register_plugin(GLTFMaterialsIridescenceExtension)
-        self._register_plugin(GLTFMaterialsEmissiveStrengthExtension)
+        self._register_plugin(GLTFMaterialsSheenExtension)
         self._register_plugin(GLTFMaterialsAnisotropyExtension)
+        self._register_plugin(GLTFMaterialsEmissiveStrengthExtension)
         self._register_plugin(GLTFMaterialsUnlitExtension)
         self._register_plugin(GLTFLightsExtension)
 
@@ -1269,6 +1270,36 @@ class GLTFMaterialsAnisotropyExtension(GLTFBaseMaterialsExtension):
         anisotropy_texture = extension.get("anisotropyTexture", None)
         if anisotropy_texture is not None:
             material.anisotropy_map = self._load_texture(anisotropy_texture)
+
+
+class GLTFMaterialsSheenExtension(GLTFBaseMaterialsExtension):
+    EXTENSION_NAME = "KHR_materials_sheen"
+
+    def extend_material(self, material_def, material):
+        if (
+            not material_def.extensions
+            or self.EXTENSION_NAME not in material_def.extensions
+        ):
+            return
+
+        extension = material_def.extensions[self.EXTENSION_NAME]
+
+        sheen_color = extension.get("sheenColorFactor", None)
+        if sheen_color is not None:
+            material.sheen = 1.0
+            material.sheen_color = gfx.Color.from_physical(*sheen_color)
+
+        sheen_color_texture = extension.get("sheenColorTexture", None)
+        if sheen_color_texture is not None:
+            material.sheen_color_map = self._load_texture(sheen_color_texture)
+
+        sheen_roughness_factor = extension.get("sheenRoughnessFactor", None)
+        if sheen_roughness_factor is not None:
+            material.sheen_roughness = sheen_roughness_factor
+
+        sheen_roughness_texture = extension.get("sheenRoughnessTexture", None)
+        if sheen_roughness_texture is not None:
+            material.sheen_roughness_map = self._load_texture(sheen_roughness_texture)
 
 
 class GLTFMaterialsEmissiveStrengthExtension(GLTFBaseMaterialsExtension):


### PR DESCRIPTION
This PR introduces support for sheen in MeshPhysicalMaterial.

A sheen layer is a common technique used in Physically-Based Rendering to represent cloth and fabric materials.

Example:

![image](https://github.com/user-attachments/assets/2c9589bb-eeb8-41e4-afe3-55f2b5ac0b6b)

![image](https://github.com/user-attachments/assets/5a4d95ee-2f21-405a-b1ff-979bcf164712)

Related glTF extension: [KHR_materials_sheen](https://github.com/KhronosGroup/glTF/blob/main/extensions/2.0/Khronos/KHR_materials_sheen/README.md)

Test Case 1:  [SheenTestGrid](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/Models/SheenTestGrid/README.md)

![image](https://github.com/user-attachments/assets/1a16aadd-528b-4ed7-9c08-26710babc293)

Test Case 2: [Compare Sheen](https://github.com/KhronosGroup/glTF-Sample-Assets/blob/main/Models/CompareSheen/README.md)

![image](https://github.com/user-attachments/assets/e8bf0313-04bc-465a-a919-1a55f346fcf7)
