### PR TITLE
No longer set the Bone object as invisible by default

### DIFF
--- a/pygfx/objects/_skins.py
+++ b/pygfx/objects/_skins.py
@@ -18,7 +18,6 @@ class Bone(WorldObject):
 
     def __init__(self, name=""):
         super().__init__(name=name)
-        self.visible = False
 
 
 class Skeleton:


### PR DESCRIPTION
While testing glTF rendering, I discovered that a very small number of models failed to render correctly, with certain Mesh components missing during rendering, as shown below: 

(The wheels of the car are missing)

![image](https://github.com/user-attachments/assets/07d659ab-c289-4105-9625-a0f62d0228c0)

After a thorough investigation, I identified the root cause of the issue: a bug in how we handle invisible objects during scene traversal.

Consider a parent-child relationship in the scene graph:
`... -> a -> b`
Here, `a` is an invisible scene control node, while `b` is a Mesh object that should be rendered. During scene traversal, since `a` is invisible, the current logic skips `a` along with its entire subtree. However, this is incorrect. Only `a` itself should be skipped, while its renderable child nodes should still be processed.

The correct result:
![image](https://github.com/user-attachments/assets/47c1df28-d835-4807-af75-1c87ce00948b)
