### PR TITLE
Fix morph on MacOS

### DIFF
--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -213,49 +213,46 @@ class Mesh(WorldObject):
 
     @morph_target_influences.setter
     def morph_target_influences(self, value):
-        morph_attrs = (
-            getattr(self.geometry, "morph_positions", None)
-            or getattr(self.geometry, "morph_normals", None)
-            or getattr(self.geometry, "morph_colors", None)
-            or []
-        )
+        value = np.asarray(value, dtype=np.float32)
 
+        # Get the number of morph targets from the morph data on the geometry
+        morph_attrs = [
+            getattr(self.geometry, name, None)
+            for name in ["morph_positions", "morph_normals", "morph_colors"]
+        ]
+        morph_attrs = [x for x in morph_attrs if x is not None]
         if not morph_attrs:
             return
+        morph_count = min(len(x) for x in morph_attrs)
 
-        morph_target_count = len(morph_attrs)
-
-        assert len(value) == morph_target_count, (
+        # Check with the size of the given data
+        assert len(value) == morph_count, (
             f"Length of morph target influences must match the number of morph targets. "
-            f"Expected {morph_target_count}, got {len(value)}."
+            f"Expected {morph_count}, got {len(value)}."
         )
 
+        buffer_size = morph_count + 1  # add roon for base influence
         if (
             self._morph_target_influences is None
-            or self._morph_target_influences.nitems != morph_target_count + 1
+            or self._morph_target_influences.nitems != buffer_size
         ):
             self._morph_target_influences = Buffer(
                 array_from_shadertype(
                     {
                         "influence": "f4",
                     },
-                    morph_target_count + 1,
+                    buffer_size,
                 )
             )
-
-        if not isinstance(value, np.ndarray):
-            value = np.array(value, dtype=np.float32)
 
         if getattr(self.geometry, "morph_targets_relative", False):
             base_influence = 1.0
         else:
             base_influence = 1 - value.sum()
 
-        # Add the base influence to the end of the array
-        value = np.concatenate([value, [base_influence]], axis=0)
-
-        self._morph_target_influences.data["influence"] = value
-        self._morph_target_influences.update_range()
+        self._morph_target_influences.data["influence"][:-1] = value
+        self._morph_target_influences.data["influence"][-1] = base_influence
+        self._morph_target_influences.update_full()
 
     @property
     def morph_target_names(self):

--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -226,10 +226,10 @@ class Mesh(WorldObject):
         morph_count = min(len(x) for x in morph_attrs)
 
         # Check with the size of the given data
-        assert len(value) == morph_count, (
-            f"Length of morph target influences must match the number of morph targets. "
-            f"Expected {morph_count}, got {len(value)}."
-        )
+        if len(value) != morph_count:
+            raise ValueError(
+                f"Length of morph target influences must match the number of morph targets. Expected {morph_count}, got {len(value)}."
+            )
 
         buffer_size = morph_count + 1  # add roon for base influence
         if (

--- a/pygfx/renderers/wgpu/shaders/meshshader.py
+++ b/pygfx/renderers/wgpu/shaders/meshshader.py
@@ -237,7 +237,7 @@ class MeshShader(BaseShader):
             )
             if morph_texture is None:
                 morph_texture, stride, width, morph_count = self._encode_morph_texture(
-                    geometry
+                    geometry, shared
                 )
                 geometry._gfx_morph_texture = (
                     morph_texture,
@@ -355,7 +355,7 @@ class MeshShader(BaseShader):
             1: bindings1,
         }
 
-    def _encode_morph_texture(self, geometry):
+    def _encode_morph_texture(self, geometry, shared):
         morph_positions = getattr(geometry, "morph_positions", None)
         morph_normals = getattr(geometry, "morph_normals", None)
         morph_colors = getattr(geometry, "morph_colors", None)
@@ -383,7 +383,7 @@ class MeshShader(BaseShader):
         width = total_count
         height = 1
 
-        max_texture_width = 4096  # TODO: use wgpu capabilities "max_texture_size"
+        max_texture_width = shared.device.limits["max-texture-dimension-2d"]
 
         if width > max_texture_width:
             height = math.ceil(width / max_texture_width)

--- a/pygfx/renderers/wgpu/shaders/meshshader.py
+++ b/pygfx/renderers/wgpu/shaders/meshshader.py
@@ -383,7 +383,7 @@ class MeshShader(BaseShader):
         width = total_count
         height = 1
 
-        max_texture_width = 2**14  # TODO: use wgpu capabilities "max_texture_size"
+        max_texture_width = 4096  # TODO: use wgpu capabilities "max_texture_size"
 
         if width > max_texture_width:
             height = math.ceil(width / max_texture_width)

--- a/pygfx/renderers/wgpu/wgsl/mesh.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/mesh.wgsl
@@ -61,10 +61,14 @@ fn get_morph( tex: texture_2d_array<f32>, vertex_index: u32, stride: u32, width:
     return textureLoad( tex, morph_uv, morph_index, 0 );
 }
 struct MorphTargetInfluence {
-    @size(16) influence: f32,
+    //@size(16) influence: f32, -> Does not work on Metal, likely an upstream bug in Naga
+    influence: f32,
+    padding0: f32,
+    padding1: f32,
+    padding2: f32,
 };
 @group(1) @binding(1)
-var<uniform> u_morph_target_influences: array<MorphTargetInfluence, {{morph_targets_count+1}}>;
+var<uniform> u_morph_target_influences: array<MorphTargetInfluence, {{influences_buffer_size}}>;
 
 $$ endif
 
@@ -124,7 +128,7 @@ fn vs_main(in: VertexInput) -> Varyings {
 
     // morph targets
     $$ if use_morph_targets
-        let base_influence = u_morph_target_influences[{{morph_targets_count}}];
+        let base_influence = u_morph_target_influences[{{influences_buffer_size-1}}];
         let stride = u32({{morph_targets_stride}});
         let width = u32({{morph_targets_texture_width}});
 


### PR DESCRIPTION
Closes #1045

While debugging I cleaned a few things up.

* [x] The actual fix is adding stub padding variables to the influences buffer.
* [x] Fix a case where a template var (`use_morph_targets`) was meant to store a bool, but ended up storing a tuple of arrays, which then participate to the shader's hash.
* [x] The morph count is the minimum of the lengths of the different morph arrays, similar to how Python's `zip` iterates up to the smallest size.
* [x] Use an explicit size for the influences buffer. 
* [x] Use the actual max texture size. 
 
cc @panxinmiao