### PR TITLE
Fix pick info inheritance

### DIFF
--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -598,7 +598,7 @@ class WorldObject(EventTarget, Trackable):
         aabb = self.get_world_bounding_box()
         return None if aabb is None else la.aabb_to_sphere(aabb)
 
-    def _wgpu_get_pick_info(self, pick_value):
+    def _wgpu_get_pick_info(self, pick_value) -> dict:
         # In most cases the material handles this.
         return self.material._wgpu_get_pick_info(pick_value)
 

--- a/pygfx/objects/_instanced.py
+++ b/pygfx/objects/_instanced.py
@@ -69,8 +69,8 @@ class InstancedMesh(Mesh):
         """get the matrix for the instance at the given index."""
         return self._store["instance_buffer"].data["matrix"][index].T
 
-    def _wgpu_get_pick_info(self, pick_value):
-        info = self.material._wgpu_get_pick_info(pick_value)
+    def _wgpu_get_pick_info(self, pick_value) -> dict:
+        info = super()._wgpu_get_pick_info(pick_value)
         # The id maps to one of our instances
         id = pick_value & 1048575  # 2**20-1
         info["instance_index"] = self._idmap.get(id)

--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -268,7 +268,8 @@ class Mesh(WorldObject):
         """
         return self._morph_target_names
 
-    def _wgpu_get_pick_info(self, pick_value):
+    def _wgpu_get_pick_info(self, pick_value) -> dict:
+        info = super()._wgpu_get_pick_info(pick_value)
         values = unpack_bitfield(
             pick_value, wobject_id=20, index=26, coord1=6, coord2=6, coord3=6
         )
@@ -292,8 +293,9 @@ class Mesh(WorldObject):
                 # face_coord slot of index 1, (see meshshader.py), so
                 # we put that at the end and put a zero in its place.
                 face_coord = face_coord[0], 0.0, face_coord[2], face_coord[1]
-
-        return {"face_index": face_index, "face_coord": tuple(face_coord)}
+        info["face_index"] = face_index
+        info["face_coord"] = tuple(face_coord)
+        return info
 
 
 class Image(WorldObject):
@@ -329,7 +331,8 @@ class Image(WorldObject):
 
     """
 
-    def _wgpu_get_pick_info(self, pick_value):
+    def _wgpu_get_pick_info(self, pick_value) -> dict:
+        info = super()._wgpu_get_pick_info(pick_value)
         tex = self.geometry.grid
         if hasattr(tex, "texture"):
             tex = tex.texture  # tex was a view
@@ -338,10 +341,9 @@ class Image(WorldObject):
         x = values["x"] / 4194303 * tex.size[0] - 0.5
         y = values["y"] / 4194303 * tex.size[1] - 0.5
         ix, iy = int(x + 0.5), int(y + 0.5)
-        return {
-            "index": (ix, iy),
-            "pixel_coord": (x - ix, y - iy),
-        }
+        info["index"] = (ix, iy)
+        info["pixel_coord"] = (x - ix, y - iy)
+        return info
 
 
 class Volume(WorldObject):
@@ -373,7 +375,8 @@ class Volume(WorldObject):
 
     """
 
-    def _wgpu_get_pick_info(self, pick_value):
+    def _wgpu_get_pick_info(self, pick_value) -> dict:
+        info = super()._wgpu_get_pick_info(pick_value)
         tex = self.geometry.grid
         if hasattr(tex, "texture"):
             tex = tex.texture  # tex was a view
@@ -383,7 +386,6 @@ class Volume(WorldObject):
         size = tex.size
         x, y, z = [(v / 16383) * s - 0.5 for v, s in zip(texcoords_encoded, size)]
         ix, iy, iz = int(x + 0.5), int(y + 0.5), int(z + 0.5)
-        return {
-            "index": (ix, iy, iz),
-            "voxel_coord": (x - ix, y - iy, z - iz),
-        }
+        info["index"] = (ix, iy, iz)
+        info["voxel_coord"] = (x - ix, y - iy, z - iz)
+        return info


### PR DESCRIPTION
When picking a `Mesh`, I get a pick info like this:

```
{
  'rgba': Color(0.8039, 0.7529, 0.698, 1.0),
  'world_object': <pygfx.Mesh  at 0x2544b7ec510>,
  'face_index': 2181,
  'face_coord': (0.015873015873015872, 0.6666666666666666, 0.2857142857142857)
}
```

When picking an `InstancedMesh`, I get a pick info like this:

```
{
  'rgba': Color(0.9765, 0.9098, 0.8471, 1.0),
  'world_object': <pygfx.InstancedMesh  at 0x24841da8050>,
  'instance_index': 5
}
```
Note that `'face_index'` and `'face_coord'` are missing. This is not only inconvenient but also a LSP violation as `InstancedMesh` derives from `Mesh`.

The expected pick info for an `InstancedMesh` would look like this:

```
{
  'rgba': Color(0.8039, 0.7529, 0.698, 1.0),
  'world_object': <pygfx.InstancedMesh  at 0x2544b7ec510>,
  'face_index': 2181,
  'face_coord': (0.015873015873015872, 0.6666666666666666, 0.2857142857142857),
  'instance_index': 5
}
```

The issue is that many implementations of `_wgpu_get_pick_info()` create a new pick info dict, when they should call the base class version and add their own keys to it.

This pull request updates all implementations of `_wgpu_get_pick_info()` to call and extend the base implementation.


