### PR TITLE
Instanced lines

### DIFF
--- a/pygfx/objects/__init__.py
+++ b/pygfx/objects/__init__.py
@@ -22,6 +22,7 @@
     TextBlock
     Ruler
     InstancedMesh
+    InstancedLine
     Light
     PointLight
     DirectionalLight
@@ -77,7 +78,7 @@ from ._more import (
 )
 from ._ruler import Ruler
 from ._text import Text, MultiText, TextBlock
-from ._instanced import InstancedMesh
+from ._instanced import InstancedMesh, InstancedLine
 from ._lights import Light, PointLight, DirectionalLight, AmbientLight, SpotLight
 from ._lights import (
     LightShadow,

--- a/pygfx/objects/_instanced.py
+++ b/pygfx/objects/_instanced.py
@@ -1,26 +1,26 @@
 import numpy as np
 
 from ._base import id_provider
-from . import Mesh
+from . import WorldObject, Mesh
 from ..resources import Buffer
 
 
-class InstancedMesh(Mesh):
-    """Display a mesh multiple times using instances.
+class InstancedObject(WorldObject):
+    """Display an object multiple times using instances.
 
-    An instanced mesh with a matrix for each instance.
+    An instanced object with a matrix for each instance.
 
     Parameters
     ----------
     geometry : Geometry
-        The mesh's geometry data.
+        The object's geometry data.
     material : Material
-        The material with which to render the mesh.
+        The material with which to render the object.
     count : int
         The number of instances to create.
     kwargs : Any
         Additional kwargs get forwarded to the :class:`base class
-        <pygfx.objects.Mesh>`.
+        <pygfx.objects.WorldObject>`.
 
     """
 
@@ -75,3 +75,7 @@ class InstancedMesh(Mesh):
         id = pick_value & 1048575  # 2**20-1
         info["instance_index"] = self._idmap.get(id)
         return info
+
+
+class InstancedMesh(Mesh, InstancedObject):
+    pass

--- a/pygfx/objects/_instanced.py
+++ b/pygfx/objects/_instanced.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from ._base import id_provider
-from . import WorldObject, Mesh
+from . import WorldObject, Mesh, Line
 from ..resources import Buffer
 
 
@@ -78,4 +78,8 @@ class InstancedObject(WorldObject):
 
 
 class InstancedMesh(Mesh, InstancedObject):
+    pass
+
+
+class InstancedLine(Line, InstancedObject):
     pass

--- a/pygfx/objects/_instanced.py
+++ b/pygfx/objects/_instanced.py
@@ -4,25 +4,29 @@ from ._base import id_provider
 from . import WorldObject, Mesh, Line
 from ..resources import Buffer
 
+DOCSTRING_TEMPLATE = """Display a {name} multiple times using instances.
 
-class InstancedObject(WorldObject):
-    """Display an object multiple times using instances.
-
-    An instanced object with a matrix for each instance.
+    An instanced {name} with a matrix for each instance.
 
     Parameters
     ----------
     geometry : Geometry
-        The object's geometry data.
+        The {name}'s geometry data.
     material : Material
-        The material with which to render the object.
+        The material with which to render the {name}.
     count : int
         The number of instances to create.
     kwargs : Any
         Additional kwargs get forwarded to the :class:`base class
-        <pygfx.objects.WorldObject>`.
+        <pygfx.objects.{base_cls}>`.
 
     """
+
+
+class InstancedObject(WorldObject):
+    __doc__ = DOCSTRING_TEMPLATE.format(name="object", base_cls="WorldObject").replace(
+        "a object", "an object"
+    )
 
     def __init__(self, geometry, material, count, **kwargs):
         super().__init__(geometry, material, **kwargs)
@@ -78,8 +82,14 @@ class InstancedObject(WorldObject):
 
 
 class InstancedMesh(Mesh, InstancedObject):
-    pass
+    __doc__ = DOCSTRING_TEMPLATE.format(name="mesh", base_cls="Mesh")
+
+    def __init__(self, geometry, material, count, **kwargs):
+        super().__init__(geometry, material, count, **kwargs)
 
 
 class InstancedLine(Line, InstancedObject):
-    pass
+    __doc__ = DOCSTRING_TEMPLATE.format(name="line", base_cls="Line")
+
+    def __init__(self, geometry, material, count, **kwargs):
+        super().__init__(geometry, material, count, **kwargs)

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -6,7 +6,7 @@ import pylinalg as la
 
 from ....utils import array_from_shadertype
 from ....resources import Buffer
-from ....objects import Line
+from ....objects import Line, InstancedLine
 from ....materials._line import (
     LineMaterial,
     LineSegmentMaterial,
@@ -37,6 +37,9 @@ class LineShader(BaseShader):
         super().__init__(wobject)
         material = wobject.material
         geometry = wobject.geometry
+
+        # Is this an instanced line?
+        self["instanced"] = isinstance(wobject, InstancedLine)
 
         self["line_type"] = "line"
         self["dashing"] = False
@@ -281,8 +284,16 @@ class LineShader(BaseShader):
         bindings = {i: b for i, b in enumerate(bindings)}
         self.define_bindings(0, bindings)
 
+        # Instanced lines have an extra storage buffer that we add manually
+        bindings1 = {}  # non-auto-generated bindings
+        if self["instanced"]:
+            bindings1[0] = Binding(
+                "s_instance_infos", rbuffer, wobject.instance_buffer, "VERTEX"
+            )
+
         return {
             0: bindings,
+            1: bindings1,
         }
 
     def get_pipeline_info(self, wobject, shared):
@@ -302,6 +313,10 @@ class LineShader(BaseShader):
         material = wobject.material
         # Determine how many vertices are needed
         offset, size = self._get_n(wobject.geometry.positions)
+
+        n_instances = 1
+        if self["instanced"]:
+            n_instances = wobject.instance_buffer.nitems
 
         render_mask = 0
         if wobject.render_mask:
@@ -332,7 +347,7 @@ class LineShader(BaseShader):
                 render_mask |= RenderMask.transparent
 
         return {
-            "indices": (size, 1, offset, 0),
+            "indices": (size, n_instances, offset, 0),
             "render_mask": render_mask,
         }
 


### PR DESCRIPTION
Introduces instanced line rendering:
* Generalize `InstancedMesh(Mesh)` to `InstancedObject(WorldObject)` (no real changes) and refactor `InstancedMesh` to inherit from `Mesh` and `InstancedObject`
* Introduce `InstancedLine` class inheriting from `Line` and `InstancedObject`
* Add instancing support to `LineShader` (copied the relevant parts from `MeshShader`)
* Add instancing support to `line.wgsl` (copied the relevant parts from `mesh.wgsl`)

The duplications in the shader classes and shader code can probably be generalized to some degree as well, but I am not familiar enough with the templating engine to know how to do that.

Requires https://github.com/pygfx/pygfx/pull/1057 because the multiple inheritance breaks the pick info even more.