### PR TITLE
Don't throw AttributeError when calling dict attributes

### DIFF
--- a/pygfx/utils/trackable.py
+++ b/pygfx/utils/trackable.py
@@ -54,9 +54,8 @@ there is no persistent knowledge of hierarchy.
 
 """
 
-import weakref
 import threading
-
+import weakref
 
 global_id_counter = 0
 global_lock = threading.RLock()
@@ -150,6 +149,8 @@ class Store(dict):
             value = self[key]
             return value
         except KeyError:
+            if hasattr(dict, key):
+                return dict.__getattribute__(self, key)
             raise AttributeError(key) from None
         finally:
             if global_context:

--- a/pygfx/utils/trackable.py
+++ b/pygfx/utils/trackable.py
@@ -149,9 +149,7 @@ class Store(dict):
             value = self[key]
             return value
         except KeyError:
-            if hasattr(dict, key):
-                return dict.__getattribute__(self, key)
-            raise AttributeError(key) from None
+            return dict.__getattribute__(self, key)
         finally:
             if global_context:
                 global_context.tracker._track_get(

--- a/tests/geometries/test_geometry.py
+++ b/tests/geometries/test_geometry.py
@@ -1,6 +1,7 @@
 import numpy as np
-import pygfx as gfx
 import pytest
+
+import pygfx as gfx
 
 
 def test_different_data_types():
@@ -48,3 +49,9 @@ def test_check_positions():
     a = np.zeros((10, 2), np.float32)
     with pytest.raises(ValueError):
         gfx.Geometry(positions=a)
+
+
+def test_check_common_dict_attributes():
+    g = gfx.Geometry(positions=[[0, 1, 0], [1, 0, 1]])
+    assert "positions" in g.keys()
+    assert len(g.keys()) == len(g.values())


### PR DESCRIPTION
This makes Geometry behave more like a proper dict.