### PR TITLE
Make the Store track hashable objects by value

### DIFF
--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -219,3 +219,43 @@ def assert_type(name, value, *classes):
 
         # Raise message with alt traceback
         raise TypeError(msg).with_traceback(tb) from None
+
+
+class ReadOnlyDict(dict):
+    """A read-only dict, for storing structured data that can be hashed."""
+
+    ___slots__ = ["_hash"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Calculate hash in a way that requires any value to also be hashable
+        parts = []
+        for k in sorted(self.keys()):
+            v = self[k]
+            parts.append(str(hash(k)))
+            parts.append(str(hash(v)))
+        self._hash = hash(" ".join(parts))
+
+    def __setitem__(self, *args, **kwargs):
+        raise TypeError("Cannot modify ReadOnlyDict")
+
+    def __delitem__(self, *args, **kwargs):
+        raise TypeError("Cannot modify ReadOnlyDict")
+
+    def clear(self, *args, **kwargs):
+        raise TypeError("Cannot modify ReadOnlyDict")
+
+    def pop(self, *args, **kwargs):
+        raise TypeError("Cannot modify ReadOnlyDict")
+
+    def popitem(self, *args, **kwargs):
+        raise TypeError("Cannot modify ReadOnlyDict")
+
+    def setdefault(self, *args, **kwargs):
+        raise TypeError("Cannot modify ReadOnlyDict")
+
+    def update(self, *args, **kwargs):
+        raise TypeError("Cannot modify ReadOnlyDict")
+
+    def __hash__(self):
+        return self._hash

--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -224,7 +224,7 @@ def assert_type(name, value, *classes):
 class ReadOnlyDict(dict):
     """A read-only dict, for storing structured data that can be hashed."""
 
-    ___slots__ = ["_hash"]
+    __slots__ = ["_hash"]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/pygfx/utils/trackable.py
+++ b/pygfx/utils/trackable.py
@@ -72,10 +72,8 @@ def get_comp_value(value):
     else:
         try:
             return "hash:" + str(hash(value))
-        except Exception:
-            raise TypeError(
-                f"You cannot store unhashable values on a Store: {value!r}"
-            ) from None
+        except TypeError:
+            return "id:" + str(id(value))
 
 
 class Undefined:

--- a/pygfx/utils/trackable.py
+++ b/pygfx/utils/trackable.py
@@ -70,7 +70,12 @@ def get_comp_value(value):
     elif isinstance(value, tuple):
         return tuple(get_comp_value(v) for v in value)
     else:
-        return f"id:{id(value)}"
+        try:
+            return "hash:" + str(hash(value))
+        except Exception:
+            raise TypeError(
+                f"You cannot store unhashable values on a Store: {value!r}"
+            ) from None
 
 
 class Undefined:

--- a/tests/utils/test_readonlydict.py
+++ b/tests/utils/test_readonlydict.py
@@ -1,0 +1,91 @@
+from pygfx.utils import ReadOnlyDict
+import pytest
+
+
+def test_readonlydict_immutable():
+    d = ReadOnlyDict(foo=3, bar=4, spam=5)
+
+    with pytest.raises(TypeError):
+        d["foo"] = 1
+    with pytest.raises(TypeError):
+        d["xxxxxxx"] = 1
+    with pytest.raises(TypeError):
+        del d["foo"]
+    with pytest.raises(TypeError):
+        d.update({})
+    with pytest.raises(TypeError):
+        d.clear()
+    with pytest.raises(TypeError):
+        d.pop("foo", None)
+    with pytest.raises(TypeError):
+        d.popitem()
+    with pytest.raises(TypeError):
+        d.setdefault("foo", 42)
+    with pytest.raises(TypeError):
+        d.setdefault("foo", 42)
+
+
+def test_readonlydict_hash():
+    d1 = ReadOnlyDict(foo=3, bar=4, spam=5)
+    d2 = ReadOnlyDict(foo=3, bar=4, spam=5)
+    d3 = ReadOnlyDict(d1)
+    d4 = ReadOnlyDict(bar=4, spam=5, foo=3)
+    d5 = ReadOnlyDict(spam=5, bar=4, foo=3)
+
+    for d in [d2, d3, d4, d5]:
+        assert d1 == d
+        assert hash(d1) == hash(d)
+
+    d11 = ReadOnlyDict(foo=2, bar=4, spam=5)
+    d12 = ReadOnlyDict(foo=3, bar=4, spam=5.01)
+    d13 = ReadOnlyDict(foo=3, bar=4)
+    d14 = ReadOnlyDict(foo=3, spam=5)
+    d15 = ReadOnlyDict(bar=4, spam=5)
+    d16 = ReadOnlyDict(foo=3, bar=4, spam=5, x=1)
+    d17 = ReadOnlyDict(foo=3, x=1, bar=4, spam=5)
+
+    for d in [d11, d12, d13, d14, d15, d16, d17]:
+        assert d1 != d
+        assert hash(d1) != hash(d)
+
+
+def test_readonlydict_init():
+    d1 = ReadOnlyDict(foo=3, bar=4, spam=5)
+    d2 = ReadOnlyDict(d1)
+    d3 = ReadOnlyDict({"foo": 3, "bar": 4, "spam": 5})
+    d4 = ReadOnlyDict({"foo": 3, "bar": 4}, spam=5)
+    d5 = ReadOnlyDict(dict(d1))
+
+    for d in [d2, d3, d4, d5]:
+        assert d1 == d
+        assert hash(d1) == hash(d)
+
+
+def test_readonlydict_values():
+    # Unhashable types
+    with pytest.raises(TypeError):
+        d1 = ReadOnlyDict(foo=[])
+    with pytest.raises(TypeError):
+        d1 = ReadOnlyDict(foo=dict(foo=3))
+
+    # This works
+    ReadOnlyDict(foo=ReadOnlyDict(foo=3))
+
+    class Foo:
+        def __init__(self, v):
+            self.v = v
+
+    # This works, but the Foo object is hashed using its id
+    d1 = ReadOnlyDict(foo=Foo(3))
+    d2 = ReadOnlyDict(foo=d1["foo"])
+    d3 = ReadOnlyDict(foo=Foo(3))
+
+    assert hash(d1) == hash(d2)
+    assert hash(d1) != hash(d3)
+
+
+if __name__ == "__main__":
+    test_readonlydict_immutable()
+    test_readonlydict_hash()
+    test_readonlydict_init()
+    test_readonlydict_values()

--- a/tests/utils/test_readonlydict.py
+++ b/tests/utils/test_readonlydict.py
@@ -24,6 +24,10 @@ def test_readonlydict_immutable():
     with pytest.raises(TypeError):
         d.setdefault("foo", 42)
 
+    # Also immutable (using __slots__)
+    with pytest.raises(AttributeError):
+        d.foo = 3
+
 
 def test_readonlydict_hash():
     d1 = ReadOnlyDict(foo=3, bar=4, spam=5)

--- a/tests/utils/test_trackable.py
+++ b/tests/utils/test_trackable.py
@@ -3,6 +3,9 @@ import time
 import weakref
 
 from pygfx.utils.trackable import Trackable, Store, PropTracker
+from pygfx.utils import ReadOnlyDict
+
+import pytest
 
 # ruff: noqa: B018 - in these tests we access values for their side-effect
 
@@ -293,44 +296,36 @@ def test_tuple_values():
     assert rt.pop_changed() == set()
 
 
-def test_list_values():
+def test_cannot_set_non_hashable_values():
     rt = MyRootTrackable()
-
-    v1 = [1, 2]
-    v2 = [3, 4]
-    v3 = [1, 2]
 
     with rt.track_usage("foo"):
         rt.foo
     assert rt.pop_changed() == set()
 
-    # Changing the value marks a change
-    rt.foo = v1
-    assert rt.pop_changed() == {"foo"}
-    rt.foo = v2
+    # Cannot set to a list
+    with pytest.raises(TypeError):
+        rt.foo = [1, 2]
+
+    # But a tuple works
+    rt.foo = (1, 2)
     assert rt.pop_changed() == {"foo"}
 
-    # Even if the value is the same - it tracks the object!
-    rt.foo = v1
-    assert rt.pop_changed() == {"foo"}
-    rt.foo = v3
-    assert rt.pop_changed() == {"foo"}
-
-    # This means that ...
-    v3.append(8)
-    assert rt.foo == v3  # changed in-place
-    rt.foo = v3  # so this does not do much
+    # Changing again with the same value
+    rt.foo = (1, 2)
     assert rt.pop_changed() == set()
 
-    # It can even mean that the second assert below fails, because when
-    # that last list is allocated, it may use the memory previously
-    # occupied by [0, 1], so it has the same id ... This is hard to
-    # test reliably, but it *can* happen.
-    rt.foo = [0, 1]
+    # Cannot set to a dict
+    with pytest.raises(TypeError):
+        rt.foo = {"foo": 42}
+
+    # But ReadOnlyDict works
+    rt.foo = ReadOnlyDict({"foo": 42})
     assert rt.pop_changed() == {"foo"}
-    rt.foo = [0, 2]  # on this line, the previous list is freed
-    rt.foo = [0, 3]  # a new list object is allocated
-    # assert rt.pop_changed() == {"foo"}
+
+    # Changing again with the same value
+    rt.foo = ReadOnlyDict({"foo": 42})
+    assert rt.pop_changed() == set()
 
 
 def test_whole_tree_get_removed():


### PR DESCRIPTION
* [x] ~Can only store hashable objects on the `Store`.~
* [x] Objects that are not primitive types, but are hashable, are now tracked by their hash. 
* [x] Implement simple `ReadOnlyDict` that is hashable. Not used yet, but I plan to use it in #1002