### PR TITLE
`Camera.get_state()` returns new copy of the array instead of a view

### DIFF
--- a/examples/feature_demo/panzoom_camera.py
+++ b/examples/feature_demo/panzoom_camera.py
@@ -57,13 +57,10 @@ def on_key_down(event):
 
     if event.key == "s":
         camera_state = camera.get_state()
-        print("save")
     elif event.key == "l":
         camera.set_state(camera_state)
-        print("load")
     elif event.key == "r":
         camera.show_object(scene)
-        print("reset")
 
     controller.enabled = True
 

--- a/examples/feature_demo/panzoom_camera.py
+++ b/examples/feature_demo/panzoom_camera.py
@@ -41,13 +41,33 @@ camera.show_object(scene)
 controller = gfx.PanZoomController(camera, register_events=renderer)
 
 
+# initial camera state
+camera_state = camera.get_state()
+
+
 def on_key_down(event):
+    if event.key not in ["s", "l", "r"]:
+        return
+
+    global camera_state
+
+    # without disabling the controller any in-progress action
+    # during this function call will overwrite the camera state
+    controller.enabled = False
+
     if event.key == "s":
-        controller.save_state()
+        camera_state = camera.get_state()
+        print("save")
     elif event.key == "l":
-        controller.load_state()
+        camera.set_state(camera_state)
+        print("load")
     elif event.key == "r":
-        controller.show_object(camera, plane)
+        camera.show_object(scene)
+        print("reset")
+
+    controller.enabled = True
+
+    canvas.request_draw()  # not required if you are continuously rendering
 
 
 renderer.add_event_handler(on_key_down, "key_down")

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -240,10 +240,10 @@ class PerspectiveCamera(Camera):
 
         """
         return {
-            "position": self.local.position,
-            "rotation": self.local.rotation,
-            "scale": self.local.scale,
-            "reference_up": self.world.reference_up,
+            "position": self.local.position.copy(),
+            "rotation": self.local.rotation.copy(),
+            "scale": self.local.scale.copy(),
+            "reference_up": self.world.reference_up.copy(),
             "fov": self.fov,
             "width": self.width,
             "height": self.height,


### PR DESCRIPTION
fixes #1073 

For `Camera.get_state()` to return a dict that can be used to restore states it must return a copy of the arrays instead of a reference that shares the same buffer. I cannot think where this might be detrimental. I would think that the typical use of `get_state()` is to _get and keep_ a snapshot of the camera state so it makes sense to return a copy of the arrays.

Also updates the example, enabling & disabling the controller is necessary to cancel any in-progress actions, see vid for what I mean.

https://github.com/user-attachments/assets/4d6d50c6-285b-4b87-a643-f81528a56a38

Bonus feature: if you guys think it makes sense we can have a `Controller.pause` decorator which can be useful in many situations.

```python
def pause(self, func):
    def wrapper(*args, **kwargs):
        state = self.enabled
        self.enabled = False
        func(*args, **kwargs)
        self.enabled = state

    return wrapper
```

It can then be used like this:

```python
@controller.pause
def do_stuff_while_controller_paused()
    ...
```