### PR TITLE
BF: register_wgsl_loader accepts package path instead of callable function.

### DIFF
--- a/pygfx/renderers/wgpu/shader/templating.py
+++ b/pygfx/renderers/wgpu/shader/templating.py
@@ -14,7 +14,7 @@ jinja_env = jinja2.Environment(
 )
 
 
-def register_wgsl_loader(context, func):
+def register_wgsl_loader(context, package):
     """Register a source for shader snippets.
 
     When code is encountered that looks like::
@@ -28,17 +28,16 @@ def register_wgsl_loader(context, func):
     ----------
     context : str
         The context of the loader.
-    func: callable
-        The function that will be called when a shader is loaded for the given context.
-        The function must accept one positional argument (the name to include).
+    package: str
+        The path of the package that contains the shader snippets.
     """
     if not (isinstance(context, str) and "." not in context):
-        raise TypeError("Wgsl load context must be a string witout dots.")
-    if not callable(func):
-        raise TypeError("The given wgsl load func must be callable.")
+        raise TypeError("Wgsl load context must be a string without dots.")
+    if not isinstance(package, str):
+        raise TypeError("The given package must be a string.")
     if context in loader.mapping:
         raise RuntimeError(f"A loader is already registered for '{context}'.")
-    loader.mapping[context] = func
+    loader.mapping[context] = jinja2.PackageLoader(package, ".")
 
 
 def apply_templating(code, **kwargs):


### PR DESCRIPTION

- This eliminates the func requirement and introduces the package path
- The function resulted in the error saying function does not have attribute `load` as it was expecting a `PackageLoader`.
- The PrefixLoader expects dict of `[str, PackageLoader]` which this function will serve.

Hi,
I saw this function while adding include in the my wgsl files in another wgsl file like pygfx.std.wgsl But when I try the above function it gives me the error explained above. I realized that we accept a func but never use it in the code. 

I am creating this PR so it becomes easy to add downstream wgsl package in the loader.

Let me know if you any other concerns. 