### PR TITLE
Properly implement `register_wgsl_loader`

### DIFF
--- a/tests/renderers/test_shader_composer.py
+++ b/tests/renderers/test_shader_composer.py
@@ -1,8 +1,10 @@
+import pygfx
 from pygfx.renderers.wgpu.shader import BaseShader
-from pygfx.renderers.wgpu import Binding
+from pygfx.renderers.wgpu import Binding, register_wgsl_loader
 from pygfx.utils import array_from_shadertype
 from pygfx import Buffer
 from pytest import raises
+import jinja2
 import numpy as np
 
 
@@ -187,7 +189,43 @@ def test_uniform_definitions():
         shader.define_binding(0, 0, Binding("zz", "buffer/uniform", struct))
 
 
+def test_custom_wgsl_loaders():
+    class MyLoader(jinja2.BaseLoader):
+        def get_source(self, environment, x):
+            return f"// loader: {x}", None, None
+
+    my_loader = MyLoader()
+
+    def my_func(x):
+        return f"// func: {x}"
+
+    my_dict = {"foo.wgsl": "// dict: foo.wgsl"}
+
+    register_wgsl_loader("testloader1", my_loader)
+    register_wgsl_loader("testloader2", my_func)
+    register_wgsl_loader("testloader3", my_dict)
+
+    with raises(RuntimeError):
+        register_wgsl_loader("testloader3", {})
+
+    code1 = """
+    {$ include 'testloader1.foo.wgsl' $}
+    {$ include 'testloader2.foo.wgsl' $}
+    {$ include 'testloader3.foo.wgsl' $}
+    """
+
+    code2 = """
+    // loader: foo.wgsl
+    // func: foo.wgsl
+    // dict: foo.wgsl
+    """
+
+    code3 = pygfx.renderers.wgpu.shader.templating.apply_templating(code1)
+    assert code3 == code2
+
+
 if __name__ == "__main__":
     test_templating()
     test_logic_beyond_templating()
     test_uniform_definitions()
+    test_custom_wgsl_loaders()


### PR DESCRIPTION
Ref #1077

We implemented `register_wgsl_loader()` with the idea to let downstream code register their own loader. It seems like the implementation was a stub that was never properly finished: there is no test, we don't use it ourselves, and it's simply broken.

This PR fixes that, allowing downstream code to provide either a `jinja2.BaseLoader`, a function, or a dict.

