### PR TITLE
Camera with fov==0 does not move backwards when zooming out

### DIFF
--- a/pygfx/cameras/_orthographic.py
+++ b/pygfx/cameras/_orthographic.py
@@ -8,10 +8,6 @@ class OrthographicCamera(PerspectiveCamera):
     You can use this instead of a PerspectiveCamera if you have data that does
     not make sense to view with a nonzero fov.
 
-    When used with the show methods and/or a controller, the ``OrthographicCamera``'s
-    position does not move along the view-axis (to zoom in/out), unlike the
-    ``PerspectiveCamera``, which does this even when fov is 0.
-
     Parameters
     ----------
     width: float
@@ -25,7 +21,7 @@ class OrthographicCamera(PerspectiveCamera):
     maintain_aspect: bool
         Whether the aspect ration is maintained as the window size changes.
         Default True. If false, the dimensions are stretched to fit the window.
-     depth: float | None
+    depth: float | None
         The reference size of the scene in the depth dimension. By default this value gets set
         to the average of ``width`` and ``height``. This happens on initialization and by ``show_pos()``, ``show_object()`` and ``show_rect()``.
         It is used to calculate a sensible depth range when ``depth_range`` is not set.

--- a/pygfx/controllers/_base.py
+++ b/pygfx/controllers/_base.py
@@ -6,7 +6,7 @@ import numpy as np
 import pylinalg as la
 
 from ..cameras import Camera, PerspectiveCamera
-from ..cameras._perspective import fov_distance_factor
+from ..cameras._perspective import fov_limit, fov_distance_factor
 from ..renderers import Renderer
 from ..utils.viewport import Viewport
 
@@ -303,7 +303,7 @@ class Controller:
         extent = kwargs.get("extent", extent)
         fov = kwargs.get("fov", camera_state.get("fov"))
 
-        distance = fov_distance_factor(fov) * extent
+        distance = fov_distance_factor(fov_limit(fov)) * extent
         return la.vec_transform_quat((0, 0, -distance), rotation)
 
     def _get_camera_vecs(self, rect):
@@ -559,6 +559,7 @@ class Controller:
 
         # Update fov and position
         new_fov = min(max(fov + delta, fov_range[0]), fov_range[1])
+        new_fov = fov_limit(new_fov)
         pos2target1 = self._get_target_vec(cam_state, fov=fov)
         pos2target2 = self._get_target_vec(cam_state, fov=new_fov)
         new_position = position + pos2target1 - pos2target2

--- a/pygfx/controllers/_panzoom.py
+++ b/pygfx/controllers/_panzoom.py
@@ -149,18 +149,10 @@ class PanZoomController(Controller):
             new_height = height / fy
 
         # Get new position
-        if self._cameras and all(
-            max(cam_tuple[0]._fov_range) == 0 for cam_tuple in self._cameras
-        ):
-            # OrthographicCamera's don't need to update their position to zoom, because their fov is fixed to zero.
-            new_position = position
-        else:
-            # If any of the attached cameras can have a fov > 0, even if its fov is currently 0, we should also the position.
-            # For these , setting width/height is also necessary, to set the extent, i.e. the distance to the center.
-            new_extent = 0.5 * (new_width + new_height)
-            pos2target1 = self._get_target_vec(cam_state, extent=extent)
-            pos2target2 = self._get_target_vec(cam_state, extent=new_extent)
-            new_position = position + pos2target1 - pos2target2
+        new_extent = 0.5 * (new_width + new_height)
+        pos2target1 = self._get_target_vec(cam_state, extent=extent)
+        pos2target2 = self._get_target_vec(cam_state, extent=new_extent)
+        new_position = position + pos2target1 - pos2target2
 
         return {
             "width": new_width,


### PR DESCRIPTION
This is a bit of an extension to #1085. I thought that the camera had to move backwards in order to allow a smooth transition when changing the fov, but this is not the case.

So with this PR, a camera with `fov==0` stays at the center of the scene. This has a few advantages:

* Now the `OrthograpicCamera` and `PerspectiveCamera` with `fov == 0` behave the same. (We previously avoided the backwards motion for camera's when `isinstance(camera, OrthograpicCamera)`).
* Zooming out does not push the scene beyond the far clipping plane.
* It also means we can set relatively conservative clipping plane values whgen `fov==0`, which is preferable because the depth precision is linear.

