### PR TITLE
Fix matnx3 fields in uniforms

### DIFF
--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -45,7 +45,7 @@ class Material(Trackable):
 
     uniform_type: ClassVar[dict[str, str]] = dict(
         opacity="f4",
-        clipping_planes="0*4xf4",  # array<vec4<f32>,3>
+        clipping_planes="0*4x3xf4",  # array<vec4<f32>,3>
     )
 
     def __init__(
@@ -176,7 +176,7 @@ class Material(Trackable):
         self._set_size_of_uniform_array("clipping_planes", len(planes2))
         self._store.clipping_plane_count = len(planes2)
         for i in range(len(planes2)):
-            self.uniform_buffer.data["clipping_planes"][i] = planes2[i]
+            self.uniform_buffer.data["clipping_planes"][i, :, 1] = planes2[i]
         self.uniform_buffer.update_full()
 
     @property

--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -45,7 +45,7 @@ class Material(Trackable):
 
     uniform_type: ClassVar[dict[str, str]] = dict(
         opacity="f4",
-        clipping_planes="0*4x3xf4",  # array<vec4<f32>,3>
+        clipping_planes="0*4xf4",  # array<vec4<f32>,3>
     )
 
     def __init__(
@@ -176,7 +176,7 @@ class Material(Trackable):
         self._set_size_of_uniform_array("clipping_planes", len(planes2))
         self._store.clipping_plane_count = len(planes2)
         for i in range(len(planes2)):
-            self.uniform_buffer.data["clipping_planes"][i, :, 1] = planes2[i]
+            self.uniform_buffer.data["clipping_planes"][i] = planes2[i]
         self.uniform_buffer.update_full()
 
     @property

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -727,6 +727,9 @@ class WgpuRenderer(RootEventHandler, Renderer):
         self, camera: Camera, physical_size, logical_size, ndc_offset
     ):
         # Update the stdinfo buffer's data
+        # All matrices need to be transposed, because in WGSL they are column-major.
+        # -> From the numpy p.o.v. the matrices are transposed, in wgsl they are
+        #    upright again because the different interpretation of the memory.
         stdinfo_data = self._shared.uniform_buffer.data
         stdinfo_data["cam_transform"] = camera.world.inverse_matrix.T
         stdinfo_data["cam_transform_inv"] = camera.world.matrix.T

--- a/pygfx/renderers/wgpu/engine/utils.py
+++ b/pygfx/renderers/wgpu/engine/utils.py
@@ -155,7 +155,7 @@ def generate_uniform_struct(dtype_struct, structname):
     # name that starts with '__meta_xx__'
     array_names = []
     mat3_names = []
-    for fieldname in dtype_struct.fields.keys():
+    for fieldname in dtype_struct.names:
         if fieldname.startswith("__meta_"):
             if fieldname.startswith("__meta_array_names__"):
                 array_names.extend(fieldname.replace("__", " ").split()[1:])
@@ -164,6 +164,8 @@ def generate_uniform_struct(dtype_struct, structname):
 
     # Process fields
     for fieldname, (dtype, offset) in dtype_struct.fields.items():
+        # Note that dtype.names is a list of str names, but the dtype.fields also
+        # includes keys for the field titles. We don't use titles, but keep in mind.
         if fieldname.startswith("__"):
             continue
         # Resolve primitive type

--- a/pygfx/renderers/wgpu/shader/bindings.py
+++ b/pygfx/renderers/wgpu/shader/bindings.py
@@ -54,11 +54,11 @@ class BindingDefinitions:
         if isinstance(resource, dict):
             dtype_struct = array_from_shadertype(resource).dtype
         elif isinstance(resource, Buffer):
-            if resource.data.dtype.fields is None:
+            if resource.data.dtype.names is None:
                 raise TypeError("define_uniform() needs a structured dtype")
             dtype_struct = resource.data.dtype
         elif isinstance(resource, np.dtype):
-            if resource.fields is None:
+            if resource.names is None:
                 raise TypeError("define_uniform() needs a structured dtype")
             dtype_struct = resource
         else:

--- a/pygfx/renderers/wgpu/wgsl/clipping_planes.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/clipping_planes.wgsl
@@ -5,12 +5,13 @@ $$ if n_clipping_planes
             let plane = u_material.clipping_planes[i];
             if (dot(varyings.world_pos, plane.xyz) < plane.w) {
                 discard;
-            } 
+            }
         }
     $$ else
         var clipped: bool = true;
         for (var i=0; i<{{ n_clipping_planes }}; i=i+1) {
-            let plane = u_material.clipping_planes[i];
+            let raw = u_material.clipping_planes[i];
+            let plane =vec4f(raw[0].y, raw[1].y, raw[2].y, raw[3].y);
             if (dot(varyings.world_pos, plane.xyz) > plane.w) {
                 clipped = false;
                 break;  //at least one plane is outside, so we can keep the fragment

--- a/pygfx/renderers/wgpu/wgsl/clipping_planes.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/clipping_planes.wgsl
@@ -10,8 +10,7 @@ $$ if n_clipping_planes
     $$ else
         var clipped: bool = true;
         for (var i=0; i<{{ n_clipping_planes }}; i=i+1) {
-            let raw = u_material.clipping_planes[i];
-            let plane =vec4f(raw[0].y, raw[1].y, raw[2].y, raw[3].y);
+            let plane = u_material.clipping_planes[i];
             if (dot(varyings.world_pos, plane.xyz) > plane.w) {
                 clipped = false;
                 break;  //at least one plane is outside, so we can keep the fragment

--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -74,10 +74,10 @@ def array_from_shadertype(shadertype, count=None):
     The fields are re-ordered and padded as necessary to fulfil alignment rules.
     See https://www.w3.org/TR/WGSL/#structure-layout-rules
 
-    A note on matrices (e.g. "4x4xf4" or "2x3xf4"): from the Python side, the
-    matrices in a uniform array are transposed, and nx3 matrices are actually nx4.
+    A note on matrices (e.g. "4x4xf4" or "2x3xf4"): from the perspective of Python,
+    the matrices in a uniform array are transposed, and nx3 matrices are actually nx4.
 
-    To deal with this, setting a matrix in a uniform:
+    To deal with this, setting a matrix in a uniform goes like this:
 
         uniform.data["a_matrix"] = numpy_array.T
         uniform.data["an_nx3_matrix"][:, :3] = numpy_array.T
@@ -85,7 +85,7 @@ def array_from_shadertype(shadertype, count=None):
     The reason is that WGSL matrices are column-major, while Numpy arrays are
     row-major (i.e. C-order) by default. Although numpy does support
     column-major arrays (F-order), it looks like we cannot apply this to the
-    sub-arrays in the uniform struct. Ad for the nx3 matrices, WGSL's alignment
+    sub-arrays in the uniform struct. And for the nx3 matrices, WGSL's alignment
     constraint requires padding for each column in an nx3 matrix, so it takes up
     the same space as an nx4 matrix.
 

--- a/tests/utils/test_array_from_shadertype.py
+++ b/tests/utils/test_array_from_shadertype.py
@@ -8,7 +8,7 @@ def test_array_from_shadertype_scalar():
         bar="f4",
     )
     a = array_from_shadertype(d)
-    assert a.dtype.names == ("foo", "bar", "__")
+    assert a.dtype.names == ("foo", "bar")
     assert a.nbytes == 8  # 4 + 4
 
     # Order is preserved
@@ -17,7 +17,7 @@ def test_array_from_shadertype_scalar():
         foo="f4",
     )
     a = array_from_shadertype(d)
-    assert a.dtype.names == ("bar", "foo", "__")
+    assert a.dtype.names == ("bar", "foo")
     assert a.nbytes == 8  # 4 + 4
 
 
@@ -28,7 +28,7 @@ def test_array_from_shadertype_vec2():
         bar="f4",
     )
     a = array_from_shadertype(d)
-    assert a.dtype.names == ("foo", "bar", "__padding1", "__")
+    assert a.dtype.names == ("foo", "bar", "__padding1")
     assert a.nbytes == 16  # 8 + 4 + padding to 8
 
     # Order is based on alignment
@@ -37,7 +37,7 @@ def test_array_from_shadertype_vec2():
         foo="2xf4",
     )
     a = array_from_shadertype(d)
-    assert a.dtype.names == ("foo", "bar", "__padding1", "__")
+    assert a.dtype.names == ("foo", "bar", "__padding1")
     assert a.nbytes == 16  # 8 + 4 + padding to 8
 
 
@@ -48,7 +48,7 @@ def test_array_from_shadertype_vec3():
         bar="f4",
     )
     a = array_from_shadertype(d)
-    assert a.dtype.names == ("foo", "bar", "__")
+    assert a.dtype.names == ("foo", "bar")
     assert a.nbytes == 16  # 12 + 4
 
     # The float will be hoisted up to fill the gap.
@@ -59,7 +59,7 @@ def test_array_from_shadertype_vec3():
         bar="f4",
     )
     a = array_from_shadertype(d)
-    assert a.dtype.names == ("foo1", "bar", "foo2", "__padding1", "__")
+    assert a.dtype.names == ("foo1", "bar", "foo2", "__padding1")
     assert a.nbytes == 32  # 12 + 12 + 4 + padding to 16
 
     # But in this case it does: no padding!
@@ -70,7 +70,7 @@ def test_array_from_shadertype_vec3():
         bar2="f4",
     )
     a = array_from_shadertype(d)
-    assert a.dtype.names == ("foo1", "bar1", "foo2", "bar2", "__")
+    assert a.dtype.names == ("foo1", "bar1", "foo2", "bar2")
     assert a.nbytes == 32  # 12 + 12 + 4 + 4
 
     # With nothing to fill it up, uses padding
@@ -79,7 +79,7 @@ def test_array_from_shadertype_vec3():
         foo2="3xf4",
     )
     a = array_from_shadertype(d)
-    assert a.dtype.names == ("foo1", "__padding1", "foo2", "__padding2", "__")
+    assert a.dtype.names == ("foo1", "__padding1", "foo2", "__padding2")
     assert a.nbytes == 32  # 12 + 4 + 12 + 4
 
 
@@ -89,7 +89,7 @@ def test_array_from_shadertype_mat2():
         foo="3x2xf4",
     )
     a = array_from_shadertype(d)
-    assert a.dtype.names == ("foo", "__")
+    assert a.dtype.names == ("foo",)
     assert a.nbytes == 24  # padded to 8
 
     # A nx2-mat has alignment 8
@@ -98,7 +98,7 @@ def test_array_from_shadertype_mat2():
         bar="f4",
     )
     a = array_from_shadertype(d)
-    assert a.dtype.names == ("foo", "bar", "__padding1", "__")
+    assert a.dtype.names == ("foo", "bar", "__padding1")
     assert a.nbytes == 32  #  + 24 + 4 + padding to 8
 
 
@@ -108,7 +108,7 @@ def test_array_from_shadertype_mat3():
         foo="2x3xf4",
     )
     a = array_from_shadertype(d)
-    assert a.dtype.names == ("foo", "__padding1", "__")
+    assert a.dtype.names == ("foo", "__meta_mat3_names__foo")
     assert a.nbytes == 32  # 24 + pad to 16
 
     # These also *needs* internal padding.
@@ -116,7 +116,7 @@ def test_array_from_shadertype_mat3():
     # So that bar-field cannot be used to fill the gap, like we did for vec3.
     d = dict(foo="3x3xf4", bar="f4")
     a = array_from_shadertype(d)
-    assert a.dtype.names == ("foo", "__padding1", "bar", "__padding2", "__")
+    assert a.dtype.names == ("foo", "bar", "__padding1", "__meta_mat3_names__foo")
     assert a.nbytes == 64  # 36 + 12 internal padding + 4 + pad to 16
 
 


### PR DESCRIPTION
Fixes a few bugs introduced in #1091

* The padding of an nx3 matrix is not at the end, but 4 bytes after each column, i.e. a mat nx3 is actually stored as an nx4 matrix.
* Also fixed the shape of the array (it should not be reversed).

For clarity, I here repeat an explanation that I also included in the code:

    A note on matrices (e.g. "4x4xf4" or "2x3xf4"): from the perspective of Python,
    the matrices in a uniform array are transposed, and nx3 matrices are actually nx4.

    To deal with this, setting a matrix in a uniform goes like this:

        uniform.data["a_matrix"] = numpy_array.T
        uniform.data["an_nx3_matrix"][:, :3] = numpy_array.T

    The reason is that WGSL matrices are column-major, while Numpy arrays are
    row-major (i.e. C-order) by default. Although numpy does support
    column-major arrays (F-order), it looks like we cannot apply this to the
    sub-arrays in the uniform struct. And for the nx3 matrices, WGSL's alignment
    constraint requires padding for each column in an nx3 matrix, so it takes up
    the same space as an nx4 matrix.
