### PR TITLE
Migrate to `logger.warning`

### DIFF
--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -62,7 +62,7 @@ def _set_log_level():
             else:
                 logger.setLevel(level.upper())
         except Exception:
-            logger.warn(f"Invalid pygfx log level: {level}")
+            logger.warning(f"Invalid pygfx log level: {level}")
 
 
 _set_log_level()


### PR DESCRIPTION
# PR Summary
This small PR migrates from the deprecated `logger.warn` to the recommended `logger.warning` method.