### PR TITLE
Render lines using SDF

### DIFF
--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -99,6 +99,8 @@ class LineShader(BaseShader):
         # ):
         #     # self["line_type"] = "quickline"
 
+        self["quickline"] = False
+
         # Handle looping. The line_loop_buffer is one larger to enable looping the last point.
         if material.loop:
             self["loop"] = True
@@ -300,15 +302,17 @@ class LineShader(BaseShader):
         }
 
     def get_pipeline_info(self, wobject, shared):
+        # Note: making quads using triangle_strip and 6 verts, with degenerate triangles is apparently
+        # much faster than using triangle_list with 6 verts.
         return {
-            "primitive_topology": wgpu.PrimitiveTopology.triangle_list,
+            "primitive_topology": wgpu.PrimitiveTopology.triangle_strip,
             "cull_mode": wgpu.CullMode.none,
         }
 
     def _get_n(self, positions):
         offset, size = positions.draw_range
-        if self["loop"]:
-            size += 1
+        if not self["loop"]:
+            size -= 1
         return offset * 6, size * 6
 
     def get_render_info(self, wobject, shared):

--- a/pygfx/renderers/wgpu/wgsl/line2.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/line2.wgsl
@@ -1,4 +1,7 @@
 
+//
+//  x===========x===========x=========x
+//  1           2           3         4
 
 {# Includes #}
 {$ include 'pygfx.std.wgsl' $}
@@ -67,6 +70,47 @@ fn project_point_to_edge_ndc(point1: vec4f, point2: vec4f, can_move_backwards: b
 }
 
 
+fn get_line_radius(pos_s: vec2f, l2p: f32) -> f32 {
+    // The thickness of the line in terms of geometry is a wee bit thicker.
+    // Just enough so that fragments that are partially on the line, are also included
+    // in the fragment shader. That way we can do aa without making the lines thinner.
+    // All logic in this function works with the ticker line width. But we pass the real line width as a varying.
+    $$ if thickness_space == 'screen'
+        let thickness_ratio = 1.0;
+    $$ else
+        // The thickness is expressed in world space. So we first check where a point, moved shift_factor logic pixels away
+        // from the node, ends up in world space. We actually do that for both x and y, in case there's anisotropy.
+        // The shift_factor was added to alleviate issues with the point jitter when the user zooms in
+        // See https://github.com/pygfx/pygfx/issues/698
+        // and https://github.com/pygfx/pygfx/pull/706/files
+        let shift_factor = 1000.0;
+        let pos_s_node_shiftedx = pos_s + vec2<f32>(shift_factor, 0.0);
+        let pos_s_node_shiftedy = pos_s + vec2<f32>(shift_factor, 1.0);
+        let pos_n_node_shiftedx = vec4<f32>((pos_s_node_shiftedx / screen_factor - 1.0) * pos_n_2.w, pos_n_2.z, pos_n_2.w);
+        let pos_n_node_shiftedy = vec4<f32>((pos_s_node_shiftedy / screen_factor - 1.0) * pos_n_2.w, pos_n_2.z, pos_n_2.w);
+        let pos_w_node_shiftedx = u_stdinfo.cam_transform_inv * u_stdinfo.projection_transform_inv * pos_n_node_shiftedx;
+        let pos_w_node_shiftedy = u_stdinfo.cam_transform_inv * u_stdinfo.projection_transform_inv * pos_n_node_shiftedy;
+        $$ if thickness_space == 'model'
+            // Transform back to model space
+            let pos_m_node_shiftedx = u_stdinfo.world_transform_inv * pos_w_node_shiftedx;
+            let pos_m_node_shiftedy = u_stdinfo.world_transform_inv * pos_w_node_shiftedy;
+            // Distance in model space
+            let thickness_ratio = (1.0 / shift_factor) * 0.5 * (distance(pos_m_2.xyz, pos_m_node_shiftedx.xyz) + distance(pos_m_2.xyz, pos_m_node_shiftedy.xyz));
+        $$ else
+            // Distance in world space
+            let thickness_ratio = (1.0 / shift_factor) * 0.5 * (distance(pos_w_2.xyz, pos_w_node_shiftedx.xyz) + distance(pos_w_2.xyz, pos_w_node_shiftedy.xyz));
+        $$ endif
+    $$ endif
+    let min_size_for_pixel = 1.415 / l2p;  // For minimum pixel coverage. Use sqrt(2) to take diagonals into account.
+    $$ if aa
+    let thickness:f32 = u_material.thickness / thickness_ratio;  // Logical pixels
+    let half_thickness = 0.5 * max(min_size_for_pixel, thickness + 1.0 / l2p);  // add 0.5 physical pixel on each side.
+    $$ else
+    let thickness:f32 = max(min_size_for_pixel, u_material.thickness / thickness_ratio);  // non-aa lines get no thinner than 1 px
+    let half_thickness = 0.5 * thickness;
+    $$ endif
+    return half_thickness;
+}
 // -------------------- vertex shader --------------------
 
 
@@ -105,14 +149,16 @@ fn vs_main(in: VertexInput) -> Varyings {
 
     // Indexing
     let index = i32(in.index);
-    var node_index1 = index / 6;
+    let face_index = index / 6;
     let vertex_index = index % 6;
-    let vertex_num = vertex_index + 1;
-    var face_index = node_index1;  // corrected below if necessary, depending on configuration
-    let node_index_is_even = node_index1 % 2 == 0;
 
-    var node_index2 = min(u_renderer.last_i, node_index1 + 1);
-    var node_index3 = min(u_renderer.last_i, node_index1 + 2);
+    var node_index1 = face_index - 1;
+    let node_index2 = face_index;
+    let node_index3 = face_index + 1;
+    var node_index4 = face_index + 2;
+
+    // var node_index2 = min(u_renderer.last_i, node_index1 + 1);
+    // var node_index3 = min(u_renderer.last_i, node_index1 + 2);
 
     $$ if loop
     var is_first_node_in_loop = false;
@@ -139,25 +185,37 @@ fn vs_main(in: VertexInput) -> Varyings {
 
     // Sample the current node and it's two neighbours. Model coords.
     // Note that if we sample out of bounds, this affects the shader in mysterious ways (21-12-2021).
-    var pos_m_1 = load_s_positions(node_index1);
     var pos_m_2 = load_s_positions(node_index2);
     var pos_m_3 = load_s_positions(node_index3);
+    $$ if not quickline
+    var pos_m_1 = load_s_positions(node_index1);
+    var pos_m_4 = load_s_positions(node_index4);
+    $$ endif
+
     // Convert to world
-    var pos_w_1 = world_transform * vec4<f32>(pos_m_1.xyz, 1.0);
     var pos_w_2 = world_transform * vec4<f32>(pos_m_2.xyz, 1.0);
     var pos_w_3 = world_transform * vec4<f32>(pos_m_3.xyz, 1.0);
     // Convert to camera view
-    var pos_c_1 = u_stdinfo.cam_transform * pos_w_1;
     var pos_c_2 = u_stdinfo.cam_transform * pos_w_2;
     var pos_c_3 = u_stdinfo.cam_transform * pos_w_3;
     // convert to NDC
-    var pos_n_1 = u_stdinfo.projection_transform * pos_c_1;
     var pos_n_2 = u_stdinfo.projection_transform * pos_c_2;
     var pos_n_3 = u_stdinfo.projection_transform * pos_c_3;
     // Convert to logical screen coordinates, because that's where the lines work
-    var pos_s_1 = (pos_n_1.xy / pos_n_1.w + 1.0) * screen_factor;
     var pos_s_2 = (pos_n_2.xy / pos_n_2.w + 1.0) * screen_factor;
     var pos_s_3 = (pos_n_3.xy / pos_n_3.w + 1.0) * screen_factor;
+
+    // Same for outer nodes
+    $$ if not quickline
+    var pos_w_1 = world_transform * vec4<f32>(pos_m_1.xyz, 1.0);
+    var pos_w_4 = world_transform * vec4<f32>(pos_m_4.xyz, 1.0);
+    var pos_c_1 = u_stdinfo.cam_transform * pos_w_1;
+    var pos_c_4 = u_stdinfo.cam_transform * pos_w_4;
+    var pos_n_1 = u_stdinfo.projection_transform * pos_c_1;
+    var pos_n_4 = u_stdinfo.projection_transform * pos_c_4;
+    var pos_s_1 = (pos_n_1.xy / pos_n_1.w + 1.0) * screen_factor;
+    var pos_s_4 = (pos_n_4.xy / pos_n_4.w + 1.0) * screen_factor;
+    $$ endif
 
     $$ if line_type == 'infsegment'
     let can_move_backwards = {{ 'true' if (start_is_infinite and end_is_infinite) else 'false' }};
@@ -196,88 +254,53 @@ fn vs_main(in: VertexInput) -> Varyings {
     $$ endif
     $$ endif
 
-     // The thickness of the line in terms of geometry is a wee bit thicker.
-    // Just enough so that fragments that are partially on the line, are also included
-    // in the fragment shader. That way we can do aa without making the lines thinner.
-    // All logic in this function works with the ticker line width. But we pass the real line width as a varying.
-    $$ if thickness_space == 'screen'
-        let thickness_ratio = 1.0;
-    $$ else
-        // The thickness is expressed in world space. So we first check where a point, moved shift_factor logic pixels away
-        // from the node, ends up in world space. We actually do that for both x and y, in case there's anisotropy.
-        // The shift_factor was added to alleviate issues with the point jitter when the user zooms in
-        // See https://github.com/pygfx/pygfx/issues/698
-        // and https://github.com/pygfx/pygfx/pull/706/files
-        let shift_factor = 1000.0;
-        let pos_s_node_shiftedx = pos_s_2 + vec2<f32>(shift_factor, 0.0);
-        let pos_s_node_shiftedy = pos_s_2 + vec2<f32>(shift_factor, 1.0);
-        let pos_n_node_shiftedx = vec4<f32>((pos_s_node_shiftedx / screen_factor - 1.0) * pos_n_2.w, pos_n_2.z, pos_n_2.w);
-        let pos_n_node_shiftedy = vec4<f32>((pos_s_node_shiftedy / screen_factor - 1.0) * pos_n_2.w, pos_n_2.z, pos_n_2.w);
-        let pos_w_node_shiftedx = u_stdinfo.cam_transform_inv * u_stdinfo.projection_transform_inv * pos_n_node_shiftedx;
-        let pos_w_node_shiftedy = u_stdinfo.cam_transform_inv * u_stdinfo.projection_transform_inv * pos_n_node_shiftedy;
-        $$ if thickness_space == 'model'
-            // Transform back to model space
-            let pos_m_node_shiftedx = world_transform_inv * pos_w_node_shiftedx;
-            let pos_m_node_shiftedy = world_transform_inv * pos_w_node_shiftedy;
-            // Distance in model space
-            let thickness_ratio = (1.0 / shift_factor) * 0.5 * (distance(pos_m_2.xyz, pos_m_node_shiftedx.xyz) + distance(pos_m_2.xyz, pos_m_node_shiftedy.xyz));
-        $$ else
-            // Distance in world space
-            let thickness_ratio = (1.0 / shift_factor) * 0.5 * (distance(pos_w_2.xyz, pos_w_node_shiftedx.xyz) + distance(pos_w_2.xyz, pos_w_node_shiftedy.xyz));
-        $$ endif
-    $$ endif
-    let min_size_for_pixel = 1.415 / l2p;  // For minimum pixel coverage. Use sqrt(2) to take diagonals into account.
-    $$ if aa
-    let thickness:f32 = u_material.thickness / thickness_ratio;  // Logical pixels
-    let half_thickness = 0.5 * max(min_size_for_pixel, thickness + 1.0 / l2p);  // add 0.5 physical pixel on each side.
-    $$ else
-    let thickness:f32 = max(min_size_for_pixel, u_material.thickness / thickness_ratio);  // non-aa lines get no thinner than 1 px
-    let half_thickness = 0.5 * thickness;
+    // Get radii
+    let radius2 = get_line_radius(pos_s_2, l2p);
+    let radius3 = get_line_radius(pos_s_3, l2p);
+    $$ if not quickline
+    let radius1 = get_line_radius(pos_s_1, l2p);
+    let radius4 = get_line_radius(pos_s_4, l2p);
     $$ endif
 
     // Get vectors representing the two incident line segments (screen coords)
-    var vec_s_prev: vec2<f32> = pos_s_2.xy - pos_s_1.xy;  // from node 1 (to node 2)
-    var vec_s_next: vec2<f32> = pos_s_3.xy - pos_s_2.xy;  // to node 3 (from node 2)
+    var vec_s_23: vec2<f32> = pos_s_3.xy - pos_s_2.xy;  // current segment
+    $$ if not quickline
+    var vec_s_12: vec2<f32> = pos_s_2.xy - pos_s_1.xy;  // segment before
+    var vec_s_34: vec2<f32> = pos_s_4.xy - pos_s_3.xy;  // segment after
+    $$ endif
 
     // Calculate interpolation ratio.
     // Get ratio in screen space, and then correct for perspective.
     // I derived this step by calculating the new w from the ratio, and then substituting terms.
-    let ratio_divisor = length(pos_n_1 - pos_n_2);
+    let ratio_divisor = length(pos_n_3 - pos_n_2);
     let offset_ratio = -1.0;
-    var ratio_interp = offset_ratio * half_thickness / ratio_divisor;
+    var ratio_interp = offset_ratio * radius2 / ratio_divisor;
     ratio_interp = select(ratio_interp, 0.0, ratio_divisor==0.0);  // prevent inf
-    ratio_interp = (1.0 - ratio_interp) * ratio_interp * pos_n_1.w / pos_n_2.w + ratio_interp * ratio_interp;
+    ratio_interp = (1.0 - ratio_interp) * ratio_interp * pos_n_2.w / pos_n_3.w + ratio_interp * ratio_interp;
 
+    let z = mix(pos_n_2.z, pos_n_3.z, ratio_interp);
+    let w = mix(pos_n_3.w, pos_n_3.w, ratio_interp);
 
-    let z = mix(pos_n_1.z, pos_n_2.z, ratio_interp);
-    let w = mix(pos_n_1.w, pos_n_2.w, ratio_interp);
-
-    let hlw_indir_line = normalize(vec_s_prev) * half_thickness;
+    let hlw_indir_line = normalize(vec_s_23);
     let hlw_ortog_line = vec2f(- hlw_indir_line.y, hlw_indir_line.x);
 
+    // let quad1 = pos_s_2.xy + radius2 * (- hlw_indir_line  - hlw_ortog_line);
+    // let quad2 = pos_s_2.xy + radius2 * (- hlw_indir_line  + hlw_ortog_line);
+    // let quad3 = pos_s_3.xy + radius3 * (  hlw_indir_line  - hlw_ortog_line);
+    // let quad4 = pos_s_3.xy + radius3 * (  hlw_indir_line  + hlw_ortog_line);
 
-    let quad1 = pos_s_1.xy - hlw_indir_line  - hlw_ortog_line;
-    let quad2 = pos_s_1.xy - hlw_indir_line  + hlw_ortog_line;
-    let quad3 = pos_s_2.xy + hlw_indir_line  - hlw_ortog_line;
-    let quad4 = pos_s_2.xy + hlw_indir_line  + hlw_ortog_line;
+    var the_pos_s: vec2f;
 
-    var the_coord: vec2f;
-
-    if (vertex_index < 3) {
-        if vertex_index == 0 { the_coord = quad2; }
-        if vertex_index == 1 { the_coord = quad3; }
-        if vertex_index == 2 { the_coord = quad1; }
+     if (vertex_index < 3) {
+        if vertex_index < 2 {   the_pos_s = pos_s_2.xy + radius2 * (- hlw_indir_line  - hlw_ortog_line); } // quad1
+        else {                  the_pos_s = pos_s_2.xy + radius2 * (- hlw_indir_line  + hlw_ortog_line); }  // quad2
     } else {
-        if vertex_index == 3 { the_coord = quad2; }
-        if vertex_index == 4 { the_coord = quad4; }
-        if vertex_index == 5 { the_coord = quad3; }
+        if vertex_index == 3 {  the_pos_s = pos_s_3.xy + radius3 * (  hlw_indir_line  - hlw_ortog_line); }  // quad3
+        else {                  the_pos_s = pos_s_3.xy + radius3 * (  hlw_indir_line  + hlw_ortog_line); }  // quad4
     }
 
     // Calculate vertex position in NDC.The z and w are inter/extra-polated.
-    let the_pos_s = the_coord;
     var the_pos_n = vec4<f32>((the_pos_s / screen_factor - 1.0) * w, z, w);
-
-
 
     // Build varyings output
     var varyings: Varyings;
@@ -285,13 +308,22 @@ fn vs_main(in: VertexInput) -> Varyings {
     // Position
     varyings.position = vec4<f32>(the_pos_n);
     varyings.world_pos = vec3<f32>(ndc_to_world_pos(the_pos_n));
+
     varyings.sdf_pos = vec2<f32>(the_pos_s) * l2p;  /// simply physical screen pos
-    varyings.segment_cur = vec4<f32>(pos_s_1, pos_s_2) * l2p;
-    varyings.segment_next = vec4<f32>(pos_s_2, pos_s_3) * l2p;
+    varyings.pos2 = vec2<f32>(pos_s_2) * l2p;
+    varyings.pos3 = vec2<f32>(pos_s_3) * l2p;
+    $$ if not quickline
+    varyings.pos1 = vec2<f32>(pos_s_1) * l2p;
+    varyings.pos4 = vec2<f32>(pos_s_4) * l2p;
+    $$ else
+    // varyings.pos1 = vec2<f32>(pos_s_2) * l2p;
+    // varyings.pos4 = vec2<f32>(pos_s_3) * l2p;
+    $$ endif
 
     //  Thickness and segment coord. These are corrected for perspective, otherwise the dashes are malformed in 3D.
     varyings.w = f32(w);
-    varyings.thickness_pw = f32(thickness * l2p * w);  // the real thickness, in physical coords
+    varyings.thickness_pw = f32(radius2 * l2p * w);  // the real thickness, in physical coords
+
     //varyings.segment_coord_pw = vec2<f32>(the_coord * half_thickness * l2p * w);  // uses a slightly wider thickness
     // Coords related to joins
     //varyings.join_coord = f32(join_coord);
@@ -314,7 +346,7 @@ fn vs_main(in: VertexInput) -> Varyings {
     // Picking
     // Note: in theory, we can store ints up to 16_777_216 in f32,
     // but in practice, its about 4_000_000 for f32 varyings (in my tests).
-    // We use a real u32 to not lose presision, see frag shader for details.
+    // We use a real u32 to not lose precision, see frag shader for details.
     varyings.pick_idx = u32(node_index);
     varyings.pick_zigzag = f32(node_index_is_even);
 
@@ -364,6 +396,7 @@ fn vs_main(in: VertexInput) -> Varyings {
     return varyings;
 }
 
+// https://iquilezles.org/articles/distfunctions2d/
 
 fn sdSegment(p: vec2f, a: vec2f, b: vec2f ) -> f32
 {
@@ -390,26 +423,71 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
 
     // Get the half-thickness in physical coordinates. This is the reference thickness.
     // If aa is used, the line is actually a bit thicker, leaving space to do aa.
-    let half_thickness_p = 0.5 * varyings.thickness_pw / varyings.w;
+    let radius = varyings.thickness_pw / varyings.w;
+
+    let sdf_pos = varyings.sdf_pos;
 
 
-    let dist1 = sdSegment(varyings.sdf_pos, varyings.segment_cur.xy, varyings.segment_cur.zw);
+    $$ if quickline
 
-    // TODO: above dist is in logical
-    if (dist1 > half_thickness_p) {
+    let dist_curr = sdSegment(sdf_pos, varyings.pos2, varyings.pos3);
+    if (dist_curr > radius) {
         discard;
     }
 
-    let dist2 = sdSegment(varyings.sdf_pos, varyings.segment_next.xy, varyings.segment_next.zw);
+    $$ else
 
-    if (dist2 < half_thickness_p) {
+    let dist_prev = sdSegment(sdf_pos, varyings.pos1, varyings.pos2);
+    let dist_curr = sdSegment(sdf_pos, varyings.pos2, varyings.pos3);
+    let dist_next = sdSegment(sdf_pos, varyings.pos3, varyings.pos4);
+
+    let ref_len = 0.5 * length(varyings.pos2 - varyings.pos3);
+    let ref_cur = 0.5 * (varyings.pos2 + varyings.pos3);
+    let ref_prev = varyings.pos2 + normalize(varyings.pos1 - varyings.pos2) * ref_len;
+    let ref_next = varyings.pos3 + normalize(varyings.pos4 - varyings.pos3) * ref_len;
+
+
+    // Drop fragment if its already covered by next one
+    //if (dist_curr > radius || dist_next < radius ) {
+    let refdist_cur = distance(sdf_pos, ref_cur);
+    let refdist_prev = distance(sdf_pos, ref_prev);
+    let refdist_next = distance(sdf_pos, ref_next);
+
+    if (dist_curr > radius || refdist_cur > refdist_prev || refdist_cur > refdist_next ) {
         discard;
     }
 
+    $$ endif
 
-    let color = u_material.color;
 
+    // Determine srgb color
+    $$ if color_mode == 'vertex'
+        var color = varyings.color_vert;
+        if (is_join) {
+            let color_segment = varyings.color_node - (varyings.color_node - varyings.color_vert) / (1.0 - abs(join_coord_lin));
+            color = mix(color_segment, varyings.color_node, abs(join_coord_fan));
+        }
+    $$ elif color_mode == 'face'
+        let color = varyings.color_vert;
+    $$ elif color_mode == 'vertex_map'
+        var texcoord = varyings.texcoord_vert;
+        if (is_join) {
+            let texcoord_segment = varyings.texcoord_node - (varyings.texcoord_node - varyings.texcoord_vert) / (1.0 - abs(join_coord_lin));
+            texcoord = mix(texcoord_segment, varyings.texcoord_node, abs(join_coord_fan));
+        }
+        let color = sample_colormap(texcoord);
+    $$ elif color_mode == 'face_map'
+        let color = sample_colormap(varyings.texcoord_vert);
+    $$ else
+        let color = u_material.color;
+    $$ endif
     var physical_color = srgb2physical(color.rgb);
+
+    $$ if false
+        // Alternative debug options during dev.
+        physical_color = vec3<f32>(abs(dist_to_dash_p) / 20.0, 0.0, 0.0);
+    $$ endif
+
 
     let alpha = 1.0;
     // Determine final rgba value


### PR DESCRIPTION
## Problem I try to solve

When rendering a semi-transparent line, relatively sharp corners result in 'brighter' parts because there is overlap:

<img width="639" alt="image" src="https://github.com/user-attachments/assets/495a5d60-33d7-4298-8d00-ee34872568c7" />

This happens, because at some angle, the vertices can no longer be placed so that the line is continuous. What angle this is, depends on the length of the two segments and the line width. When the angle is two small, it 'breaks' the line causing overlap.

## The idea of the approach of this PR

The idea is to render each line segment as a separate quad, using an SDF. But within each quad, the fragment shader calculates the sdf for the current as well as the *next*  line segment. It will then subtract the color/alpha of the next fragment from the current color, so that the final result shows no overlap. The cool thing is that we can also make it look 2 segments further and/or turn the overlap on 'smoothly'.


## State of this PR

For now this is a POC that demonstrates that the basic idea works:

<img width="569" alt="image" src="https://github.com/user-attachments/assets/43782255-9e98-456a-9e9b-327ecf4167d9" />

But I have ignored per-vertex colors, texcoords, dashing, loops, and probably more.

## Moving forward

I think the first next step is making sure this can work with colors and texcoords. If it does, this approach is viable IMO. Next up would be fixing the caps and loops (but I see no issues there).

As for dashing, I kindof hope we can use SDF trickeries for that as well, but I'm not sure yet whether this is possible. If not, or if it's hard and we want to postpone that, we use fall back to the old approach when there is dashing. 

One big advantage of this approach, if it can be made to work, is that it's actually quite simple as it has much less 'geometry-juggling' than the current implementation.

cc @hmaarrfk @kingbedjed @claydugo 