### PR TITLE
Promote the use of VolumeMipMaterial instead of the VolumeRayMaterial base class

### DIFF
--- a/examples/feature_demo/volume_render1.py
+++ b/examples/feature_demo/volume_render1.py
@@ -24,7 +24,7 @@ voldata = iio.imread("imageio:stent.npz").astype(np.float32)
 tex = gfx.Texture(voldata, dim=3)
 vol = gfx.Volume(
     gfx.Geometry(grid=tex),
-    gfx.VolumeRayMaterial(clim=(0, 2000), map=gfx.cm.cividis, pick_write=True),
+    gfx.VolumeMipMaterial(clim=(0, 2000), map=gfx.cm.cividis, pick_write=True),
 )
 slice = gfx.Volume(
     gfx.Geometry(grid=tex),

--- a/examples/feature_demo/volume_render2.py
+++ b/examples/feature_demo/volume_render2.py
@@ -22,7 +22,7 @@ scene = gfx.Scene()
 voldata = iio.imread("imageio:stent.npz").astype(np.float32)
 
 geometry = gfx.Geometry(grid=voldata)
-material = gfx.VolumeRayMaterial(clim=(0, 2000))
+material = gfx.VolumeMipMaterial(clim=(0, 2000))
 
 vol1 = gfx.Volume(geometry, material)
 vol2 = gfx.Volume(geometry, material)

--- a/examples/feature_demo/world_bounding_box.py
+++ b/examples/feature_demo/world_bounding_box.py
@@ -24,7 +24,7 @@ voldata = iio.imread("imageio:stent.npz").astype(np.float32)
 
 geometry = gfx.Geometry(grid=voldata)
 geometry_with_texture = gfx.Geometry(grid=gfx.Texture(data=voldata, dim=3))
-material = gfx.VolumeRayMaterial(clim=(0, 2000))
+material = gfx.VolumeMipMaterial(clim=(0, 2000))
 
 vol1 = gfx.Volume(geometry, material)
 vol2 = gfx.Volume(geometry_with_texture, material)

--- a/examples/validation/validate_volume.py
+++ b/examples/validation/validate_volume.py
@@ -43,7 +43,7 @@ box2 = gfx.Mesh(
 
 # In scene1 we show a raycasted volume
 scene1 = gfx.Scene()
-vol = gfx.Volume(geo, gfx.VolumeRayMaterial(clim=(0, 2000)))
+vol = gfx.Volume(geo, gfx.VolumeMipMaterial(clim=(0, 2000)))
 vol.local.position = (-1, -1, -1)
 scene1.add(vol, box1)
 

--- a/pygfx/materials/_volume.py
+++ b/pygfx/materials/_volume.py
@@ -130,14 +130,15 @@ class VolumeSliceMaterial(VolumeBasicMaterial):
 
 
 class VolumeRayMaterial(VolumeBasicMaterial):
-    """A material for rendering volumes using raycasting."""
+    """The base class for materials that render volumes using raycasting."""
 
-    # todo: define render modes as material subclasses or using a `mode` or `style` property?
-    render_mode = "mip"
+    render_mode = None  # to be set by the subclasses
 
 
 class VolumeMipMaterial(VolumeRayMaterial):
     """A material rendering a volume using MIP rendering."""
+
+    render_mode = "mip"
 
 
 class VolumeMinipMaterial(VolumeRayMaterial):

--- a/pygfx/renderers/wgpu/shaders/volumeshader.py
+++ b/pygfx/renderers/wgpu/shaders/volumeshader.py
@@ -128,7 +128,17 @@ class VolumeRayShader(BaseVolumeShader):
     type = "render"
 
     def get_bindings(self, wobject, shared):
-        self["mode"] = wobject.material.render_mode
+        render_mode = wobject.material.render_mode
+
+        # Fall back to MIP, because we've written our examples to use the plain VolumeRayMaterial for quite a while.
+        # Deprecate / remove this after a few releases (now is june 2025)
+        render_mode = render_mode or "mip"
+
+        if not render_mode:
+            raise RuntimeError(
+                f"Invalid value for {wobject.material.__class__.__name__}.render_mode: {render_mode!r}. Use an appropriate volume material, e.g. VolumeMipMaterial or VolumeIsoMaterial."
+            )
+        self["mode"] = render_mode
         return super().get_bindings(wobject, shared)
 
     def get_pipeline_info(self, wobject, shared):

--- a/pygfx/renderers/wgpu/wgsl/volume_ray.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/volume_ray.wgsl
@@ -381,4 +381,10 @@ $$ elif mode == 'iso'
         return out;
     }
 
+$$ else
+    fn raycast(sizef: vec3<f32>, nsteps: i32, start_coord: vec3<f32>, step_coord: vec3<f32>) -> RenderOutput {
+        {{ mode }}__is_not_a_valid_render_mode();
+        var out: RenderOutput;
+        return out;
+    }
 $$ endif

--- a/pygfx/utils/load.py
+++ b/pygfx/utils/load.py
@@ -557,7 +557,7 @@ def _volume_from_voxelgrid(vxl, cmap=None, clim="data"):
     # Initialize the volume
     vol = gfx.Volume(
         gfx.Geometry(grid=tex),
-        gfx.VolumeRayMaterial(clim=clim, map=cmap),
+        gfx.VolumeMipMaterial(clim=clim, map=cmap),
     )
 
     # Apply transform


### PR DESCRIPTION
Closes #1105

* Document that `VolumeRayMaterial` is a base class.
* Update examples to not use that material.
* Update the shader to error when it's used, but for the time being just fall back to mip.
* Update the wgsl so that if a subclass of `VolumeRayMaterial` defines an unknown render mode, this results in a sensible error.