### PR TITLE
Add support for custom orbit center in OrbitController

### DIFF
--- a/pygfx/controllers/_orbit.py
+++ b/pygfx/controllers/_orbit.py
@@ -22,6 +22,14 @@ class OrbitController(PanZoomController):
 
     Supports panning parallel to the screen, zooming, orbiting.
 
+    Parameters
+    ----------
+    target : tuple of float, optional
+        The custom target position (x, y, z) that the camera orbits around.
+        Default is None, which means the target is determined from the camera state.
+
+    Notes
+    -----
     The direction of rotation is defined such that it feels like you're
     grabbing onto something in the foreground; if you move the mouse
     to the right, the objects in the foreground move to the right, and
@@ -45,6 +53,27 @@ class OrbitController(PanZoomController):
         "wheel": ("zoom", "push", -0.001),
         "alt+wheel": ("fov", "push", -0.01),
     }
+
+    def __init__(self, *args, target=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._custom_target = np.array(target) if target is not None else None
+
+    @property
+    def target(self):
+        """The target position (x, y, z) that the camera orbits around."""
+        if self._custom_target is not None:
+            return self._custom_target.copy()
+        else:
+            camera_state = self._get_camera_state()
+            return self._get_target_vec(camera_state)
+
+    @target.setter
+    def target(self, value):
+        """Set the target position (x, y, z) that the camera orbits around."""
+        if value is None:
+            self._custom_target = None
+        else:
+            self._custom_target = np.array(value, dtype=np.float32)
 
     def rotate(self, delta: Tuple, rect: Tuple, *, animate=False):
         """Rotate in an orbit around the target, using two angles (azimuth and elevation, in radians).
@@ -106,9 +135,25 @@ class OrbitController(PanZoomController):
 
         # Calculate new position
         pos1 = position
-        pos2target1 = self._get_target_vec(camera_state, rotation=rot1)
-        pos2target2 = self._get_target_vec(camera_state, rotation=rot2)
-        pos2 = pos1 + pos2target1 - pos2target2
+        if self._custom_target is not None:
+            # If we have a custom target, we need to calculate the target vector
+
+            target_pos = self._custom_target
+            pos1_to_target = target_pos - pos1
+
+            pos1_to_target_rotated = la.vec_transform_quat(pos1_to_target, r_azimuth)
+
+            right = la.vec_transform_quat((1, 0, 0), rot1)
+            r_elevation_world = la.quat_from_axis_angle(right, -delta_elevation)
+            pos1_to_target_final = la.vec_transform_quat(
+                pos1_to_target_rotated, r_elevation_world
+            )
+
+            pos2 = target_pos - pos1_to_target_final
+        else:
+            pos2target1 = self._get_target_vec(camera_state, rotation=rot1)
+            pos2target2 = self._get_target_vec(camera_state, rotation=rot2)
+            pos2 = pos1 + pos2target1 - pos2target2
 
         # Apply new state
         new_camera_state = {"position": pos2, "rotation": rot2}
@@ -120,3 +165,48 @@ class OrbitController(PanZoomController):
         # easier. The only downside I can think of is that the far plane
         # is now less far away but this effect is only 0.2%, since the
         # far plane is 500 * dist.
+
+    def _update_pan(self, delta, *, vecx, vecy):
+        if self._custom_target is not None:
+            # If we have a custom target, we need to pan relative to that
+            target_pos = self._custom_target
+
+            distance_to_target = la.vec_dist(
+                target_pos, self._get_camera_state()["position"]
+            )
+
+            scaled_delta = (
+                delta[0] * distance_to_target * 0.01,
+                delta[1] * distance_to_target * 0.01,
+            )
+            offest = -vecx * scaled_delta[0] + vecy * scaled_delta[1]
+            self._custom_target = target_pos + offest
+
+        return super()._update_pan(scaled_delta, vecx=vecx, vecy=vecy)
+
+    def _update_zoom(self, delta):
+        if isinstance(delta, (int, float)):
+            delta = (delta, delta)
+        assert isinstance(delta, tuple) and len(delta) == 2
+
+        if self._custom_target is not None:
+            target_pos = self._custom_target
+            radius_vec = self._get_camera_state()["position"] - target_pos
+
+            scale = 1 - delta[0]
+            if scale < 0.1:
+                scale = 0.1
+
+            radius_vec *= scale
+            new_position = target_pos + radius_vec
+            self._set_camera_state(
+                {
+                    "position": new_position,
+                }
+            )
+
+        else:
+            fx = 2 ** delta[0]
+            fy = 2 ** delta[1]
+            new_cam_state = self._zoom(fx, fy, self._get_camera_state())
+            self._set_camera_state(new_cam_state)


### PR DESCRIPTION
Currently, all parameters of `OrbitController` are automatically derived from the camera state. However, this can be inconvenient—especially when a user wants to explicitly set both the camera position and the orbit center (i.e., the look-at target) in a scene. In practice, it's quite difficult to achieve this setup. Based on my experience, unless one uses the convenience method `camera.show_object()` from pygfx, the `OrbitController` is hardly usable in most scenarios.

This PR adds an optional `target` parameter to the `OrbitController`, allowing users to specify the orbit center manually. The camera will move on a sphere centered at target, always looking at the target. Pan and zoom operations automatically adapt based on the distance between the camera and the target to ensure a smooth user experience.

When `target` is not specified, the `OrbitController` behaves exactly as before.