### PR TITLE
Use rendercanvas in all our examples

### DIFF
--- a/examples/feature_demo/animation_mixer.py
+++ b/examples/feature_demo/animation_mixer.py
@@ -33,14 +33,16 @@ except NameError:
 
 import pygfx as gfx
 from pygfx.utils.text import FontProps
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 from wgpu.utils.imgui import ImguiRenderer
 from imgui_bundle import imgui, hello_imgui  # type: ignore
 
 gltf_path = model_dir / "Soldier.glb"
 
-canvas = WgpuCanvas(size=(1280, 720), max_fps=-1, title="Animation Mixer", vsync=False)
+canvas = RenderCanvas(
+    size=(1280, 720), update_mode="fastest", title="Animation Mixer", vsync=False
+)
 
 renderer = gfx.WgpuRenderer(canvas)
 camera = gfx.PerspectiveCamera(45, 1280 / 720, depth_range=(1, 100))
@@ -346,4 +348,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/anisotropy_barn_lamp.py
+++ b/examples/feature_demo/anisotropy_barn_lamp.py
@@ -10,11 +10,11 @@ The visually distinct feature is the elongated appearance of the specular reflec
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 # Init
-canvas = WgpuCanvas(size=(1280, 720), title="Anisotropy")
+canvas = RenderCanvas(size=(1280, 720), title="Anisotropy")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -63,4 +63,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/audio_visualizer.py
+++ b/examples/feature_demo/audio_visualizer.py
@@ -18,7 +18,7 @@ import sounddevice as sd
 import soundfile as sf
 import requests
 from tqdm import tqdm
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 from pygfx.renderers.wgpu import (
     Binding,
     GfxSampler,
@@ -692,7 +692,7 @@ fragment_shader_code4 = """
 FFT_SIZE = 128
 
 renderer = gfx.WgpuRenderer(
-    WgpuCanvas(title="audio visualizer", max_fps=60, size=(1280, 720))
+    RenderCanvas(title="audio visualizer", max_fps=60, size=(1280, 720))
 )
 camera = gfx.NDCCamera()  # Not actually used
 
@@ -764,4 +764,4 @@ if __name__ == "__main__":
     song_path = "https://audio-download.ngfiles.com/376000/376737_Skullbeatz___Bad_Cat_Maste.mp3"
     audio_player.play(song_path)
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/clearcoat.py
+++ b/examples/feature_demo/clearcoat.py
@@ -31,13 +31,13 @@ except NameError:
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 from wgpu.utils.imgui import ImguiRenderer
 from imgui_bundle import imgui
 
 # Init
-canvas = WgpuCanvas(size=(800, 450), title="clearcoat")
+canvas = RenderCanvas(size=(800, 450), title="clearcoat")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -135,4 +135,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/clearcoat2.py
+++ b/examples/feature_demo/clearcoat2.py
@@ -31,11 +31,11 @@ except NameError:
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 # Init
-canvas = WgpuCanvas(size=(640, 480), title="clearcoat")
+canvas = RenderCanvas(size=(640, 480), title="clearcoat")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -88,4 +88,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/colormap_image.py
+++ b/examples/feature_demo/colormap_image.py
@@ -10,11 +10,11 @@ Example demonstrating different colormap dimensions on an image.
 
 import numpy as np
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(900, 400))
+canvas = RenderCanvas(size=(900, 400))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 camera = gfx.OrthographicCamera(1800, 550)
@@ -94,4 +94,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/colormap_mesh.py
+++ b/examples/feature_demo/colormap_mesh.py
@@ -14,12 +14,12 @@ this can also be applied for points and lines.
 
 import numpy as np
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-canvas = WgpuCanvas(size=(900, 400))
+canvas = RenderCanvas(size=(900, 400))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -140,4 +140,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/compute_cloth.py
+++ b/examples/feature_demo/compute_cloth.py
@@ -13,13 +13,15 @@ import numpy as np
 import pygfx as gfx
 import wgpu
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 from pygfx.utils.compute import ComputeShader
 from imgui_bundle import imgui
 from wgpu.utils.imgui import ImguiRenderer
 from wgpu.utils.imgui import Stats
 
-canvas = WgpuCanvas(size=(1280, 720), max_fps=-1, title="compute cloth", vsync=False)
+canvas = RenderCanvas(
+    size=(1280, 720), update_mode="fastest", title="compute cloth", vsync=False
+)
 renderer = gfx.WgpuRenderer(canvas)
 camera = gfx.PerspectiveCamera(45, 1280 / 720, depth_range=(0.01, 10))
 
@@ -709,4 +711,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/custom_object1.py
+++ b/examples/feature_demo/custom_object1.py
@@ -19,7 +19,7 @@ It demonstrates:
 # sphinx_gallery_pygfx_test = 'run'
 
 import wgpu
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 from pygfx.renderers.wgpu import (
     Binding,
@@ -93,7 +93,7 @@ class TriangleShader(BaseShader):
 
 # Setup scene
 
-renderer = gfx.WgpuRenderer(WgpuCanvas())
+renderer = gfx.WgpuRenderer(RenderCanvas())
 camera = gfx.NDCCamera()  # This material does not actually use the camera
 
 t = Triangle(None, TriangleMaterial())
@@ -104,4 +104,4 @@ scene.add(t)
 
 if __name__ == "__main__":
     renderer.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/custom_object2.py
+++ b/examples/feature_demo/custom_object2.py
@@ -21,7 +21,7 @@ It demonstrates:
 # sphinx_gallery_pygfx_test = 'run'
 
 import wgpu
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 from pygfx.renderers.wgpu import (
     Binding,
@@ -124,7 +124,7 @@ class TriangleShader(BaseShader):
 
 # Setup scene
 
-renderer = gfx.WgpuRenderer(WgpuCanvas())
+renderer = gfx.WgpuRenderer(RenderCanvas())
 camera = gfx.OrthographicCamera(10, 10)
 
 t = Triangle(None, TriangleMaterial(color="cyan"))
@@ -136,4 +136,4 @@ scene.add(t)
 
 if __name__ == "__main__":
     renderer.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/custom_object3.py
+++ b/examples/feature_demo/custom_object3.py
@@ -22,7 +22,7 @@ It demonstrates:
 
 import numpy as np
 import wgpu
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 from pygfx.renderers.wgpu import (
     Binding,
@@ -142,7 +142,7 @@ class TriangleShader(BaseShader):
 
 # Setup scene
 
-renderer = gfx.WgpuRenderer(WgpuCanvas())
+renderer = gfx.WgpuRenderer(RenderCanvas())
 camera = gfx.OrthographicCamera(10, 10)
 
 t = Triangle(
@@ -157,4 +157,4 @@ scene.add(t)
 
 if __name__ == "__main__":
     renderer.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/cylinder.py
+++ b/examples/feature_demo/cylinder.py
@@ -9,11 +9,11 @@ Example showing different types of geometric cylinders.
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -81,4 +81,4 @@ scene.add(ground)
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/dynamic_env_map.py
+++ b/examples/feature_demo/dynamic_env_map.py
@@ -20,12 +20,12 @@ import time
 
 import imageio.v3 as iio
 import pylinalg as la
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 import pygfx as gfx
 from pygfx.utils.cube_camera import CubeCamera
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas())
 scene = gfx.Scene()
 
 
@@ -111,4 +111,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/earth.py
+++ b/examples/feature_demo/earth.py
@@ -33,12 +33,12 @@ except NameError:
 import imageio.v3 as iio
 import numpy as np
 import pylinalg as la
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
 # Init
-canvas = WgpuCanvas(size=(640, 480), max_fps=60, title="Earth")
+canvas = RenderCanvas(size=(640, 480), max_fps=60, title="Earth")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -121,4 +121,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/env_maps.py
+++ b/examples/feature_demo/env_maps.py
@@ -19,7 +19,7 @@ import imageio
 import trimesh
 from pathlib import Path
 import pylinalg as la
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 import pygfx as gfx
 
@@ -32,7 +32,7 @@ except NameError:
 
 TEAPOT = model_dir / "teapot.stl"
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas())
 scene = gfx.Scene()
 
 dir_light = gfx.DirectionalLight(1, 2)
@@ -101,4 +101,4 @@ controller = gfx.OrbitController(camera, register_events=renderer)
 
 if __name__ == "__main__":
     renderer.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/flat_shaded_torus.py
+++ b/examples/feature_demo/flat_shaded_torus.py
@@ -8,12 +8,12 @@ Example showing a Torus knot, using flat shading.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -39,4 +39,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/fly_controller.py
+++ b/examples/feature_demo/fly_controller.py
@@ -12,12 +12,12 @@ Tip: try using different blending.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 scene.add(gfx.Background.from_color("#000"))
@@ -62,4 +62,4 @@ controller = gfx.FlyController(camera, register_events=renderer)
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/geometry_image.py
+++ b/examples/feature_demo/geometry_image.py
@@ -9,11 +9,11 @@ Show an image.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -32,4 +32,4 @@ camera.local.scale_y = -1
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/geometry_klein_bottle.py
+++ b/examples/feature_demo/geometry_klein_bottle.py
@@ -11,11 +11,11 @@ of the mesh, in different colors. It can be seen how the object turns itself
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -45,4 +45,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/geometry_plane.py
+++ b/examples/feature_demo/geometry_plane.py
@@ -9,7 +9,7 @@ Use a plane geometry to show a texture, which is continuously updated to show vi
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
@@ -19,7 +19,7 @@ def loop_video(video):
             yield frame[:, :, 0]
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -48,4 +48,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/geometry_torus_knot.py
+++ b/examples/feature_demo/geometry_torus_knot.py
@@ -9,11 +9,11 @@ Example showing a Torus knot, with a texture and lighting.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -36,4 +36,4 @@ controller = gfx.TrackballController(camera, register_events=renderer)
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/gltf_animations.py
+++ b/examples/feature_demo/gltf_animations.py
@@ -34,14 +34,16 @@ except NameError:
 # sphinx_gallery_pygfx_test = 'run'
 
 import pygfx as gfx
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 from wgpu.utils.imgui import ImguiRenderer
 from imgui_bundle import imgui, icons_fontawesome_6, hello_imgui  # type: ignore
 
 gltf_path = model_dir / "Soldier.glb"
 
-canvas = WgpuCanvas(size=(800, 600), max_fps=-1, title="Animations", vsync=False)
+canvas = RenderCanvas(
+    size=(800, 600), update_mode="fastest", title="Animations", vsync=False
+)
 
 renderer = gfx.WgpuRenderer(canvas)
 camera = gfx.PerspectiveCamera(45, 800 / 600, depth_range=(1, 100))
@@ -187,4 +189,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/gltf_unlit.py
+++ b/examples/feature_demo/gltf_unlit.py
@@ -31,13 +31,13 @@ except NameError:
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 from wgpu.utils.imgui import ImguiRenderer
 from imgui_bundle import imgui
 
 # Init
-canvas = WgpuCanvas(size=(1280, 720), title="gltf_unlit")
+canvas = RenderCanvas(size=(1280, 720), title="gltf_unlit")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -145,4 +145,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/gltf_viewer.py
+++ b/examples/feature_demo/gltf_viewer.py
@@ -10,7 +10,7 @@ This example demonstrates loading glTF models from remote URLs (KhronosGroup glT
 # sphinx_gallery_pygfx_test = 'off'
 
 import pygfx as gfx
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import imageio.v3 as iio
 
 from wgpu.utils.imgui import ImguiRenderer
@@ -21,7 +21,9 @@ import httpx
 import threading
 import asyncio
 
-canvas = WgpuCanvas(size=(1280, 720), max_fps=-1, title="glTF viewer", vsync=False)
+canvas = RenderCanvas(
+    size=(1280, 720), update_mode="fastest", title="glTF viewer", vsync=False
+)
 
 renderer = gfx.WgpuRenderer(canvas)
 
@@ -268,4 +270,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/helpers_gizmo.py
+++ b/examples/feature_demo/helpers_gizmo.py
@@ -9,11 +9,11 @@ Click the center sphere to toggle between object-space, world-space, and screen-
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 viewport = gfx.Viewport(renderer)
 scene = gfx.Scene()
@@ -47,4 +47,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/helpers_stats.py
+++ b/examples/feature_demo/helpers_stats.py
@@ -10,11 +10,11 @@ the render loop.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 # Show something
@@ -53,4 +53,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/image_click_events.py
+++ b/examples/feature_demo/image_click_events.py
@@ -9,11 +9,11 @@ Show an image and print the x, y image data coordinates for click events.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -86,4 +86,4 @@ image.add_event_handler(event_handler, "click")
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/image_overlay.py
+++ b/examples/feature_demo/image_overlay.py
@@ -10,10 +10,10 @@ Show an image with another image overlaid with alpha blending.
 
 import numpy as np
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -63,4 +63,4 @@ controller = gfx.PanZoomController(camera, register_events=renderer)
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/image_plus_points.py
+++ b/examples/feature_demo/image_plus_points.py
@@ -9,11 +9,11 @@ Show an image with points overlaid.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -55,4 +55,4 @@ controller = gfx.PanZoomController(camera, register_events=renderer)
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/image_scaling.py
+++ b/examples/feature_demo/image_scaling.py
@@ -31,12 +31,12 @@ to better understand how they can adapt the provided classes to their needs.
 
 import imageio.v3 as iio
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
 canvas_size = 512 * 2 + 50, 512 + 100
-canvas = WgpuCanvas(size=canvas_size, max_fps=999)
+canvas = RenderCanvas(size=canvas_size, update_mode="fastest")
 renderer = gfx.renderers.WgpuRenderer(canvas, show_fps=True)
 scene = gfx.Scene()
 camera = gfx.OrthographicCamera(canvas_size[0], canvas_size[1])
@@ -82,4 +82,4 @@ scene.add(line)
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/image_stitching.py
+++ b/examples/feature_demo/image_stitching.py
@@ -10,11 +10,11 @@ images are used as weights.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene1 = gfx.Scene()
 scene1.add(gfx.Background.from_color("#000"))
@@ -82,4 +82,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/instancing_mesh.py
+++ b/examples/feature_demo/instancing_mesh.py
@@ -10,12 +10,12 @@ Example rendering the same mesh object multiple times, using instancing.
 
 import numpy as np
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -53,4 +53,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/iridescence.py
+++ b/examples/feature_demo/iridescence.py
@@ -9,11 +9,11 @@ This example demonstrates iridescence on the abalone shell.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 # Init
-canvas = WgpuCanvas(size=(1280, 720), title="Iridescence")
+canvas = RenderCanvas(size=(1280, 720), title="Iridescence")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -57,4 +57,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/iridescence2.py
+++ b/examples/feature_demo/iridescence2.py
@@ -12,11 +12,11 @@ from time import perf_counter
 import numpy as np
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 # Init
-canvas = WgpuCanvas(size=(640, 480), title="Iridescence2")
+canvas = RenderCanvas(size=(640, 480), title="Iridescence2")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -102,4 +102,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/labelled_image_grid.py
+++ b/examples/feature_demo/labelled_image_grid.py
@@ -12,7 +12,7 @@ import random
 
 import imageio.v3 as iio
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 import pygfx as gfx
 
@@ -29,7 +29,7 @@ images = [iio.imread(f"imageio:{name}") for name in image_names]
 
 grid_shape = (24, 16)
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas, show_fps=True)
 scene = gfx.Scene()
 
@@ -112,4 +112,4 @@ def update_scene():
 
 
 canvas.request_draw(update_scene)
-run()
+loop.run()

--- a/examples/feature_demo/light_directional_shadow.py
+++ b/examples/feature_demo/light_directional_shadow.py
@@ -15,10 +15,10 @@ outside the view frustum of the camera will not cast shadows.
 import math
 import pylinalg as la
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas())
 scene = gfx.Scene()
 
 floor = gfx.Mesh(
@@ -69,4 +69,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/light_shadow.py
+++ b/examples/feature_demo/light_shadow.py
@@ -14,12 +14,12 @@ import time
 import math
 import pylinalg as la
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas())
 scene = gfx.Scene()
 
 cube = gfx.Mesh(
@@ -110,4 +110,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/light_spotlight_shadows.py
+++ b/examples/feature_demo/light_spotlight_shadows.py
@@ -15,7 +15,7 @@ import math
 import random
 import pylinalg as la
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
@@ -85,7 +85,7 @@ class Tween:
 
 
 def init_scene():
-    renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(max_fps=60))
+    renderer = gfx.renderers.WgpuRenderer(RenderCanvas(max_fps=60))
 
     scene = gfx.Scene()
     camera = gfx.PerspectiveCamera(35, 16 / 9)
@@ -165,4 +165,4 @@ def init_scene():
 
 if __name__ == "__main__":
     renderer = init_scene()
-    run()
+    loop.run()

--- a/examples/feature_demo/light_spotlights.py
+++ b/examples/feature_demo/light_spotlights.py
@@ -15,7 +15,7 @@ import math
 import random
 import pylinalg as la
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
@@ -85,7 +85,7 @@ class Tween:
 
 
 def init_scene():
-    renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+    renderer = gfx.renderers.WgpuRenderer(RenderCanvas())
 
     scene = gfx.Scene()
     camera = gfx.PerspectiveCamera(35, 16 / 9)
@@ -152,4 +152,4 @@ def init_scene():
 
 if __name__ == "__main__":
     renderer = init_scene()
-    run()
+    loop.run()

--- a/examples/feature_demo/lightmap.py
+++ b/examples/feature_demo/lightmap.py
@@ -31,12 +31,12 @@ except NameError:
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
 # Init
-canvas = WgpuCanvas(size=(1200, 400), title="lightmap")
+canvas = RenderCanvas(size=(1200, 400), title="lightmap")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 meshes = gfx.load_gltf_mesh(model_dir / "lightmap" / "scene.gltf", materials=False)
@@ -92,4 +92,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/line_basic.py
+++ b/examples/feature_demo/line_basic.py
@@ -12,11 +12,11 @@ mode.
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
-canvas = WgpuCanvas(size=(1000, 800))
+canvas = RenderCanvas(size=(1000, 800))
 renderer = gfx.WgpuRenderer(canvas)
 renderer_svg = gfx.SvgRenderer(640, 480, "~/line.svg")
 
@@ -103,4 +103,4 @@ def animate():
 if __name__ == "__main__":
     renderer_svg.render(scene, camera)
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/line_performance.py
+++ b/examples/feature_demo/line_performance.py
@@ -9,11 +9,11 @@ Display a line depicting a noisy signal consisting of a lot of points.
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -34,4 +34,4 @@ camera.local.position = (50, 0, 0)
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/line_plot.py
+++ b/examples/feature_demo/line_plot.py
@@ -9,12 +9,12 @@ Show a line plot, with axii and a grid.
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 from pylinalg import vec_transform, vec_unproject
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -100,4 +100,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/line_segments.py
+++ b/examples/feature_demo/line_segments.py
@@ -9,11 +9,11 @@ Display line segments. Can be useful e.g. for visializing vector fields.
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -39,4 +39,4 @@ controller = gfx.PanZoomController(camera, register_events=renderer)
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/line_thick.py
+++ b/examples/feature_demo/line_thick.py
@@ -9,11 +9,11 @@ Display very thick lines to show how lines stay pretty on large scales.
 # sphinx_gallery_pygfx_test = 'run'
 
 import random
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.WgpuRenderer(canvas)
 
 # A straight line
@@ -43,4 +43,4 @@ camera = gfx.ScreenCoordsCamera()
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/map_click_events_to_world.py
+++ b/examples/feature_demo/map_click_events_to_world.py
@@ -9,14 +9,14 @@ by adding scatter points at click event locations
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 import pygfx as gfx
 import numpy as np
 
 from pylinalg import vec_transform, vec_unproject
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 # default cam position
@@ -124,4 +124,4 @@ layout()
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/measure_distances_2d.py
+++ b/examples/feature_demo/measure_distances_2d.py
@@ -11,11 +11,11 @@ end-points.
 
 import numpy as np
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -53,4 +53,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/measure_distances_3d.py
+++ b/examples/feature_demo/measure_distances_3d.py
@@ -11,11 +11,11 @@ two objects to see the distance betweeen these points.
 
 import numpy as np
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -72,4 +72,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/mesh_depth_material.py
+++ b/examples/feature_demo/mesh_depth_material.py
@@ -9,7 +9,7 @@ A custom material for drawing geometry by depth
 # sphinx_gallery_pygfx_test = 'run'
 
 import wgpu
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 from pygfx.renderers.wgpu import Binding, register_wgpu_render_function
 from pygfx.renderers.wgpu.shaders.meshshader import MeshShader
@@ -95,7 +95,7 @@ class DepthShader(MeshShader):
 
 # Setup scene
 
-renderer = gfx.WgpuRenderer(WgpuCanvas(size=(640, 480)))
+renderer = gfx.WgpuRenderer(RenderCanvas(size=(640, 480)))
 
 camera = gfx.PerspectiveCamera(45, 640 / 480, depth_range=(8, 12))
 camera.local.z = 10
@@ -116,4 +116,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/mesh_slice.py
+++ b/examples/feature_demo/mesh_slice.py
@@ -8,11 +8,11 @@ Example showing off the mesh slice material.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -62,4 +62,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/mesh_toon.py
+++ b/examples/feature_demo/mesh_toon.py
@@ -9,12 +9,12 @@ This example demonstrates the affect of the `MeshToonMaterial`
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -50,4 +50,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/mesh_toon2.py
+++ b/examples/feature_demo/mesh_toon2.py
@@ -13,12 +13,12 @@ import math
 from time import perf_counter
 import numpy as np
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 import pygfx as gfx
 
 # Init
-canvas = WgpuCanvas(size=(640, 480), title="gfx_toon")
+canvas = RenderCanvas(size=(640, 480), title="gfx_toon")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -122,4 +122,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/morph_facecap.py
+++ b/examples/feature_demo/morph_facecap.py
@@ -36,7 +36,7 @@ except NameError:
 
 import pygfx as gfx
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 from wgpu.utils.imgui import ImguiRenderer
 from imgui_bundle import imgui
 
@@ -44,7 +44,9 @@ gltf_path = model_dir / "facecap.glb"
 
 scene = gfx.Scene()
 
-canvas = WgpuCanvas(size=(1280, 720), max_fps=-1, title="Facecap", vsync=False)
+canvas = RenderCanvas(
+    size=(1280, 720), update_mode="fastest", title="Facecap", vsync=False
+)
 
 renderer = gfx.WgpuRenderer(canvas)
 camera = gfx.PerspectiveCamera(45, 1280 / 720, depth_range=(0.1, 1000))
@@ -118,4 +120,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/morph_targets.py
+++ b/examples/feature_demo/morph_targets.py
@@ -13,7 +13,7 @@ import time
 import numpy as np
 import pygfx as gfx
 import pylinalg as la
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 
 def create_geometry():
@@ -55,7 +55,7 @@ def create_geometry():
     return geometry
 
 
-canvas = WgpuCanvas(size=(640, 480), max_fps=60, title="Morph Targets")
+canvas = RenderCanvas(size=(640, 480), max_fps=60, title="Morph Targets")
 
 renderer = gfx.WgpuRenderer(canvas)
 
@@ -90,4 +90,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/multi_slice1.py
+++ b/examples/feature_demo/multi_slice1.py
@@ -14,12 +14,12 @@ from time import time
 
 import imageio.v3 as iio
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -82,4 +82,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/multi_slice2.py
+++ b/examples/feature_demo/multi_slice2.py
@@ -16,12 +16,12 @@ from time import time
 
 import imageio.v3 as iio
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 from skimage.measure import marching_cubes
 import pylinalg as la
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -77,4 +77,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/multiple_fonts.py
+++ b/examples/feature_demo/multiple_fonts.py
@@ -9,7 +9,7 @@ multiple different fonts.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 from datetime import datetime
@@ -44,7 +44,7 @@ text_instructions.local.position = (0, 40, 0)
 scene = gfx.Scene()
 scene.add(text_noto, text_humor, text_instructions)
 camera = gfx.OrthographicCamera(400, 300)
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(800, 600)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(800, 600)))
 
 
 @renderer.add_event_handler("pointer_down")
@@ -58,4 +58,4 @@ def change_text(event):
 
 renderer.request_draw(lambda: renderer.render(scene, camera))
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/examples/feature_demo/multiprocessing_zmq/view.py
+++ b/examples/feature_demo/multiprocessing_zmq/view.py
@@ -15,7 +15,7 @@ import numpy as np
 import zmq
 
 import pygfx as gfx
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 context = zmq.Context()
 
@@ -44,7 +44,7 @@ def get_bytes():
     return None
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -80,4 +80,4 @@ def update_frame():
 
 if __name__ == "__main__":
     canvas.request_draw(update_frame)
-    run()
+    loop.run()

--- a/examples/feature_demo/paint_to_texture.py
+++ b/examples/feature_demo/paint_to_texture.py
@@ -12,11 +12,11 @@ horizontal panning over the texture, using shift+mouse or scrolling.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas())
 scene = gfx.Scene()
 
 scene.add(gfx.Background.from_color("#cde"))
@@ -62,4 +62,4 @@ controller.controls = {
 
 if __name__ == "__main__":
     renderer.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/paint_to_texture_directly.py
+++ b/examples/feature_demo/paint_to_texture_directly.py
@@ -14,11 +14,11 @@ texture is manipilated directly using ``send_data()``.
 # sphinx_gallery_pygfx_test = 'run'
 
 import wgpu
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas())
 scene = gfx.Scene()
 
 scene.add(gfx.Background.from_color("#cde"))
@@ -68,4 +68,4 @@ controller.controls = {
 
 if __name__ == "__main__":
     renderer.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/panzoom_camera.py
+++ b/examples/feature_demo/panzoom_camera.py
@@ -12,12 +12,12 @@ press 'l' to load the last saved state.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -72,4 +72,4 @@ renderer.add_event_handler(on_key_down, "key_down")
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/pbr.py
+++ b/examples/feature_demo/pbr.py
@@ -32,11 +32,11 @@ except NameError:
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 # Init
-canvas = WgpuCanvas(size=(640, 480), title="gfx_pbr")
+canvas = RenderCanvas(size=(640, 480), title="gfx_pbr")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -80,4 +80,4 @@ controller = gfx.OrbitController(camera, register_events=renderer)
 
 if __name__ == "__main__":
     renderer.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/pbr2.py
+++ b/examples/feature_demo/pbr2.py
@@ -13,13 +13,13 @@ import math
 from time import perf_counter
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 import pygfx as gfx
 import pylinalg as la
 
 # Init
-canvas = WgpuCanvas(size=(640, 480), title="gfx_pbr")
+canvas = RenderCanvas(size=(640, 480), title="gfx_pbr")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -113,4 +113,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/pbr_instanced.py
+++ b/examples/feature_demo/pbr_instanced.py
@@ -33,11 +33,11 @@ except NameError:
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 # Init
-canvas = WgpuCanvas(size=(640, 480), title="gfx_pbr")
+canvas = RenderCanvas(size=(640, 480), title="gfx_pbr")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -96,4 +96,4 @@ controller = gfx.OrbitController(camera, register_events=renderer)
 
 if __name__ == "__main__":
     renderer.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/physical_color.py
+++ b/examples/feature_demo/physical_color.py
@@ -15,11 +15,11 @@ This example shows how you can also provide colors in physical colorspace
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -65,4 +65,4 @@ camera.local.scale_y = -1
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/picking_color.py
+++ b/examples/feature_demo/picking_color.py
@@ -11,12 +11,12 @@ object being clicked, more detailed picking info is available.
 
 import numpy as np
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -55,4 +55,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/picking_mesh.py
+++ b/examples/feature_demo/picking_mesh.py
@@ -16,12 +16,12 @@ are visible, its undetermined which is picked.
 
 import numpy as np
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -82,4 +82,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/picking_points.py
+++ b/examples/feature_demo/picking_points.py
@@ -10,11 +10,11 @@ is changed. With a small change, a line is shown instead.
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -41,4 +41,4 @@ def offset_point(event):
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/point_marker_multi_color.py
+++ b/examples/feature_demo/point_marker_multi_color.py
@@ -18,7 +18,7 @@ not move with the controller.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
@@ -132,7 +132,7 @@ def make_logo_scene_camera(size=100, edge_width=3, padding=(5, 5)):
 # Make singleton for fast access
 logo, logo_camera = make_logo_scene_camera()
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 scene.add(gfx.Background.from_color("#000"))
@@ -203,4 +203,4 @@ def render_full_scene():
 
 if __name__ == "__main__":
     canvas.request_draw(render_full_scene)
-    run()
+    loop.run()

--- a/examples/feature_demo/quad_mesh.py
+++ b/examples/feature_demo/quad_mesh.py
@@ -14,7 +14,7 @@ Contributed by S. Shaji
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
@@ -30,7 +30,7 @@ def generate_sample_quads(cols=9):
     return pos, indices.astype(np.int32)
 
 
-canvas = WgpuCanvas(
+canvas = RenderCanvas(
     title="Mesh Object with quads. Press 1,2 or 3 for wireframe, per vertex coloring or per face coloring"
 )
 renderer = gfx.renderers.WgpuRenderer(canvas)
@@ -123,4 +123,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/scene_camlink1.py
+++ b/examples/feature_demo/scene_camlink1.py
@@ -10,12 +10,12 @@ but not for the y dimension.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(800, 800)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(800, 800)))
 
 
 # Create a scene to display multiple times. It contains a point cloud
@@ -95,4 +95,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/scene_camlink2.py
+++ b/examples/feature_demo/scene_camlink2.py
@@ -12,12 +12,12 @@ This demonstrates how the controllers are stateless (except during interaction).
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(900, 600)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(900, 600)))
 
 
 # Create a scene to display multiple times. It contains a point cloud
@@ -79,4 +79,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/scene_overlay.py
+++ b/examples/feature_demo/scene_overlay.py
@@ -11,14 +11,14 @@ overlay render pass.
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
 # Create a canvas and renderer
 
-canvas = WgpuCanvas(size=(500, 300))
+canvas = RenderCanvas(size=(500, 300))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 # Compose a 3D scene
@@ -78,4 +78,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/scene_subplots1.py
+++ b/examples/feature_demo/scene_subplots1.py
@@ -13,14 +13,14 @@ scene_subplot2.py for a slightly higher-level approach.
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
 # Create a anvas and a renderer
 
-canvas = WgpuCanvas(size=(500, 300))
+canvas = RenderCanvas(size=(500, 300))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 # Compose a 3D scene
@@ -68,4 +68,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/scene_subplots2.py
+++ b/examples/feature_demo/scene_subplots2.py
@@ -8,12 +8,12 @@ Like scene_side_by_side, but now with a more plot-like idea, and mouse interacti
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas())
 
 
 # Create a scene to display multiple times. It contains three points clouds.
@@ -91,4 +91,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/scene_subplots_video.py
+++ b/examples/feature_demo/scene_subplots_video.py
@@ -9,11 +9,11 @@ Double click to re-center the images.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 dims = (512, 512)  # image dimensions
@@ -105,4 +105,4 @@ layout()
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/sheen_chair.py
+++ b/examples/feature_demo/sheen_chair.py
@@ -9,11 +9,11 @@ This example demonstrates the sheen effect in a glTF model.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 # Init
-canvas = WgpuCanvas(size=(1280, 720), title="Sheen Chair")
+canvas = RenderCanvas(size=(1280, 720), title="Sheen Chair")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -62,4 +62,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/sheen_glam_velvet_sofa.py
+++ b/examples/feature_demo/sheen_glam_velvet_sofa.py
@@ -9,11 +9,11 @@ This example demonstrates the sheen effect in a glTF model.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 # Init
-canvas = WgpuCanvas(size=(1280, 720), title="Sheen Glam Velvet Sofa")
+canvas = RenderCanvas(size=(1280, 720), title="Sheen Glam Velvet Sofa")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -62,4 +62,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/show_image.py
+++ b/examples/feature_demo/show_image.py
@@ -9,11 +9,11 @@ Use camera.show_object to ensure the Image is in view.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -37,4 +37,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/skinned_mesh.py
+++ b/examples/feature_demo/skinned_mesh.py
@@ -13,7 +13,7 @@ import time
 import numpy as np
 import pygfx as gfx
 import pylinalg as la
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 
 def create_geometry(sizing):
@@ -85,7 +85,7 @@ sizing = {
     "half_height": half_height,
 }
 
-canvas = WgpuCanvas(size=(640, 480), max_fps=60, title="Skinnedmesh")
+canvas = RenderCanvas(size=(640, 480), max_fps=60, title="Skinnedmesh")
 
 renderer = gfx.WgpuRenderer(canvas)
 
@@ -119,4 +119,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/skinning_animation.py
+++ b/examples/feature_demo/skinning_animation.py
@@ -32,14 +32,16 @@ except NameError:
 # sphinx_gallery_pygfx_test = 'run'
 
 import pygfx as gfx
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 from wgpu.utils.imgui import ImguiRenderer
 from imgui_bundle import imgui, hello_imgui, icons_fontawesome_6  # type: ignore
 
 gltf_path = model_dir / "Michelle.glb"
 
-canvas = WgpuCanvas(size=(640, 480), max_fps=-1, title="Skinnedmesh", vsync=False)
+canvas = RenderCanvas(
+    size=(640, 480), update_mode="fastest", title="Skinnedmesh", vsync=False
+)
 
 renderer = gfx.WgpuRenderer(canvas)
 camera = gfx.PerspectiveCamera(75, 640 / 480, depth_range=(0.1, 1000))
@@ -149,4 +151,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/skinning_bind_detached.py
+++ b/examples/feature_demo/skinning_bind_detached.py
@@ -33,11 +33,13 @@ except NameError:
 
 import numpy as np
 import pygfx as gfx
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 gltf_path = model_dir / "Michelle.glb"
 
-canvas = WgpuCanvas(size=(640, 480), max_fps=-1, title="Skinnedmesh", vsync=False)
+canvas = RenderCanvas(
+    size=(640, 480), update_mode="fastest", title="Skinnedmesh", vsync=False
+)
 
 renderer = gfx.WgpuRenderer(canvas)
 camera = gfx.PerspectiveCamera(75, 640 / 480, depth_range=(0.1, 1000))
@@ -106,4 +108,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/skybox.py
+++ b/examples/feature_demo/skybox.py
@@ -11,7 +11,7 @@ Inspired by https://github.com/gfx-rs/wgpu-rs/blob/master/examples/skybox/main.r
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
@@ -23,7 +23,7 @@ im = iio.imread("imageio:meadow_cube.jpg")
 width = height = im.shape[1]
 im.shape = -1, width, height, 3
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -66,4 +66,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/skybox_rotate.py
+++ b/examples/feature_demo/skybox_rotate.py
@@ -10,7 +10,7 @@ Example with a skybox background in a rotating scene.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
@@ -22,7 +22,7 @@ im = iio.imread("imageio:meadow_cube.jpg")
 width = height = im.shape[1]
 im.shape = -1, width, height, 3
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -54,4 +54,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/spheres.py
+++ b/examples/feature_demo/spheres.py
@@ -9,11 +9,11 @@ Example showing different types of geometric cylinders.
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -68,4 +68,4 @@ controller = gfx.OrbitController(camera, register_events=renderer)
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/synced_video.py
+++ b/examples/feature_demo/synced_video.py
@@ -9,11 +9,11 @@ Example demonstrating synced video rendering
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(512 * 3 + 100, 400), max_fps=999)
+canvas = RenderCanvas(size=(512 * 3 + 100, 400), max_fps=999)
 renderer = gfx.renderers.WgpuRenderer(canvas, show_fps=True)
 scene = gfx.Scene()
 camera = gfx.OrthographicCamera(1800, 550)
@@ -57,4 +57,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/text_align.py
+++ b/examples/feature_demo/text_align.py
@@ -14,7 +14,7 @@ justification of text anchored to the center of the screen.
 
 import os
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 import pygfx as gfx
 
@@ -102,7 +102,7 @@ scene.add(text, points)
 camera = gfx.OrthographicCamera(4, 3)
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(800, 600)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(800, 600)))
 
 
 @renderer.add_event_handler("key_down")
@@ -208,4 +208,4 @@ Use
 )
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/examples/feature_demo/text_contrast.py
+++ b/examples/feature_demo/text_contrast.py
@@ -16,7 +16,7 @@ background.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 scene = gfx.Scene()
@@ -65,8 +65,8 @@ scene.add(t1, t2, t3, t4)
 camera = gfx.OrthographicCamera(4, 3)
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas())
 renderer.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/examples/feature_demo/text_multiple_grid.py
+++ b/examples/feature_demo/text_multiple_grid.py
@@ -8,7 +8,7 @@ This example demonstrate how to use MultiText to show a grid of text blocks.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 import pygfx as gfx
 import numpy as np
@@ -58,11 +58,11 @@ for iy in range(10):
 camera = gfx.OrthographicCamera(100, 100)
 camera.local.position = 51, 51, 0
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(800, 600)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(800, 600)))
 controller = gfx.PanZoomController(camera, register_events=renderer)
 
 renderer.request_draw(lambda: renderer.render(scene, camera))
 
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/examples/feature_demo/text_multiple_labels.py
+++ b/examples/feature_demo/text_multiple_labels.py
@@ -17,7 +17,7 @@ can re-allocate its buffers if the number of text blocks changes.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 import pygfx as gfx
 import numpy as np
@@ -63,11 +63,11 @@ scene.add(points)
 camera = gfx.PerspectiveCamera()
 camera.show_object(scene)
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(800, 600)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(800, 600)))
 controller = gfx.OrbitController(camera, register_events=renderer)
 
 renderer.request_draw(lambda: renderer.render(scene, camera))
 
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/examples/feature_demo/text_snake.py
+++ b/examples/feature_demo/text_snake.py
@@ -16,12 +16,12 @@ blocks move in a wave.
 
 from time import perf_counter
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas())
 scene = gfx.Scene()
 
 
@@ -75,4 +75,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/text_waterfall.py
+++ b/examples/feature_demo/text_waterfall.py
@@ -10,12 +10,12 @@ text rendering to its limits.
 # sphinx_gallery_pygfx_docs = 'animate 5s'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(800, 400)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(800, 400)))
 scene = gfx.Scene()
 glyph_atlas = gfx.utils.text.glyph_atlas
 glyph_atlas.clear_free_regions = True  # So we can see regions being freed
@@ -103,4 +103,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/transparency1.py
+++ b/examples/feature_demo/transparency1.py
@@ -13,11 +13,11 @@ Press 1-4 to select the blending mode.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -96,4 +96,4 @@ def animate():
 if __name__ == "__main__":
     print(__doc__)
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/transparency2.py
+++ b/examples/feature_demo/transparency2.py
@@ -14,11 +14,11 @@ Press 1-4 to select the blending mode.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -95,4 +95,4 @@ def animate():
 if __name__ == "__main__":
     print(__doc__)
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/volume_iso_render.py
+++ b/examples/feature_demo/volume_iso_render.py
@@ -10,11 +10,11 @@ Render a 3D volume with isosurface rendering..
 
 import imageio.v3 as iio
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -38,4 +38,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/volume_minip_render.py
+++ b/examples/feature_demo/volume_minip_render.py
@@ -9,11 +9,11 @@ Render a 3D volume with minimum intensity projection rendering.
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -38,4 +38,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/volume_render1.py
+++ b/examples/feature_demo/volume_render1.py
@@ -10,11 +10,11 @@ Render a volume. Shift-click to draw white blobs inside the volume.
 
 import imageio.v3 as iio
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -59,4 +59,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/volume_render2.py
+++ b/examples/feature_demo/volume_render2.py
@@ -10,12 +10,12 @@ Render three volumes using different world transforms.
 
 import imageio.v3 as iio
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -52,4 +52,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/volume_slice1.py
+++ b/examples/feature_demo/volume_slice1.py
@@ -10,11 +10,11 @@ Simple and ... slow.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -46,4 +46,4 @@ def handle_event(event):
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/volume_slice2.py
+++ b/examples/feature_demo/volume_slice2.py
@@ -11,11 +11,11 @@ a plane geometry. Simple, fast and subpixel!
 
 import imageio.v3 as iio
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -48,4 +48,4 @@ def handle_event(event):
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/volume_slice3.py
+++ b/examples/feature_demo/volume_slice3.py
@@ -10,11 +10,11 @@ it with a VolumeSliceMaterial. Easy because we can just define the view plane.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -55,4 +55,4 @@ def handle_pointer_event(event):
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/feature_demo/wireframe1.py
+++ b/examples/feature_demo/wireframe1.py
@@ -12,12 +12,12 @@ producing a look of a metallic frame around a soft tube.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -50,4 +50,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/wireframe2.py
+++ b/examples/feature_demo/wireframe2.py
@@ -10,12 +10,12 @@ gray.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -50,4 +50,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/wireframe_material.py
+++ b/examples/feature_demo/wireframe_material.py
@@ -12,7 +12,7 @@ not of equal thickness.
 
 import numpy as np
 import wgpu
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 from pygfx.renderers.wgpu import Binding, register_wgpu_render_function
 from pygfx.resources import Buffer
@@ -142,7 +142,7 @@ class WireframeShader(BaseShader):
 
 # Setup scene
 
-renderer = gfx.WgpuRenderer(WgpuCanvas(size=(640, 480)))
+renderer = gfx.WgpuRenderer(RenderCanvas(size=(640, 480)))
 
 thickness = 4
 
@@ -174,4 +174,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/feature_demo/world_bounding_box.py
+++ b/examples/feature_demo/world_bounding_box.py
@@ -12,11 +12,11 @@ to trigger an Exception.
 
 import imageio.v3 as iio
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -46,4 +46,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/introductory/clipping_planes.py
+++ b/examples/introductory/clipping_planes.py
@@ -8,13 +8,13 @@ Example demonstrating clipping planes on a mesh.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
 # Create a canvas and a renderer
 
-canvas = WgpuCanvas(size=(800, 400))
+canvas = RenderCanvas(size=(800, 400))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 # Compose two of the same scenes
@@ -64,4 +64,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/introductory/hello_triangle.py
+++ b/examples/introductory/hello_triangle.py
@@ -8,11 +8,11 @@ Replicating the WGPU triangle example, but with about 10x less code.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'run'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.WgpuRenderer(canvas)
 camera = gfx.NDCCamera()
 
@@ -28,4 +28,4 @@ triangle = gfx.Mesh(
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(triangle, camera))
-    run()
+    loop.run()

--- a/examples/introductory/light_basic.py
+++ b/examples/introductory/light_basic.py
@@ -13,11 +13,11 @@ This example shows a cube with MeshPhongMaterial illuminated by a point light an
 import time
 import numpy as np
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas())
 scene = gfx.Scene()
 
 cube = gfx.Mesh(
@@ -62,4 +62,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/introductory/offscreen.py
+++ b/examples/introductory/offscreen.py
@@ -20,11 +20,11 @@ import imageio.v3 as iio
 import numpy as np
 import pygfx as gfx
 import pylinalg as la
-from wgpu.gui.offscreen import WgpuCanvas
+from rendercanvas.offscreen import RenderCanvas
 
 
 # Create offscreen canvas, renderer and scene
-canvas = WgpuCanvas(size=(640, 480), pixel_ratio=1)
+canvas = RenderCanvas(size=(640, 480), pixel_ratio=1)
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 scene.add(gfx.Background.from_color("#000"))

--- a/examples/introductory/orbit_camera.py
+++ b/examples/introductory/orbit_camera.py
@@ -12,13 +12,13 @@ press 'l' to load the last saved state.
 # sphinx_gallery_pygfx_test = 'run'
 
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 import pylinalg as la
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -70,4 +70,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/introductory/points_basic.py
+++ b/examples/introductory/points_basic.py
@@ -10,11 +10,11 @@ Render Points
 # sphinx_gallery_pygfx_test = 'run'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -35,4 +35,4 @@ camera = gfx.NDCCamera()
 
 if __name__ == "__main__":
     canvas.request_draw(lambda: renderer.render(scene, camera))
-    run()
+    loop.run()

--- a/examples/other/background_subtraction.py
+++ b/examples/other/background_subtraction.py
@@ -17,7 +17,7 @@ image with no background subtraction.
 
 import imageio.v3 as iio
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 from pygfx.renderers.wgpu import register_wgpu_render_function
 from pygfx.renderers.wgpu.shaders.imageshader import ImageShader
@@ -35,7 +35,7 @@ im *= 1 - radius[..., np.newaxis] / radius.max()
 im = im.astype(np.uint8)
 
 canvas_size = im.shape[0], im.shape[1]
-canvas = WgpuCanvas(size=canvas_size, max_fps=999)
+canvas = RenderCanvas(size=canvas_size, max_fps=999)
 renderer = gfx.renderers.WgpuRenderer(canvas, show_fps=True)
 scene = gfx.Scene()
 camera = gfx.OrthographicCamera(canvas_size[0], canvas_size[1])
@@ -160,4 +160,4 @@ gui_renderer.set_gui(draw_imgui)
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/other/collection_line.py
+++ b/examples/other/collection_line.py
@@ -10,11 +10,11 @@ this is still performant.
 # sphinx_gallery_pygfx_test = 'off'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(max_fps=999)
+canvas = RenderCanvas(max_fps=999)
 renderer = gfx.WgpuRenderer(canvas, show_fps=True)
 scene = gfx.Scene()
 
@@ -62,4 +62,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/other/compare_images.py
+++ b/examples/other/compare_images.py
@@ -28,7 +28,7 @@ from pathlib import Path
 import imageio.v3 as imageio
 import numpy as np
 from imgui_bundle import imgui
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 from wgpu.utils.imgui import ImguiRenderer
 
 import pygfx as gfx
@@ -84,7 +84,7 @@ else:
 
 canvas_size = 800, 800
 
-canvas = WgpuCanvas(size=canvas_size)
+canvas = RenderCanvas(size=canvas_size)
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 w, h = canvas.get_logical_size()
@@ -287,4 +287,4 @@ def animate():
 gui_renderer.set_gui(draw_imgui)
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/other/cube_qt.py
+++ b/examples/other/cube_qt.py
@@ -3,21 +3,24 @@ Simple Cube with Qt
 ===================
 
 Example showing a single geometric cube.
+
+Alternatively one can import the Qt library of your choice, and then use
+``from rendercanvas.qt import RenderCanvas`` to get the corresponding canvas class.
 """
 
 # sphinx_gallery_pygfx_docs = 'code'
 # sphinx_gallery_pygfx_test = 'off'
 
 import pygfx as gfx
-
-from PySide6 import QtWidgets  # Replace PySide6 with PyQt6, PyQt5 or PySide2
-from wgpu.gui.qt import WgpuCanvas
 import pylinalg as la
 
+# Select one
+# from rendercanvas.pyqt5 import RenderCanvas
+# from rendercanvas.pyqt6 import RenderCanvas
+from rendercanvas.pyside6 import RenderCanvas, loop
 
-app = QtWidgets.QApplication([])
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -46,4 +49,4 @@ def animate():
 
 if __name__ == "__main__":
     canvas.request_draw(animate)
-    app.exec()
+    loop.run()  # i.e. app.exec()

--- a/examples/other/cube_wx.py
+++ b/examples/other/cube_wx.py
@@ -10,13 +10,13 @@ Example showing a single geometric cube.
 
 import pylinalg as la
 import wx
-from wgpu.gui.wx import WgpuCanvas
+from rendercanvas.wx import RenderCanvas
 
 import pygfx as gfx
 
 app = wx.App()
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 

--- a/examples/other/integration_pytorch.py
+++ b/examples/other/integration_pytorch.py
@@ -104,7 +104,7 @@ import pygfx as gfx
 from pygfx.renderers import WgpuRenderer
 
 # wgpu
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 # pytorch
 import torch
@@ -594,7 +594,7 @@ class SceneHandler:
 
         SceneHandler._scene_state = SceneState()
         SceneHandler._in_queue = in_queue
-        SceneHandler._renderer = WgpuRenderer(WgpuCanvas())
+        SceneHandler._renderer = WgpuRenderer(RenderCanvas())
 
         (
             SceneHandler._background_viewport,
@@ -661,7 +661,7 @@ class SceneHandler:
 
         on_resize()
         SceneHandler._renderer.request_draw(SceneHandler._animate)
-        run()
+        loop.run()
 
 
 class PyGfxCallback(Callback):

--- a/examples/other/integration_qt.py
+++ b/examples/other/integration_qt.py
@@ -1,6 +1,12 @@
 """
 Integrate Pygfx in Qt
 =====================
+
+Note how we use ``QRenderWidget`` instead of ``RenderCanvas``. The former
+is inteded to be embedded in an application, the latter is meant as a toplevel window.
+
+Importing from ``rendercanvas.qt`` will automatically use the appropriate
+Qt library, based on which one is currently imported.
 """
 
 # sphinx_gallery_pygfx_docs = 'code'
@@ -9,7 +15,7 @@ Integrate Pygfx in Qt
 import random
 
 from PySide6 import QtWidgets
-from wgpu.gui.qt import WgpuCanvas
+from rendercanvas.qt import QRenderWidget
 
 import pygfx as gfx
 
@@ -24,7 +30,7 @@ class Main(QtWidgets.QWidget):
         self._button.clicked.connect(self._on_button_click)
 
         # Create canvas, renderer and a scene object
-        self._canvas = WgpuCanvas(parent=self)
+        self._canvas = QRenderWidget(parent=self)
         self._renderer = gfx.WgpuRenderer(self._canvas)
         self._scene = gfx.Scene()
         self._camera = gfx.OrthographicCamera(110, 110)

--- a/examples/other/light_view.py
+++ b/examples/other/light_view.py
@@ -11,7 +11,7 @@ Lighting effect demonstration examples with adjustable parameters
 import math
 
 from PySide6 import QtWidgets, QtGui, QtCore
-from wgpu.gui.qt import WgpuWidget
+from rendercanvas.qt import QRenderWidget
 import pygfx as gfx
 import pylinalg as la
 
@@ -21,7 +21,7 @@ class LightViewer(QtWidgets.QWidget):
         super().__init__()
         self.setWindowTitle("Light_viewer")
         self.resize(800, 600)
-        self.wgpu_widget = WgpuWidget(max_fps=60)
+        self.wgpu_widget = QRenderWidget(max_fps=60)
 
         main_layout = QtWidgets.QHBoxLayout()
         main_layout.addWidget(self.wgpu_widget, 1)

--- a/examples/other/ray_tracing/ray_tracing.py
+++ b/examples/other/ray_tracing/ray_tracing.py
@@ -13,7 +13,7 @@ import wgpu
 import numpy as np
 import math
 from wgpu.utils.imgui import Stats
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 from pathlib import Path
 from camera import OrbitCamera
 from scene import Material, parse_gfx_scene
@@ -166,15 +166,18 @@ def load_wgsl(shader_name):
         return f.read().decode()
 
 
-canvas = WgpuCanvas(
-    title="Raytracing", size=(IMAGE_WIDTH, IMAGE_HEIGHT), max_fps=-1, vsync=False
+canvas = RenderCanvas(
+    title="Raytracing",
+    size=(IMAGE_WIDTH, IMAGE_HEIGHT),
+    update_mode="fastest",
+    vsync=False,
 )
 
 adapter = wgpu.gpu.request_adapter_sync(power_preference="high-performance")
 device = adapter.request_device_sync(
     required_features=["texture-adapter-specific-format-features", "float32-filterable"]
 )
-present_context = canvas.get_context()
+present_context = canvas.get_context("wgpu")
 render_texture_format = present_context.get_preferred_format(device.adapter)
 present_context.configure(device=device, format=render_texture_format)
 
@@ -373,12 +376,12 @@ stats = Stats(device, canvas)
 stats.extra_data = state
 
 
-def loop():
+def animate():
     with stats:
         do_ray_tracing()
     canvas.request_draw()
 
 
 if __name__ == "__main__":
-    canvas.request_draw(loop)
-    run()
+    canvas.request_draw(animate)
+    loop.run()

--- a/examples/other/reactive_rendering.py
+++ b/examples/other/reactive_rendering.py
@@ -16,7 +16,7 @@ import pickle
 from pathlib import Path
 
 from observ import reactive, watch
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
@@ -24,7 +24,7 @@ HERE = Path(__file__).parent
 state_file = HERE / "reactive_rendering_state.pkl"
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 viewport = gfx.Viewport.from_viewport_or_renderer(renderer)
 scene = gfx.Scene()
@@ -150,4 +150,4 @@ if __name__ == "__main__":
     canvas.request_draw(render_frame)
 
     # start!
-    run()
+    loop.run()

--- a/examples/other/sam2_point_segmentation.py
+++ b/examples/other/sam2_point_segmentation.py
@@ -26,7 +26,7 @@ from PySide6 import QtWidgets
 from PySide6.QtCore import QThread, Signal
 from sam2.build_sam import build_sam2
 from sam2.sam2_image_predictor import SAM2ImagePredictor
-from wgpu.gui.qt import WgpuCanvas
+from rendercanvas.qt import QRenderWidget
 
 import pygfx as gfx
 
@@ -39,7 +39,7 @@ class SAMPoint(QtWidgets.QWidget):
         self.setWindowTitle("SAM2 Real-time Point Segmentation")
         self.resize(800, 800)
 
-        self.canvas = WgpuCanvas(parent=self, max_fps=-1)
+        self.canvas = QRenderWidget(parent=self, update_mode="fastest")
         self.renderer = gfx.WgpuRenderer(self.canvas, show_fps=True)
         self.scene = gfx.Scene()
         self.camera = gfx.PerspectiveCamera(0)

--- a/examples/other/sponza_scene.py
+++ b/examples/other/sponza_scene.py
@@ -17,7 +17,7 @@ in this directory, or *any* of its parent directories.
 
 from pathlib import Path
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
@@ -32,7 +32,7 @@ else:
 gltf_path = gltf_samples_dir / "Models" / "Sponza" / "glTF" / "Sponza.gltf"
 
 # Init
-canvas = WgpuCanvas(size=(640, 480), title="gltf viewer")
+canvas = RenderCanvas(size=(640, 480), title="gltf viewer")
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -91,4 +91,4 @@ def animate():
 
 if __name__ == "__main__":
     renderer.request_draw(animate)
-    run()
+    loop.run()

--- a/examples/other/two_canvases.py
+++ b/examples/other/two_canvases.py
@@ -9,15 +9,15 @@ Example demonstrating rendering the same scene into two different canvases.
 # sphinx_gallery_pygfx_test = 'off'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
 # Create two canvases and two renderers
 
-canvas_a = WgpuCanvas(size=(500, 300))
-canvas_b = WgpuCanvas(size=(300, 500))
+canvas_a = RenderCanvas(size=(500, 300))
+canvas_b = RenderCanvas(size=(300, 500))
 
 renderer_b = gfx.renderers.WgpuRenderer(canvas_b)
 renderer_a = gfx.renderers.WgpuRenderer(canvas_a)
@@ -63,4 +63,4 @@ def animate_b():
 if __name__ == "__main__":
     canvas_a.request_draw(animate_a)
     canvas_b.request_draw(animate_b)
-    run()
+    loop.run()

--- a/examples/tests/test_examples.py
+++ b/examples/tests/test_examples.py
@@ -32,6 +32,9 @@ examples_to_run = [ex[0] for ex in examples_info if ex[2] == "run"]
 examples_to_compare = [ex[0] for ex in examples_info if ex[2] == "compare"]
 
 
+CUSTOM_TOLERANCES = {"validate_text_md": 2}
+
+
 class LogHandler(logging.Handler):
     def __init__(self, *args):
         super().__init__(*args)
@@ -148,7 +151,7 @@ def test_examples_compare(filename, pytestconfig, force_offscreen, mock_time):
     stored_img = iio.imread(screenshot_path)
 
     # assert similarity
-    atol = 1
+    atol = CUSTOM_TOLERANCES.get(module_name, 1)
     try:
         np.testing.assert_allclose(img, stored_img, atol=atol)
         is_similar = True

--- a/examples/validation/validate_blend_additive.py
+++ b/examples/validation/validate_blend_additive.py
@@ -9,13 +9,13 @@ This example draws overlapping circles of reference colors with additive blendin
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 colors = ["#ff0000", "#00ff00", "#0000ff"]
 distance_from_center = 0.5
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.WgpuRenderer(canvas, gamma_correction=1.0)
 camera = gfx.OrthographicCamera()
 camera.show_rect(-2, 2, -2, 2)
@@ -43,4 +43,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_blend_bg.py
+++ b/examples/validation/validate_blend_bg.py
@@ -17,11 +17,11 @@ the OS and GUI library are configured to do so.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(600, 600))
+canvas = RenderCanvas(size=(600, 600))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 geometry = gfx.plane_geometry(100, 100)
@@ -46,4 +46,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_blend_dither.py
+++ b/examples/validation/validate_blend_dither.py
@@ -8,11 +8,11 @@ This example draws a series of semitransparent planes using dither mode.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
-canvas = WgpuCanvas(size=(600, 600))
+canvas = RenderCanvas(size=(600, 600))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -59,4 +59,4 @@ canvas.request_draw(animate)
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_blend_weighted.py
+++ b/examples/validation/validate_blend_weighted.py
@@ -8,11 +8,11 @@ This example draws a series of semitransparent planes using weighted mode.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
-canvas = WgpuCanvas(size=(600, 600))
+canvas = RenderCanvas(size=(600, 600))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -59,4 +59,4 @@ canvas.request_draw(animate)
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_box.py
+++ b/examples/validation/validate_box.py
@@ -8,10 +8,10 @@ Example showing the box geometry.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -33,4 +33,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_color.py
+++ b/examples/validation/validate_color.py
@@ -9,13 +9,13 @@ similar output from e.g. Matplotlib.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 colors1 = ["#ff0000", "#770000", "#00ff00", "#007700", "#0000ff", "#000077"]
 colors2 = ["#000000", "#333333", "#666666", "#999999", "#cccccc", "#ffffff"]
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.WgpuRenderer(canvas, gamma_correction=1.0)
 camera = gfx.OrthographicCamera()
 camera.show_rect(-0.5, 5.5, 0, 2)
@@ -52,4 +52,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_culling.py
+++ b/examples/validation/validate_culling.py
@@ -14,12 +14,12 @@ Example test to validate winding and culling.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-canvas = WgpuCanvas(size=(1500, 600))
+canvas = RenderCanvas(size=(1500, 600))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -106,4 +106,4 @@ canvas.request_draw(animate)
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_depth_clipping.py
+++ b/examples/validation/validate_depth_clipping.py
@@ -12,11 +12,11 @@ rectangles near the near and far clipping planes.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -64,4 +64,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_depth_overlay1.py
+++ b/examples/validation/validate_depth_overlay1.py
@@ -11,14 +11,14 @@ top.
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
 # Create a canvas and renderer
 
-canvas = WgpuCanvas(size=(500, 300))
+canvas = RenderCanvas(size=(500, 300))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 # Compose a scene with a 3D cube at the origin
@@ -70,4 +70,4 @@ canvas.request_draw(draw)
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_depth_overlay2.py
+++ b/examples/validation/validate_depth_overlay2.py
@@ -10,14 +10,14 @@ always be on top.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
 # Create a canvas and renderer
 
-canvas = WgpuCanvas(size=(500, 300))
+canvas = RenderCanvas(size=(500, 300))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -54,4 +54,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_grid1.py
+++ b/examples/validation/validate_grid1.py
@@ -9,11 +9,11 @@ Show a bunch of grids touching various grid-cases.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 scene.add(gfx.Background.from_color("#fff"))
@@ -126,4 +126,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_helpers1.py
+++ b/examples/validation/validate_helpers1.py
@@ -13,11 +13,11 @@ Example showing the axes helper.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -28,4 +28,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_helpers2.py
+++ b/examples/validation/validate_helpers2.py
@@ -12,11 +12,11 @@ Example showing the axes and grid helpers with a perspective camera.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -45,4 +45,4 @@ canvas.request_draw(animate)
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_image1.py
+++ b/examples/validation/validate_image1.py
@@ -15,11 +15,11 @@ But the plane gemeometry is such that it is reversed again.
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -57,4 +57,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_image2.py
+++ b/examples/validation/validate_image2.py
@@ -13,11 +13,11 @@ Show an image displayed the correct way.
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -51,4 +51,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_image_colormap.py
+++ b/examples/validation/validate_image_colormap.py
@@ -17,11 +17,11 @@ Show an image with four different colormaps.
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(600, 600)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(600, 600)))
 
 im = np.repeat(np.linspace(0, 1, 100).reshape(1, -1), 24, 0).astype(np.float32)
 geometry = gfx.Geometry(grid=gfx.Texture(im, dim=2))
@@ -98,4 +98,4 @@ renderer.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_light_shadow.py
+++ b/examples/validation/validate_light_shadow.py
@@ -10,12 +10,12 @@ that all combinations are working properly.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 import numpy as np
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -82,4 +82,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/examples/validation/validate_line_2d.py
+++ b/examples/validation/validate_line_2d.py
@@ -13,11 +13,11 @@ Lines in 2D
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(1000, 1000))
+canvas = RenderCanvas(size=(1000, 1000))
 renderer = gfx.WgpuRenderer(canvas)
 
 positions = [
@@ -139,4 +139,4 @@ canvas.request_draw(animate)
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_line_dash.py
+++ b/examples/validation/validate_line_dash.py
@@ -11,11 +11,11 @@ Dashing
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(1000, 1000))
+canvas = RenderCanvas(size=(1000, 1000))
 renderer = gfx.WgpuRenderer(canvas)
 
 x = np.linspace(0, 4 * np.pi, 1000)
@@ -85,4 +85,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_line_thickness.py
+++ b/examples/validation/validate_line_thickness.py
@@ -13,11 +13,11 @@ Lines with different thicknesses
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(800, 600))
+canvas = RenderCanvas(size=(800, 600))
 renderer = gfx.WgpuRenderer(canvas, pixel_ratio=0.5, pixel_filter=False)
 
 x = np.linspace(0, 4 * np.pi, 100)
@@ -58,4 +58,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_line_thickness_space.py
+++ b/examples/validation/validate_line_thickness_space.py
@@ -15,11 +15,11 @@ scene. The next two columns are smaller cubes, but placed in scaled containers.
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(1000, 1000))
+canvas = RenderCanvas(size=(1000, 1000))
 renderer = gfx.WgpuRenderer(canvas)
 
 position_pairs = [
@@ -142,4 +142,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_mesh_colormap.py
+++ b/examples/validation/validate_mesh_colormap.py
@@ -12,12 +12,12 @@ Show meshes with 1D, 2D, and 3D colormaps, and per-vertex colors too.
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-canvas = WgpuCanvas(size=(900, 400))
+canvas = RenderCanvas(size=(900, 400))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 
@@ -126,4 +126,4 @@ for obj in scene.children:
 canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/examples/validation/validate_meshslice.py
+++ b/examples/validation/validate_meshslice.py
@@ -16,11 +16,11 @@ validation example we avoid regressions w.r.t. these artifacts.
 import base64
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 
@@ -150,4 +150,4 @@ def show_pick_coords(e):
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_ndc.py
+++ b/examples/validation/validate_ndc.py
@@ -13,7 +13,7 @@ Example (and test) for the NDC coordinates. Draws a square that falls partly out
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 from pygfx.renderers.wgpu import (
     Binding,
     BaseShader,
@@ -80,7 +80,7 @@ class SquareShader(BaseShader):
 
 # Setup scene
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -93,4 +93,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_normals_sides.py
+++ b/examples/validation/validate_normals_sides.py
@@ -13,12 +13,12 @@ at the front and back faces.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-renderer = gfx.WgpuRenderer(WgpuCanvas())
+renderer = gfx.WgpuRenderer(RenderCanvas())
 scene = gfx.Scene()
 
 geo = gfx.cylinder_geometry(radial_segments=16, height_segments=3, open_ended=True)
@@ -50,4 +50,4 @@ renderer.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_points_markers.py
+++ b/examples/validation/validate_points_markers.py
@@ -16,11 +16,11 @@ To this end, we repeat the pattern with the inner and outer edge painted.
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(1200, 1000))
+canvas = RenderCanvas(size=(1200, 1000))
 renderer = gfx.WgpuRenderer(canvas)
 
 colors = np.array(
@@ -276,4 +276,4 @@ def handle_event(event):
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_points_size.py
+++ b/examples/validation/validate_points_size.py
@@ -12,11 +12,11 @@ Points with different sizes
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(800, 600))
+canvas = RenderCanvas(size=(800, 600))
 renderer = gfx.WgpuRenderer(canvas, pixel_ratio=0.5, pixel_filter=False)
 
 x = np.linspace(0, 4 * np.pi, 20)
@@ -48,4 +48,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_points_size_space.py
+++ b/examples/validation/validate_points_size_space.py
@@ -15,11 +15,11 @@ scene. The next two columns are smaller cubes, but placed in scaled containers.
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(1000, 1000))
+canvas = RenderCanvas(size=(1000, 1000))
 renderer = gfx.WgpuRenderer(canvas)
 
 position_pairs = [
@@ -139,4 +139,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_ruler.py
+++ b/examples/validation/validate_ruler.py
@@ -9,11 +9,11 @@ Showing off some ruler tricks.
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -95,4 +95,4 @@ canvas.request_draw(animate)
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_send_data.py
+++ b/examples/validation/validate_send_data.py
@@ -11,7 +11,7 @@ Both the image and points are uploaded with send_data.
 
 import imageio.v3 as iio
 import wgpu
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import numpy as np
 
@@ -63,7 +63,7 @@ points = gfx.Points(
 
 # Setup for rendering
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 scene.add(image, points)
@@ -78,4 +78,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_skybox.py
+++ b/examples/validation/validate_skybox.py
@@ -19,7 +19,7 @@ import numpy as np
 import imageio.v3 as iio
 import pygfx as gfx
 from pathlib import Path
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 try:
     data_dir = Path(__file__).parents[1] / "data"
@@ -52,7 +52,7 @@ datas = [posx, negx, posy, negy, posz, negz]
 
 tex = gfx.Texture(np.stack(datas, axis=0), dim=2, size=(w, h, 6), generate_mipmaps=True)
 
-canvas = WgpuCanvas(size=(640, 640))
+canvas = RenderCanvas(size=(640, 640))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -77,4 +77,4 @@ renderer.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_srgb.py
+++ b/examples/validation/validate_srgb.py
@@ -14,11 +14,11 @@ Show images with physical colorspace, and srgb colorspace via three methods.
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(600, 600)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(600, 600)))
 
 rgba = np.repeat(np.linspace(0, 255, 6).reshape(1, -1), 2, 0).astype(np.uint8)
 rgba.shape = (*rgba.shape, 1)
@@ -67,4 +67,4 @@ renderer.request_draw(lambda: renderer.render(scene, camera))
 
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/examples/validation/validate_text_align.py
+++ b/examples/validation/validate_text_align.py
@@ -12,7 +12,7 @@ justification of text anchored to the center of the screen.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 scene = gfx.Scene()
@@ -88,9 +88,9 @@ scene.add(
 
 camera = gfx.OrthographicCamera(4, 3)
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(800, 600)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(800, 600)))
 
 renderer.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/examples/validation/validate_text_anchor.py
+++ b/examples/validation/validate_text_anchor.py
@@ -9,11 +9,11 @@ aligned in the scene.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(500, 500)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(500, 500)))
 scene = gfx.Scene()
 
 
@@ -53,4 +53,4 @@ renderer.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_text_direction.py
+++ b/examples/validation/validate_text_direction.py
@@ -20,7 +20,7 @@ would be a lot).
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 scene = gfx.Scene()
@@ -89,9 +89,9 @@ for text in (text1, text2, text3, text4):
 
 camera = gfx.OrthographicCamera(24, 18)
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(800, 600)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(800, 600)))
 
 renderer.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/examples/validation/validate_text_md.py
+++ b/examples/validation/validate_text_md.py
@@ -8,7 +8,7 @@ Test markdown formatting features.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 
 import pygfx as gfx
 
@@ -54,11 +54,11 @@ scene.add(text1, text2, text3, text4)
 camera = gfx.OrthographicCamera(1, 1)
 
 camera.show_object(scene, scale=0.7)
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(800, 600)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(800, 600)))
 
 renderer.request_draw(lambda: renderer.render(scene, camera))
 
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_text_outline.py
+++ b/examples/validation/validate_text_outline.py
@@ -10,7 +10,7 @@ one character may overlap with the neighboring one.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 scene = gfx.Scene()
@@ -36,9 +36,9 @@ text = gfx.Text(
 scene.add(text)
 
 camera = gfx.OrthographicCamera(4, 3)
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas(size=(800, 600)))
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(800, 600)))
 
 renderer.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/examples/validation/validate_text_size.py
+++ b/examples/validation/validate_text_size.py
@@ -13,12 +13,12 @@ This example shows text with different sizes.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 import pylinalg as la
 
 
-renderer = gfx.renderers.WgpuRenderer(WgpuCanvas())
+renderer = gfx.renderers.WgpuRenderer(RenderCanvas())
 scene = gfx.Scene()
 scene.add(gfx.Background.from_color("#000"))
 
@@ -112,4 +112,4 @@ renderer.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_tiny_image.py
+++ b/examples/validation/validate_tiny_image.py
@@ -15,11 +15,11 @@ where the applicability of an algorithm is tested against extreme bounds.
 
 import numpy as np
 import imageio.v3 as iio
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas(size=(180 * 5, 40 * 5))
+canvas = RenderCanvas(size=(180 * 5, 40 * 5))
 renderer = gfx.renderers.WgpuRenderer(canvas)
 scene = gfx.Scene()
 camera = gfx.OrthographicCamera(180, 40)
@@ -69,4 +69,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_transform.py
+++ b/examples/validation/validate_transform.py
@@ -8,10 +8,10 @@ Apply a variety of transform combinations.
 # sphinx_gallery_pygfx_docs = 'screenshot'
 # sphinx_gallery_pygfx_test = 'compare'
 
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 scene = gfx.Scene()
@@ -58,4 +58,4 @@ canvas.request_draw(lambda: renderer.render(scene, camera))
 
 if __name__ == "__main__":
     print(__doc__)
-    run()
+    loop.run()

--- a/examples/validation/validate_volume.py
+++ b/examples/validation/validate_volume.py
@@ -13,11 +13,11 @@ Render a volume and volume slices. You should see:
 # sphinx_gallery_pygfx_test = 'compare'
 
 import numpy as np
-from wgpu.gui.auto import WgpuCanvas, run
+from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
 
-canvas = WgpuCanvas()
+canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)
 
 # Prepare a very small data volume. The data is integer and not uint8,
@@ -76,4 +76,4 @@ def animate():
 canvas.request_draw(animate)
 
 if __name__ == "__main__":
-    run()
+    loop.run()

--- a/pygfx/utils/show.py
+++ b/pygfx/utils/show.py
@@ -35,7 +35,7 @@ class Display:
 
     Parameters
     ----------
-    canvas : WgpuCanvas
+    canvas : RenderCanvas
         The canvas used to display the object. If both ``renderer`` and
         ``canvas`` are set, then the renderer needs to use the set canvas.
     renderer : gfx.Renderer
@@ -234,10 +234,7 @@ def show(
     up : ndarray
         If set, and ``object`` does not contain a controller, set the camera
         controller's up vector to this value.
-        canvas : WgpuCanvas
-        The canvas used to display the object. If both ``renderer`` and
-        ``canvas`` are set, then the renderer needs to use the set canvas.
-    canvas : WgpuCanvas
+    canvas : RenderCanvas
         The canvas used to display the object. If both ``renderer`` and
         ``canvas`` are set, then the renderer needs to use the set canvas.
     renderer : gfx.Renderer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ keywords = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-    "rendercanvas >= 2",
+    "rendercanvas >= 2.2",
     "wgpu >=0.19.0,<0.23.0",
     "pylinalg >=0.6.7,<0.7.0",
     "numpy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ examples = [
     "scikit-image",
     "trimesh <4.6",
     "gltflib",
-    "imgui-bundle >=1.2.1,<1.92",
+    "imgui-bundle >=1.6,<1.92",
     "httpx",
 ]
 docs = [
@@ -49,7 +49,7 @@ docs = [
     "scikit-image",
     "trimesh <4.6",
     "gltflib",
-    "imgui-bundle>=1.6.0",
+    "imgui-bundle >=1.6<1.92",
     "httpx",
 ]
 tests = ["pytest", "psutil", "trimesh <4.6", "httpx", "gltflib", "imageio"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ docs = [
     "scikit-image",
     "trimesh <4.6",
     "gltflib",
-    "imgui-bundle >=1.6<1.92",
+    "imgui-bundle >=1.6,<1.92",
     "httpx",
 ]
 tests = ["pytest", "psutil", "trimesh <4.6", "httpx", "gltflib", "imageio"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ examples = [
     "scikit-image",
     "trimesh <4.6",
     "gltflib",
-    "imgui-bundle>=1.2.1",
+    "imgui-bundle >=1.2.1,<1.92",
     "httpx",
 ]
 docs = [


### PR DESCRIPTION
High time we switch ... so https://github.com/pygfx/wgpu-py/issues/627 can move forward.

* Replace `from wgpu.gui import WgpuCanvas, run` with `from rendercanvas import RenderCanvas, loop`
* Replace `run()` with `loop.run()`
* Examples that use Qt required a bit more care.
* Use `update_mode='fastest'` where `fps=-1` was used. See https://github.com/pygfx/rendercanvas/pull/99
* I tested quite a lot (but not all) examples. In the majority of examples the change is trivial.