### PR TITLE
Update uharfbuzz constraint for future proofing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,10 @@ dependencies = [
     "pylinalg >=0.6.7,<0.7.0",
     "numpy",
     "freetype-py",
-    # Something broke in uharfbuzz 0.51
-    # https://github.com/harfbuzz/uharfbuzz/releases/tag/v0.51.0
+    # ttb font shaping was brokein in uharfbuzz 0.51.0
+    # https://github.com/harfbuzz/uharfbuzz/issues/248
     # https://github.com/pygfx/pygfx/issues/1149
-    # This is a temporary bandaid
-    "uharfbuzz <0.51.0",
+    "uharfbuzz !=0.51.0",
     "jinja2",
     "hsluv >=5.0.0,<6.0.0",
 ]


### PR DESCRIPTION
Closes https://github.com/pygfx/pygfx/issues/1149

Upstream is cutting a new release as we speak