### PR TITLE
Adjust how version is reported when one checkouts a tag

### DIFF
--- a/pygfx/_version.py
+++ b/pygfx/_version.py
@@ -51,7 +51,9 @@ def get_extended_version():
     version = release
     if post and post != "0":
         version += f".post{post}"
-    if labels:
+        if labels:
+            version += "+" + ".".join(labels)
+    elif labels and labels[-1] == "dirty":
         version += "+" + ".".join(labels)
 
     return version


### PR DESCRIPTION
```
git checkout v0.12.0
python -c "import pygfx; print(pygfx.__version__)"
```

Old:
* `0.12.0+g15e3681e`
* `0.12.0`

But if it is "dirty"

* `0.12.0+g15e3681e.dirty`