### PR TITLE
Add  `environment`   Property to `Scene

### DIFF
--- a/docs/advanced_shaders.rst
+++ b/docs/advanced_shaders.rst
@@ -42,7 +42,7 @@ The shader must implement a few methods. A typical shader is shown below:
             if material.has_some_value:
                 self["some_template_variable"] = True
 
-        def get_bindings(self, wobject, shared):
+        def get_bindings(self, wobject, shared, scene):
 
             # You can also set template-variables here. Again, when things that are used here change later, this
             # is detected, and this method will be called again. When a binding has changed (e.g. a colormap is replaced
@@ -118,7 +118,7 @@ to allow flexible code generation. Here's an example:
 
 .. code-block:: python
 
-        def get_bindings(self, wobject, shared):
+        def get_bindings(self, wobject, shared, scene):
             # Template variables can be set like this
             self["scale"] = 1.2
             ...
@@ -318,7 +318,7 @@ For images / volumes:
 
 .. code-block:: python
 
-        def get_bindings(self, wobjwect, shared):
+        def get_bindings(self, wobject, shared, scene):
             ...
             extra_bindings = self.define_img_colormap(material.map)
             bindings.extend(extra_bindings)
@@ -343,7 +343,7 @@ For points / lines, meshes, etc.:
 
 .. code-block:: python
 
-        def get_bindings(self, wobjwect, shared):
+        def get_bindings(self, wobjwect, shared, scene):
             ...
             extra_bindings = self.define_vertex_colormap(material.map, geometry.texcoords)
             bindings.extend(extra_bindings)

--- a/examples/feature_demo/audio_visualizer.py
+++ b/examples/feature_demo/audio_visualizer.py
@@ -362,7 +362,7 @@ class AudioShader(BaseShader):
         if fragment_shader_code:
             self["fragment_shader_code"] = fragment_shader_code
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         material = wobject.material
 
         sampler = GfxSampler(material.interpolation, "clamp")

--- a/examples/feature_demo/custom_object1.py
+++ b/examples/feature_demo/custom_object1.py
@@ -44,7 +44,7 @@ class TriangleShader(BaseShader):
     # Mark as render-shader (as opposed to compute-shader)
     type = "render"
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         # Our only binding is a uniform buffer
         bindings = {
             0: Binding("u_stdinfo", "buffer/uniform", shared.uniform_buffer),

--- a/examples/feature_demo/custom_object2.py
+++ b/examples/feature_demo/custom_object2.py
@@ -61,7 +61,7 @@ class TriangleMaterial(gfx.Material):
 class TriangleShader(BaseShader):
     type = "render"
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         # We now use three uniform buffers
         bindings = {
             0: Binding("u_stdinfo", "buffer/uniform", shared.uniform_buffer),

--- a/examples/feature_demo/custom_object3.py
+++ b/examples/feature_demo/custom_object3.py
@@ -64,7 +64,7 @@ class TriangleMaterial(gfx.Material):
 class TriangleShader(BaseShader):
     type = "render"
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         geometry = wobject.geometry
 
         # This is how we set templating variables (dict-like access on the shader).

--- a/examples/feature_demo/gltf_viewer.py
+++ b/examples/feature_demo/gltf_viewer.py
@@ -90,10 +90,7 @@ scene.add(background)
 
 scene.add(gfx.Background.from_color((0.1, 0.1, 0.1, 1)))
 
-
-def add_env_map(obj, env_map):
-    if isinstance(obj, gfx.Mesh) and isinstance(obj.material, gfx.MeshStandardMaterial):
-        obj.material.env_map = env_map
+scene.environment = env_tex
 
 
 def load_remote_model(model_index):
@@ -130,8 +127,6 @@ def load_model(model_path):
             scene.remove(skeleton_helper)
 
         model_obj = gltf.scene if gltf.scene else gltf.scenes[0]
-        if state["ibl"]:
-            model_obj.traverse(lambda obj: add_env_map(obj, env_tex))
 
         skeleton_helper = gfx.SkeletonHelper(model_obj)
         skeleton_helper.visible = False
@@ -140,7 +135,12 @@ def load_model(model_path):
         state["selected_action"] = 0
 
         camera.show_object(model_obj, scale=1.4)
-        actions = None
+
+        if actions:
+            for action in actions:
+                action.stop()
+            actions = None
+
         clips = gltf.animations
         if clips:
             actions = [mixer.clip_action(clip) for clip in clips]
@@ -208,9 +208,9 @@ def draw_imgui():
             changed, state["ibl"] = imgui.checkbox("IBL", state["ibl"])
             if changed:
                 if state["ibl"]:
-                    model_obj.traverse(lambda obj: add_env_map(obj, env_tex))
+                    scene.environment = env_tex
                 else:
-                    model_obj.traverse(lambda obj: add_env_map(obj, None))
+                    scene.environment = None
 
         if imgui.collapsing_header("Visibility", imgui.TreeNodeFlags_.default_open):
             _, background.visible = imgui.checkbox(

--- a/examples/feature_demo/mesh_depth_material.py
+++ b/examples/feature_demo/mesh_depth_material.py
@@ -24,7 +24,7 @@ class DepthShader(MeshShader):
     # Mark as render-shader (as opposed to compute-shader)
     type = "render"
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         geometry = wobject.geometry
 
         bindings = {

--- a/examples/feature_demo/wireframe_material.py
+++ b/examples/feature_demo/wireframe_material.py
@@ -43,7 +43,7 @@ class WireframeMaterial(gfx.Material):
 class WireframeShader(BaseShader):
     type = "render"
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         geometry = wobject.geometry
         material = wobject.material
 

--- a/examples/validation/validate_ndc.py
+++ b/examples/validation/validate_ndc.py
@@ -32,7 +32,7 @@ class SquareMaterial(gfx.Material):
 
 @register_wgpu_render_function(Square, SquareMaterial)
 class SquareShader(BaseShader):
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         binding = Binding("u_stdinfo", "buffer/uniform", shared.uniform_buffer)
         self.define_binding(0, 0, binding)
         return {

--- a/pygfx/renderers/wgpu/engine/pipeline.py
+++ b/pygfx/renderers/wgpu/engine/pipeline.py
@@ -163,7 +163,7 @@ def get_cached_render_pipeline(device, *args):
     return result
 
 
-def get_pipeline_container_group(wobject, renderstate):
+def get_pipeline_container_group(wobject, scene, renderstate):
     """Return the PipelineContainerGroup object for wobject.
 
     This is the entrypoint for the renderer.
@@ -189,7 +189,7 @@ def get_pipeline_container_group(wobject, renderstate):
         PIPELINE_CONTAINER_GROUPS[pcg_key] = pipeline_container_group
 
     # Update. Quickly returns if no work to do.
-    pipeline_container_group.update(wobject, renderstate)
+    pipeline_container_group.update(wobject, scene, renderstate)
 
     # Return the pipeline container group
     return pipeline_container_group
@@ -210,7 +210,7 @@ class PipelineContainerGroup:
         self.render_containers = None
         self.bake_functions = None
 
-    def update(self, wobject, renderstate):
+    def update(self, wobject, scene, renderstate):
         """Update the pipeline containers. Creates (and re-creates) the containers if necessary."""
 
         # Get what has changed
@@ -267,9 +267,9 @@ class PipelineContainerGroup:
         # If something has changed, update containers
         if changed:
             for container in self.compute_containers:
-                container.update(wobject, renderstate, changed, tracker)
+                container.update(wobject, scene, renderstate, changed, tracker)
             for container in self.render_containers:
-                container.update(wobject, renderstate, changed, tracker)
+                container.update(wobject, scene, renderstate, changed, tracker)
 
 
 class PipelineContainer:
@@ -320,13 +320,13 @@ class PipelineContainer:
                 assert isinstance(key2, int), f"bind group slot must be int, not {key2}"
                 assert isinstance(b, Binding), f"binding must be Binding, not {b}"
 
-    def update(self, wobject, renderstate, changed, tracker):
+    def update(self, wobject, scene, renderstate, changed, tracker):
         """Make sure that the pipeline is up-to-date for the given renderstate."""
 
         # Ensure that the information provided by the shader is up-to-date
         if changed:
             try:
-                self.update_shader_data(wobject, changed, tracker)
+                self.update_shader_data(wobject, scene, changed, tracker)
             except Exception as err:
                 self.broken = 1
                 raise err
@@ -346,7 +346,7 @@ class PipelineContainer:
         if changed:
             logger.info(f"{wobject} shader update: {', '.join(sorted(changed))}.")
 
-    def update_shader_data(self, wobject, changed, tracker):
+    def update_shader_data(self, wobject, scene, changed, tracker):
         """Update the info that applies to all passes and renderstates."""
 
         if "create" in changed or "reset" in changed:
@@ -371,7 +371,7 @@ class PipelineContainer:
         if "bindings" in changed:
             with tracker.track_usage("!bindings"):
                 self.bindings_dicts = self.shader.get_bindings_info(
-                    wobject, self.shared
+                    wobject, self.shared, scene
                 )
             self._check_bindings()
             self.update_shader_hash()

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -77,6 +77,7 @@ class FlatScene:
         }
         self.shadow_objects = []
         self.object_count = object_count
+        self.scene = scene
         self.add_scene(scene)
 
     def add_scene(self, scene):
@@ -166,7 +167,9 @@ class FlatScene:
         self._compute_pipeline_containers = compute_pipeline_containers = []
         self._bake_functions = bake_functions = []
         for wrapper in self._wobject_wrappers:
-            container_group = get_pipeline_container_group(wrapper.wobject, renderstate)
+            container_group = get_pipeline_container_group(
+                wrapper.wobject, self.scene, renderstate
+            )
             compute_pipeline_containers.extend(container_group.compute_containers)
             wrapper.render_containers = container_group.render_containers
             for func in container_group.bake_functions:

--- a/pygfx/renderers/wgpu/shader/base.py
+++ b/pygfx/renderers/wgpu/shader/base.py
@@ -38,7 +38,7 @@ class ShaderInterface:
     def generate_wgsl(self, **template_vars):
         raise NotImplementedError()
 
-    def get_bindings_info(self, wobject, shared):
+    def get_bindings_info(self, wobject, shared, scene):
         """Subclasses must return a dict describing the buffers and
         textures used by this shader.
 
@@ -168,7 +168,7 @@ class BaseShader(ShaderInterface):
                 ]
             )
 
-    def get_bindings_info(self, wobject, shared):
+    def get_bindings_info(self, wobject, shared, scene):
         # We assume that in normal usage (by the pipeline.py logic),
         # this method is called first after initialization,
         # which means that we can handle the _template_vars_current here.
@@ -180,12 +180,12 @@ class BaseShader(ShaderInterface):
         self._binding_definitions.clear()
 
         try:
-            return self.get_bindings(wobject, shared)
+            return self.get_bindings(wobject, shared, scene)
         finally:
             self._template_vars_current = None
             self._hash = None  # template vars my have changed, so force a recalculation
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         # Default implementation returns zero bindings
         return {0: {}}
 

--- a/pygfx/renderers/wgpu/shaders/backgroundshader.py
+++ b/pygfx/renderers/wgpu/shaders/backgroundshader.py
@@ -19,7 +19,7 @@ from .. import (
 class BackgroundShader(BaseShader):
     type = "render"
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         material = wobject.material
 
         bindings = {}

--- a/pygfx/renderers/wgpu/shaders/gridshader.py
+++ b/pygfx/renderers/wgpu/shaders/gridshader.py
@@ -25,7 +25,7 @@ class GridShader(BaseShader):
         self["draw_major"] = material._gfx_draw_major
         self["draw_minor"] = material._gfx_draw_minor
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         material = wobject.material
 
         bindings = {}

--- a/pygfx/renderers/wgpu/shaders/imageshader.py
+++ b/pygfx/renderers/wgpu/shaders/imageshader.py
@@ -74,7 +74,7 @@ class ImageShader(BaseShader):
             self["use_colormap"] = True
             self["colorspace"] = material.map.texture.colorspace
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         geometry = wobject.geometry
         material = wobject.material
 

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -226,7 +226,7 @@ class LineShader(BaseShader):
         # Mark that the data has changed
         self.line_distance_buffer.update_range(r_offset, r_size)
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         material = wobject.material
         geometry = wobject.geometry
 
@@ -380,7 +380,7 @@ class ThinLineShader(LineShader):
         if self["color_mode"] in ("face", "face_map"):
             raise RuntimeError("Face coloring not supported for thin lines.")
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         material = wobject.material
         geometry = wobject.geometry
 

--- a/pygfx/renderers/wgpu/shaders/meshshader.py
+++ b/pygfx/renderers/wgpu/shaders/meshshader.py
@@ -133,7 +133,7 @@ class MeshShader(BaseShader):
 
         return bindings
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         geometry = wobject.geometry
         material = wobject.material
 
@@ -292,9 +292,10 @@ class MeshShader(BaseShader):
             self["use_normal_map"] = True
 
         # set envmap configs
-        if getattr(material, "env_map", None):
+        if getattr(material, "env_map", None) and not isinstance(
+            material, MeshStandardMaterial
+        ):
             # TODO: Support envmap not only cube, but also equirect (hdr format)
-
             # special check for env_map
             assert isinstance(material.env_map, TextureMap)
             assert material.env_map.texture.size[2] == 6, "env_map must be a cube map"
@@ -307,13 +308,8 @@ class MeshShader(BaseShader):
                 )  # check=False because we don't need texcoords for env_map
             )
 
-            if isinstance(material, MeshStandardMaterial):
-                self["USE_IBL"] = True
-            elif isinstance(material, MeshBasicMaterial):
-                self["use_env_map"] = True
-                self["env_combine_mode"] = getattr(
-                    material, "env_combine_mode", "MULTIPLY"
-                )
+            self["use_env_map"] = True
+            self["env_combine_mode"] = getattr(material, "env_combine_mode", "MULTIPLY")
 
             self["env_mapping_mode"] = getattr(
                 material, "env_mapping_mode", "CUBE-REFLECTION"
@@ -531,8 +527,8 @@ class MeshToonShader(MeshShader):
         super().__init__(wobject)
         self["lighting"] = "toon"
 
-    def get_bindings(self, wobject, shared):
-        result = super().get_bindings(wobject, shared)
+    def get_bindings(self, wobject, shared, scene):
+        result = super().get_bindings(wobject, shared, scene)
 
         geometry = wobject.geometry
         material = wobject.material
@@ -562,13 +558,33 @@ class MeshStandardShader(MeshShader):
         super().__init__(wobject)
         self["lighting"] = "pbr"
 
-    def get_bindings(self, wobject, shared):
-        result = super().get_bindings(wobject, shared)
+    def get_bindings(self, wobject, shared, scene):
+        result = super().get_bindings(wobject, shared, scene)
 
         geometry = wobject.geometry
         material = wobject.material
 
         bindings = []
+
+        if getattr(material, "env_map", None) or scene.environment:
+            # special check for env_map
+            env_map = getattr(material, "env_map", None) or scene.environment
+
+            assert isinstance(env_map, TextureMap)
+            assert env_map.texture.size[2] == 6, "env_map must be a cube map"
+            fmt = to_texture_format(env_map.texture.format)
+            assert "norm" in fmt or "float" in fmt
+
+            bindings.extend(
+                self._define_texture_map(
+                    geometry, env_map, "env_map", view_dim="cube", check=False
+                )  # check=False because we don't need texcoords for env_map
+            )
+
+            self["USE_IBL"] = True
+            self["env_mapping_mode"] = getattr(
+                material, "env_mapping_mode", "CUBE-REFLECTION"
+            )
 
         if material.roughness_map is not None:
             bindings.extend(
@@ -603,8 +619,8 @@ class MeshPhysicalShader(MeshStandardShader):
         self["USE_IOR"] = True
         self["USE_SPECULAR"] = True
 
-    def get_bindings(self, wobject, shared):
-        result = super().get_bindings(wobject, shared)
+    def get_bindings(self, wobject, shared, scene):
+        result = super().get_bindings(wobject, shared, scene)
 
         geometry = wobject.geometry
         material = wobject.material
@@ -784,7 +800,7 @@ class MeshSliceShader(BaseShader):
         else:
             raise RuntimeError(f"Unknown color_mode: '{color_mode}'")
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         # It would technically be possible to implement colormapping or
         # per-vertex colors, but its a tricky dance to get the per-vertex
         # data (e.g. texcoords) into a varying. And because the visual

--- a/pygfx/renderers/wgpu/shaders/pointsshader.py
+++ b/pygfx/renderers/wgpu/shaders/pointsshader.py
@@ -93,7 +93,7 @@ class PointsShader(BaseShader):
         if isinstance(material, PointsMarkerMaterial):
             self["draw_line_on_edge"] = True
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         geometry = wobject.geometry
         material = wobject.material
 

--- a/pygfx/renderers/wgpu/shaders/textshader.py
+++ b/pygfx/renderers/wgpu/shaders/textshader.py
@@ -26,7 +26,7 @@ class TextShader(BaseShader):
         self["aa"] = material.aa
         self["REF_GLYPH_SIZE"] = REF_GLYPH_SIZE
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         geometry = wobject.geometry
         material = wobject.material
 

--- a/pygfx/renderers/wgpu/shaders/volumeshader.py
+++ b/pygfx/renderers/wgpu/shaders/volumeshader.py
@@ -56,7 +56,7 @@ class BaseVolumeShader(BaseShader):
         if material.map is not None:
             self["colorspace"] = material.map.texture.colorspace
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         geometry = wobject.geometry
         material = wobject.material
 
@@ -105,7 +105,7 @@ class VolumeSliceShader(BaseVolumeShader):
 class VolumeRayShader(BaseVolumeShader):
     type = "render"
 
-    def get_bindings(self, wobject, shared):
+    def get_bindings(self, wobject, shared, scene):
         render_mode = wobject.material.render_mode
 
         # Fall back to MIP, because we've written our examples to use the plain VolumeRayMaterial for quite a while.
@@ -117,7 +117,7 @@ class VolumeRayShader(BaseVolumeShader):
                 f"Invalid value for {wobject.material.__class__.__name__}.render_mode: {render_mode!r}. Use an appropriate volume material, e.g. VolumeMipMaterial or VolumeIsoMaterial."
             )
         self["mode"] = render_mode
-        return super().get_bindings(wobject, shared)
+        return super().get_bindings(wobject, shared, scene)
 
     def get_pipeline_info(self, wobject, shared):
         return {

--- a/pygfx/resources/_texturemap.py
+++ b/pygfx/resources/_texturemap.py
@@ -1,6 +1,7 @@
 import numpy as np
 from ..utils.trackable import Trackable
 from ..resources import Buffer
+from ..resources import Texture
 from ..utils import array_from_shadertype
 
 
@@ -42,7 +43,7 @@ class TextureMap(Trackable):
 
     def __init__(
         self,
-        texture,
+        texture: Texture,
         *,
         uv_channel=0,
         filter="linear",
@@ -72,12 +73,12 @@ class TextureMap(Trackable):
         self.update_matrix()
 
     @property
-    def texture(self):
+    def texture(self) -> Texture:
         """The texture to use for this map."""
         return self._store.texture
 
     @texture.setter
-    def texture(self, value):
+    def texture(self, value: Texture):
         self._store.texture = value
 
     @property

--- a/tests/usecases/test_wobject_updates.py
+++ b/tests/usecases/test_wobject_updates.py
@@ -30,6 +30,7 @@ class PipelineSnapshotter:
         self.world_object = world_object
         self.renderer = renderer
         flat = FlatScene(scene, None)
+        self.scene = scene
         self.env = get_renderstate(flat.lights, renderer._blender)
         self._snapshot()
 
@@ -41,7 +42,7 @@ class PipelineSnapshotter:
         # the equivalent what happens during a call. This means we don't need to
         # perform an actual draw.
         pipeline_container_group = get_pipeline_container_group(
-            self.world_object, self.env
+            self.world_object, self.scene, self.env
         )
         pipeline_container = pipeline_container_group.render_containers[0]
 


### PR DESCRIPTION
### Summary:

This PR introduces support for a scene-level environment map via the `scene.environment` attribute.  It adds a `scene` parameter to the `get_bindings` method of all shaders in pygfx's WGPU renderer. This change enables shaders and render pipelines to access global, scene-wide information.

### Motivation:
In some cases, when rendering an object in a scene, the shader needs access to resources beyond the object itself—such as data defined at the scene level.
For instance, in PBR rendering, Image-Based Lighting (IBL) relies on an environment map that acts like a special kind of light source, affecting all PBR materials in the scene.
Previously, users had to manually assign the environment map to each material via the `env_map` property, which was inconvenient and error-prone.

This PR makes it possible to define a global environment map at the scene level, enabling centralized control of environmental lighting.
If a material such as `MeshStandardMaterial` or `MeshPhysicalMaterial` does not explicitly define its own environment map, it will now automatically fall back to the one defined on the scene.

This mechanism also lays the groundwork for other potential scene-level resources, such as fog.

### Key Changes:

- The `get_bindings` method signature in `BaseShader` is changed from `get_bindings(wobject, shared)` to `get_bindings(wobject, shared, scene)`.
- The `scene` parameter is now properly passed to all shader instances during pipeline updates.

