### PR TITLE
updated "expected 1.0" to 1 year from today

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ essence, you need modern (enough) graphics drivers, and `pip>=20.3`.
 ## Status
 
 We're currently working towards version `1.0`, which means that the API
-can change with each version. We expect to reach `1.0` near the end of
-2024, at which point we start caring about backwards compatibility.
+can change with each version. We expect to reach `1.0` near July 2026, 
+at which point we start caring about backwards compatibility.
 
 This means that until then, you should probably pin the Pygfx version
 that you're using, and check the [release notes](https://github.com/pygfx/pygfx/releases)


### PR DESCRIPTION
I'm just making a guess. 

But it always feel like projects are "active" when they don't have these kinds of references to the past.