### PR TITLE
ColorSpace Management

### DIFF
--- a/examples/feature_demo/dynamic_env_map.py
+++ b/examples/feature_demo/dynamic_env_map.py
@@ -36,7 +36,11 @@ cube_size = env_img.shape[1]
 env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
 
 env_static = gfx.Texture(
-    env_img, dim=2, size=(cube_size, cube_size, 6), generate_mipmaps=True
+    env_img,
+    dim=2,
+    size=(cube_size, cube_size, 6),
+    generate_mipmaps=True,
+    colorspace="tex-srgb",
 )
 
 # Create the dynamic env map

--- a/examples/feature_demo/earth.py
+++ b/examples/feature_demo/earth.py
@@ -46,11 +46,11 @@ scene = gfx.Scene()
 earth_geometry = gfx.sphere_geometry(63.71, 100, 50)
 
 
-def load_texture(path, flip=False):
+def load_texture(path, flip=False, colorspace="tex-srgb"):
     img = iio.imread(path)
     if flip:
         img = np.ascontiguousarray(np.flipud(img))
-    tex = gfx.Texture(img, dim=2)
+    tex = gfx.Texture(img, dim=2, colorspace=colorspace)
     return tex
 
 
@@ -75,7 +75,7 @@ earth_material.emissive_intensity = 3.0
 # earth_material.light_map_intensity = 3.0
 
 earth_material.normal_map = load_texture(
-    model_dir / "planets" / "earth_normal_2048.jpg", flip=True
+    model_dir / "planets" / "earth_normal_2048.jpg", flip=True, colorspace="physical"
 )
 earth_material.normal_scale = 0.85, -0.85
 

--- a/examples/feature_demo/env_maps.py
+++ b/examples/feature_demo/env_maps.py
@@ -47,7 +47,11 @@ env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
 
 # Create environment map
 env_tex = gfx.Texture(
-    env_img, dim=2, size=(cube_size, cube_size, 6), generate_mipmaps=True
+    env_img,
+    dim=2,
+    size=(cube_size, cube_size, 6),
+    generate_mipmaps=True,
+    colorspace="tex-srgb",
 )
 
 teapot = trimesh.load(TEAPOT)

--- a/examples/feature_demo/gltf_viewer.py
+++ b/examples/feature_demo/gltf_viewer.py
@@ -81,14 +81,18 @@ env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
 
 # Create environment map
 env_tex = gfx.Texture(
-    env_img, dim=2, size=(cube_size, cube_size, 6), generate_mipmaps=True
+    env_img,
+    dim=2,
+    size=(cube_size, cube_size, 6),
+    generate_mipmaps=True,
+    colorspace=gfx.ColorSpace.srgb,
 )
 
 background = gfx.Background(None, gfx.BackgroundSkyboxMaterial(map=env_tex))
 background.visible = False
 scene.add(background)
 
-scene.add(gfx.Background.from_color((0.1, 0.1, 0.1, 1)))
+scene.add(gfx.Background.from_color(gfx.Color(0.1, 0.1, 0.1, 1).to_physical()))
 
 
 def add_env_map(obj, env_map):

--- a/examples/feature_demo/lightmap.py
+++ b/examples/feature_demo/lightmap.py
@@ -42,7 +42,7 @@ renderer = gfx.renderers.WgpuRenderer(canvas)
 meshes = gfx.load_gltf_mesh(model_dir / "lightmap" / "scene.gltf", materials=False)
 
 light_map = iio.imread(model_dir / "lightmap" / "lightmap-ao-shadow.png")
-light_map_tex = gfx.Texture(light_map, dim=2)
+light_map_tex = gfx.Texture(light_map, dim=2, colorspace="tex-srgb")
 
 # Create camera and controller
 camera = gfx.PerspectiveCamera(45, 1)

--- a/pygfx/__init__.py
+++ b/pygfx/__init__.py
@@ -17,6 +17,14 @@ from .animation import *
 from .renderers import *
 
 from .utils.color import Color
+
+from .utils.show import show, Display
+from .utils.viewport import Viewport
+from .utils.text import font_manager
+from .utils import cm, enums, logger
+from .utils.enums import *
+from .utils.color_management import ColorManagement
+
 from .utils.load import load_mesh, load_meshes, load_scene
 from .utils.load_gltf import (
     load_gltf,
@@ -25,11 +33,6 @@ from .utils.load_gltf import (
     load_gltf_mesh_async,
     print_scene_graph,
 )
-from .utils.show import show, Display
-from .utils.viewport import Viewport
-from .utils.text import font_manager
-from .utils import cm, enums, logger
-from .utils.enums import *
 
 # Temp fix for pyinstaller to pick up pylinalg
 import pylinalg

--- a/pygfx/animation/keyframe_track.py
+++ b/pygfx/animation/keyframe_track.py
@@ -23,7 +23,7 @@ class KeyframeTrack:
             # remove adjacent keyframes scheduled at the same times
             if time != prev_time:
                 if np.any(value != prev_value):
-                    if prev_time is not None:
+                    if prev_time != optimized_times[-1] if optimized_times else None:
                         optimized_times.append(prev_time)
                         optimized_values.append(prev_value)
                     optimized_times.append(time)

--- a/pygfx/renderers/wgpu/shaders/imageshader.py
+++ b/pygfx/renderers/wgpu/shaders/imageshader.py
@@ -61,7 +61,6 @@ class ImageShader(BaseShader):
 
         # Determine colorspace
         self["colorspace"] = geometry.grid.colorspace
-        self["colorrange"] = geometry.grid.colorrange
         self["three_grid_yuv"] = (
             self["colorspace"] in ["yuv420p", "yuv444p"] and geometry.grid.size[2] == 1
         )

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -485,7 +485,7 @@ class ThinLineShader(LineShader):
                 let color = u_material.color;
             $$ endif
 
-            let physical_color = srgb2physical(color.rgb);
+            let physical_color = color.rgb;
             let opacity = color.a * u_material.opacity;
             let out_color = vec4<f32>(physical_color, opacity);
 

--- a/pygfx/renderers/wgpu/wgsl/background.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/background.wgsl
@@ -75,10 +75,11 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
             + u_material.color_top_left * (1.0 - f.x) * f.y
             + u_material.color_top_right * f.x * f.y
         );
+        final_color = vec4<f32>(final_color.rgb, final_color.a);
     $$ endif
 
     // Make physical color with combined alpha
-    let physical_color = srgb2physical(final_color.rgb);
+    let physical_color = final_color.rgb;
     let opacity = final_color.a * u_material.opacity;
     let out_color = vec4<f32>(physical_color, opacity);
 

--- a/pygfx/renderers/wgpu/wgsl/grid.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/grid.wgsl
@@ -273,7 +273,7 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
     // ---------------------
 
     // Make physical color with combined alpha
-    let physical_color = srgb2physical(color.rgb);
+    let physical_color = color.rgb;
     let opacity = alpha * color.a * u_material.opacity;
     let out_color = vec4<f32>(physical_color, opacity);
 

--- a/pygfx/renderers/wgpu/wgsl/image.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/image.wgsl
@@ -45,14 +45,8 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
     let value = sample_im(varyings.texcoord.xy, sizef);
     let color = sampled_value_to_color(value);
 
-    // Move to physical colorspace (linear photon count) so we can do math
-    $$ if colorspace == 'srgb' or colorspace.startswith('yuv')
-        let physical_color = srgb2physical(color.rgb);
-    $$ else
-        let physical_color = color.rgb;
-    $$ endif
     let opacity = color.a * u_material.opacity;
-    let out_color = vec4<f32>(physical_color, opacity);
+    let out_color = vec4<f32>(color.rgb, opacity);
 
     do_alpha_test(opacity);
 

--- a/pygfx/renderers/wgpu/wgsl/image_common.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/image_common.wgsl
@@ -31,45 +31,7 @@ fn yuv_full_to_rgb(y: f32, u: f32, v: f32) -> vec4<f32> {
 
 fn sample_im(texcoord: vec2<f32>, sizef: vec2<f32>) -> vec4<f32> {
     $$ if img_format == 'f32'
-        $$ if colorspace == 'yuv420p'
-            $$ if three_grid_yuv
-            let y = textureSample(t_img, s_img, texcoord.xy).x;
-            let u = textureSample(t_u_img, s_img, texcoord.xy).x;
-            let v = textureSample(t_v_img, s_img, texcoord.xy).x;
-            $$ else
-            // In this implementation we share a single 2D texture between U and V
-            // We must therefore take care to not sample at the edge where
-            // the texture will be poorly interpolated. See
-            // https://github.com/pygfx/pygfx/pull/873#issuecomment-2516613301
-            let txy = clamp(texcoord.xy / 2.0, 0.5 / sizef, 0.5 - 0.5 / sizef);
-            let y = textureSample(t_img, s_img, texcoord.xy, 0).x;
-            let u = textureSample(t_img, s_img, txy, 1).x;
-            let v = textureSample(t_img, s_img, txy + vec2<f32>(0.5, 0.0), 1).x;
-            $$ endif
-
-            $$ if colorrange == "limited"
-            return yuv_limited_to_rgb(y, u, v);
-            $$ else
-            return yuv_full_to_rgb(y, u, v);
-            $$ endif
-        $$ elif colorspace == "yuv444p"
-            $$ if three_grid_yuv
-            let y = textureSample(t_img, s_img, texcoord.xy).x;
-            let u = textureSample(t_u_img, s_img, texcoord.xy).x;
-            let v = textureSample(t_v_img, s_img, texcoord.xy).x;
-            $$ else
-            let y = textureSample(t_img, s_img, texcoord.xy, 0).x;
-            let u = textureSample(t_img, s_img, texcoord.xy, 1).x;
-            let v = textureSample(t_img, s_img, texcoord.xy, 2).x;
-            $$ endif
-            $$ if colorrange == "limited"
-            return yuv_limited_to_rgb(y, u, v);
-            $$ else
-            return yuv_full_to_rgb(y, u, v);
-            $$ endif
-        $$ else
-            return textureSample(t_img, s_img, texcoord.xy);
-        $$ endif
+        return textureSample(t_img, s_img, texcoord.xy);
     $$ else
         let texcoords_u = vec2<i32>(texcoord.xy * sizef.xy);
         return vec4<f32>(textureLoad(t_img, texcoords_u, 0));

--- a/pygfx/renderers/wgpu/wgsl/light_common.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/light_common.wgsl
@@ -38,7 +38,7 @@ struct GeometricContext {
 $$ if num_dir_lights > 0
 fn getDirectionalLightInfo( directional_light: DirectionalLight, geometry: GeometricContext ) -> IncidentLight {
     var light: IncidentLight;
-    light.color = srgb2physical(directional_light.color.rgb) * directional_light.intensity;
+    light.color = directional_light.color.rgb * directional_light.intensity;
     light.direction = -directional_light.direction.xyz;
     light.visible = true;
     return light;
@@ -51,7 +51,7 @@ fn getPointLightInfo( point_light: PointLight, geometry: GeometricContext ) -> I
     let i_vector = point_light.world_transform[3].xyz - geometry.position;
     light.direction = normalize(i_vector);
     let light_distance = length(i_vector);
-    light.color = srgb2physical(point_light.color.rgb) * point_light.intensity;
+    light.color = point_light.color.r * point_light.intensity;
     light.color *= getDistanceAttenuation( light_distance, point_light.distance, point_light.decay );
     light.visible = any(light.color != vec3<f32>(0.0));
     return light;
@@ -67,7 +67,7 @@ fn getSpotLightInfo( spot_light: SpotLight, geometry: GeometricContext ) -> Inci
     let spot_attenuation = getSpotAttenuation(spot_light.cone_cos, spot_light.penumbra_cos, angle_cos);
     if ( spot_attenuation > 0.0 ) {
         let light_distance = length( i_vector );
-        light.color = srgb2physical(spot_light.color.rgb) * spot_light.intensity;
+        light.color = spot_light.color.rgb * spot_light.intensity;
         light.color *= spot_attenuation;
         light.color *= getDistanceAttenuation( light_distance, spot_light.distance, spot_light.decay );
         light.visible = any(light.color != vec3<f32>(0.0));

--- a/pygfx/renderers/wgpu/wgsl/light_pbr.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/light_pbr.wgsl
@@ -202,8 +202,8 @@ fn getMipLevel(maxMIPLevelScalar: f32, level: f32) -> f32 {
 
 fn getIBLIrradiance( normal: vec3<f32> ) -> vec3<f32> {
     let mip_level = getMipLevel(u_material.env_map_max_mip_level, 1.0);
-    let envMapColor_srgb = textureSampleLevel( t_env_map, s_env_map, vec3<f32>( -normal.x, normal.yz), mip_level );
-    return srgb2physical(envMapColor_srgb.rgb) * u_material.env_map_intensity * PI;
+    let envMapColor = textureSampleLevel( t_env_map, s_env_map, vec3<f32>( -normal.x, normal.yz), mip_level );
+    return envMapColor.rgb * u_material.env_map_intensity * PI;
 }
 
 fn getIBLRadiance(view_dir: vec3<f32>, normal: vec3<f32>, roughness: f32) -> vec3<f32> {
@@ -215,8 +215,8 @@ fn getIBLRadiance(view_dir: vec3<f32>, normal: vec3<f32>, roughness: f32) -> vec
         let mip_level = 1.0;
     $$ endif
     reflectVec = normalize(mix(reflectVec, normal, roughness*roughness));
-    let envMapColor_srgb = textureSampleLevel( t_env_map, s_env_map, vec3<f32>( -reflectVec.x, reflectVec.yz), mip_level );
-    return srgb2physical(envMapColor_srgb.rgb) * u_material.env_map_intensity;
+    let envMapColor = textureSampleLevel( t_env_map, s_env_map, vec3<f32>( -reflectVec.x, reflectVec.yz), mip_level );
+    return envMapColor.rgb * u_material.env_map_intensity;
 }
 
 

--- a/pygfx/renderers/wgpu/wgsl/light_pbr_fragment.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/light_pbr_fragment.wgsl
@@ -29,10 +29,10 @@ $$ if USE_IOR is defined
 
     $$ if USE_SPECULAR
         var specular_intensity = u_material.specular_intensity;
-        var specular_color = srgb2physical(u_material.specular_color.rgb);
-        
+        var specular_color = u_material.specular_color.rgb;
+
         $$ if use_specular_map is defined
-            specular_color *= srgb2physical(textureSample( t_specular_map, s_specular_map, specular_map_uv ).rgb);
+            specular_color *= textureSample( t_specular_map, s_specular_map, specular_map_uv ).rgb;
         $$ endif
 
         $$ if use_specular_intensity_map is defined
@@ -113,7 +113,7 @@ $$ endif
 
 $$ if USE_SHEEN is defined
 
-    material.sheen_color = srgb2physical(u_material.sheen_color.rgb) * u_material.sheen;
+    material.sheen_color = u_material.sheen_color.rgb * u_material.sheen;
 
     $$ if use_sheen_color_map is defined
         material.sheen_color *= textureSample( t_sheen_color_map, s_sheen_color_map, varyings.texcoord{{sheen_color_map_uv or ''}} ).rgb;

--- a/pygfx/renderers/wgpu/wgsl/light_phong_fragment.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/light_phong_fragment.wgsl
@@ -1,5 +1,5 @@
 var material: BlinnPhongMaterial;
 material.diffuse_color = physical_albeido;
-material.specular_color = srgb2physical(u_material.specular_color.rgb);
+material.specular_color = u_material.specular_color.rgb;
 material.specular_shininess = u_material.shininess;
 material.specular_strength = specular_strength;

--- a/pygfx/renderers/wgpu/wgsl/light_phong_simple.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/light_phong_simple.wgsl
@@ -8,7 +8,7 @@
     view_dir: vec3<f32>,
     albeido: vec3<f32>,
 ) -> vec3<f32> {
-    let light_color = srgb2physical(vec3<f32>(1.0, 1.0, 1.0));
+    let light_color = vec3<f32>(1.0, 1.0, 1.0);
 
     // Light parameters
     let ambient_factor = 0.1;
@@ -35,7 +35,7 @@
     let specular_color = specular_factor * specular_term * light_color;
 
     // Emissive color is additive and unaffected by lights
-    let emissive_color = srgb2physical(u_material.emissive_color.rgb);
+    let emissive_color = u_material.emissive_color.rgb;
 
     // Put together
     return albeido * (ambient_color + diffuse_color) + specular_color + emissive_color;

--- a/pygfx/renderers/wgpu/wgsl/line.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/line.wgsl
@@ -974,7 +974,7 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
     $$ else
         let color = u_material.color;
     $$ endif
-    var physical_color = srgb2physical(color.rgb);
+    var physical_color = color.rgb;
 
     $$ if false
         // Alternative debug options during dev.

--- a/pygfx/renderers/wgpu/wgsl/mesh_normal_lines.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/mesh_normal_lines.wgsl
@@ -57,17 +57,10 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
     {$ include 'pygfx.clipping_planes.wgsl' $}
 
     let color_value = u_material.color;
-    let albeido = color_value.rgb;
 
-    // Move to physical colorspace (linear photon count) so we can do math
-    $$ if colorspace == 'srgb'
-        let physical_albeido = srgb2physical(albeido);
-    $$ else
-        let physical_albeido = albeido;
-    $$ endif
     let opacity = color_value.a * u_material.opacity;
 
-    var physical_color = physical_albeido;
+    var physical_color = color_value.rgb;
     let out_color = vec4<f32>(physical_color, opacity);
 
     do_alpha_test(opacity);

--- a/pygfx/renderers/wgpu/wgsl/mesh_slice.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/mesh_slice.wgsl
@@ -226,9 +226,8 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
     // No aa. This is something we need to decide on. See line renderer.
     let alpha = 1.0;
     // Set color
-    let physical_color = srgb2physical(albeido);
     let opacity = min(1.0, color_value.a) * alpha;
-    let out_color = vec4<f32>(physical_color, opacity);
+    let out_color = vec4<f32>(albeido, opacity);
 
     do_alpha_test(opacity);
 

--- a/pygfx/renderers/wgpu/wgsl/points.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/points.wgsl
@@ -364,9 +364,9 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
     $$ endif
 
     $$ if color_mode == 'debug'
-        let out_color = vec4<f32>(srgb2physical(the_color.rgb), the_color.a);
+        let out_color = the_color;
     $$ else
-        let out_color = vec4<f32>(srgb2physical(the_color.rgb), the_color.a * u_material.opacity);
+        let out_color = vec4<f32>(the_color.rgb, the_color.a * u_material.opacity);
     $$ endif
 
     // Always discard the empty space, but also allow custom alpha test

--- a/pygfx/renderers/wgpu/wgsl/text.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/text.wgsl
@@ -288,7 +288,7 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
     // Get color for this fragment
     let base_srgb = u_material.color;
     let outline_srgb = u_material.outline_color;
-    let color = mix(srgb2physical(base_srgb.rgb), srgb2physical(outline_srgb.rgb), outline);
+    let color = mix(base_srgb.rgb, outline_srgb.rgb, outline);
     let color_alpha = mix(base_srgb.a, outline_srgb.a, outline);
 
     // Compose total opacity and the output color

--- a/pygfx/renderers/wgpu/wgsl/volume_ray.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/volume_ray.wgsl
@@ -198,14 +198,9 @@ $$ if mode == 'mip'
 
         // Colormapping
         let color = sampled_value_to_color(the_value);
-        // Move to physical colorspace (linear photon count) so we can do math
-        $$ if colorspace == 'srgb'
-            let physical_color = srgb2physical(color.rgb);
-        $$ else
-            let physical_color = color.rgb;
-        $$ endif
+
         let opacity = color.a * u_material.opacity;
-        let out_color = vec4<f32>(physical_color, opacity);
+        let out_color = vec4<f32>(color.rgb, opacity);
 
         // Produce result
         var out: RenderOutput;
@@ -267,14 +262,9 @@ $$ elif mode == 'minip'
 
         // Colormapping
         let color = sampled_value_to_color(the_value);
-        // Move to physical colorspace (linear photon count) so we can do math
-        $$ if colorspace == 'srgb'
-            let physical_color = srgb2physical(color.rgb);
-        $$ else
-            let physical_color = color.rgb;
-        $$ endif
+
         let opacity = color.a * u_material.opacity;
-        let out_color = vec4<f32>(physical_color, opacity);
+        let out_color = vec4<f32>(color.rgb, opacity);
 
         // Produce result
         var out: RenderOutput;
@@ -342,12 +332,6 @@ $$ elif mode == 'iso'
 
         // Colormapping
         let color = sampled_value_to_color(the_value);
-        // Move to physical colorspace (linear photon count) so we can do math
-        $$ if colorspace == 'srgb'
-            let physical_color = srgb2physical(color.rgb);
-        $$ else
-            let physical_color = color.rgb;
-        $$ endif
 
         // Compute the normal
         var normal : vec3<f32>;
@@ -371,7 +355,7 @@ $$ elif mode == 'iso'
         // Do the lighting
         let view_direction = normalize(step_coord);
         let is_front = dot(normal, view_direction) > 0.0;
-        let lighted_color = lighting_phong(is_front, normal, view_direction, physical_color);
+        let lighted_color = lighting_phong(is_front, normal, view_direction, color.rgb);
 
         let opacity = color.a * u_material.opacity;
         let out_color = vec4<f32>(lighted_color, opacity);

--- a/pygfx/renderers/wgpu/wgsl/volume_slice.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/volume_slice.wgsl
@@ -179,14 +179,8 @@ fn fs_main(varyings: Varyings) -> FragmentOutput {
     let value = sample_vol(varyings.texcoord.xyz, sizef);
     let color = sampled_value_to_color(value);
 
-    // Move to physical colorspace (linear photon count) so we can do math
-    $$ if colorspace == 'srgb'
-        let physical_color = srgb2physical(color.rgb);
-    $$ else
-        let physical_color = color.rgb;
-    $$ endif
     let opacity = color.a * u_material.opacity;
-    let out_color = vec4<f32>(physical_color, opacity);
+    let out_color = vec4<f32>(color.rgb, opacity);
 
     do_alpha_test(out_color.a);
 

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -12,6 +12,7 @@ from ._utils import (
     make_little_endian,
     logger,
 )
+from ..utils.enums import ColorSpace
 
 
 class Texture(Resource):
@@ -41,13 +42,7 @@ class Texture(Resource):
         Can also be wgpu's ``TextureFormat``. Optional: if None, it is
         automatically determined from the data.
     colorspace : str
-        If this data is used as color, it is interpreted to be in this
-        colorspace. Can be "srgb", "tex-srgb", "physical", "yuv420p", or "yuv444p". Default "srgb".
-    colorrange : str
-        For YUV textures, this is either "limited", or "full". For the limited range,
-        the luma plane is limited between 16-235, and the chroma planes (U and V) are
-        limited to 16-240. While it may seem suboptimal, many videos are stored in
-        the limited colorrange.
+        If this data is used as color, it is interpreted to be in this colorspace.
     generate_mipmaps : bool
         If True, automatically generates mipmaps when transferring data to the
         GPU. Default False.
@@ -84,8 +79,7 @@ class Texture(Resource):
         dim,
         size=None,
         format=None,
-        colorspace="srgb",
-        colorrange="limited",
+        colorspace=ColorSpace.no_colorspace,
         generate_mipmaps=False,
         chunk_size=None,
         force_contiguous=False,
@@ -107,16 +101,8 @@ class Texture(Resource):
         self._force_contiguous = bool(force_contiguous)
         assert dim in (1, 2, 3)
         self._store.dim = int(dim)
-        self._colorspace = (colorspace or "srgb").lower()
-        assert self._colorspace in (
-            "srgb",
-            "tex-srgb",
-            "physical",
-            "yuv420p",
-            "yuv444p",
-        )
-        self._colorrange = (colorrange or "limited").lower()
-        assert self._colorrange in ("limited", "full")
+        self._colorspace = colorspace
+
         self._generate_mipmaps = bool(generate_mipmaps)
 
         # Normalize size
@@ -273,43 +259,8 @@ class Texture(Resource):
 
     @property
     def colorspace(self):
-        """If this data is used as color, it is interpreted to be in this colorspace.
-        Can be "srgb", "tex-srgb", "physical", "yuv420p", or "yuv444p". Default "srgb".
-
-        * "srgb": the data represents intensity, rgb, or rgba pixels in the sRGB space.
-          sRGB is a standard color space designed for consistent representation of colors
-          across devices like monitors. Most images store colors in this space.
-          The shader convers sRGB colors to physical in the shader before doing color computations.
-        * "tex-srgb": the underlying texture will be of an sRGB format. This means the data
-          is automatically converted to sRGB when it is sampled. This results in better glTF
-          compliance (because interpolation in the sampling happens in linear space).
-          Note that sampling *always* results in the sRGB values, also when not interpreted as color.
-          Only supported for rgb and rgba data.
-        * "physical": the colors are (already) in the physical / linear space, where lighting
-          calculations can be applied. Shader code that interprets the data as color will use it as-is.
-        * "yuv420p": A common video format. The data is represented as 3 planes (y, u, and v).
-          The y represents intensity, and is at full resolution. The u and v planes are a
-          quarter of the size. The planes must be stored in two layers of the texture,
-          with the u and v plane next to each-other in top half the second layer.
-        * "yuv444p": A lesser common video format. The data is represented as 3 planes
-          (y, u, and v) similar to yuv420p however the u and v planes are stored
-          at full resolution.
-        """
+        """If this data is used as color, it is interpreted to be in this colorspace."""
         return self._colorspace
-
-    @property
-    def colorrange(self):
-        """For YUV textures, this is either "limited", or "full".
-
-        * "limited": The luma plane (Y) is limited to the range of 16-235 for 8 bits.
-                     The chroma planes (U and V) are limited to the range of 16-240 for 8 bits
-        * "full": The luma plane and chroma plane use the full range of the storage format.
-
-        See the following links from the FFMPEG documentation for more details:
-        https://trac.ffmpeg.org/wiki/colorspace
-        https://ffmpeg.org/doxygen/7.0/pixfmt_8h_source.html#l00609
-        """
-        return self._colorrange
 
     @property
     def generate_mipmaps(self):

--- a/pygfx/utils/__init__.py
+++ b/pygfx/utils/__init__.py
@@ -44,6 +44,7 @@ import numpy as np
 
 from .color import Color  # noqa: F401
 from . import enums  # noqa: F401
+from .color_management import ColorManagement  # noqa: F401
 
 from ._dirs import get_resources_dir, get_cache_dir  # noqa: F401
 

--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -163,7 +163,7 @@ class Color:
         if colorspace is not None:
             ColorManagement.convert_to_working_space(self, colorspace)
 
-    def _set_from_str(self, color):
+    def _set_from_str(self, color, colorspace=None):
         color = color.lower()
         if color.startswith("#"):
             # A hex number
@@ -238,6 +238,12 @@ class Color:
                 raise ValueError(f"Unknown color: '{color}'") from None
             else:
                 self._set_from_str(color_int)
+
+        if colorspace is None:
+            # for css colors, we assume in srgb colorspace default
+            colorspace = ColorSpace.srgb
+
+        ColorManagement.convert_to_working_space(self, colorspace)
 
     @property
     def rgba(self):

--- a/pygfx/utils/color.py
+++ b/pygfx/utils/color.py
@@ -3,6 +3,8 @@
 import ctypes
 import colorsys
 import hsluv
+from .enums import ColorSpace
+from .color_management import ColorManagement
 
 F4 = ctypes.c_float * 4
 
@@ -76,19 +78,19 @@ class Color:
     # Internally, the color is a ctypes float array
     __slots__ = ["_val"]
 
-    def __init__(self, *args):
+    def __init__(self, *args, colorspace=None):
         if len(args) == 1:
             color = args[0]
             if isinstance(color, (int, float)):
-                self._set_from_tuple(args)
+                self._set_from_tuple(args, colorspace=colorspace)
             elif isinstance(color, str):
-                self._set_from_str(color)
+                self._set_from_str(color, colorspace=colorspace)
             else:
                 # Assume it's an iterable,
                 # may raise TypeError 'object is not iterable'
-                self._set_from_tuple(color)
+                self._set_from_tuple(color, colorspace=colorspace)
         else:
-            self._set_from_tuple(args)
+            self._set_from_tuple(args, colorspace=colorspace)
 
     def __repr__(self):
         # A precision of 4 decimals, i.e. 10001 possible values for each color.
@@ -145,7 +147,7 @@ class Color:
         a = max(0.0, min(1.0, float(a)))
         self._val = F4(float(r), float(g), float(b), a)
 
-    def _set_from_tuple(self, color):
+    def _set_from_tuple(self, color, colorspace=None):
         color = tuple(float(c) for c in color)
         if len(color) == 4:
             self._set_from_rgba(*color)
@@ -157,6 +159,9 @@ class Color:
             self._set_from_rgba(color[0], color[0], color[0], 1)
         else:
             raise ValueError(f"Cannot parse color tuple with {len(color)} values")
+
+        if colorspace is not None:
+            ColorManagement.convert_to_working_space(self, colorspace)
 
     def _set_from_str(self, color):
         color = color.lower()

--- a/pygfx/utils/color_management.py
+++ b/pygfx/utils/color_management.py
@@ -1,0 +1,50 @@
+from .enums import ColorSpace
+from .color import Color
+
+
+def _srgb_to_linear(c):
+    # The simplified version has a maximum error less than 1%, but that's still
+    # two steps in the range 0..255.
+    # return c ** 2.2
+    return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
+def _linear_to_srgb(c):
+    # return c ** (1 / 2.2)
+    return c * 12.92 if c <= 0.0031308 else c ** (1 / 2.4) * 1.055 - 0.055
+
+
+class _ColorManagement:
+    def __init__(self):
+        self._working_color_space = ColorSpace.linear_srgb
+
+    @property
+    def working_color_space(self):
+        """The working color space used for rendering."""
+        return self._working_color_space
+
+    @working_color_space.setter
+    def working_color_space(self, value):
+        """Set the working color space."""
+        if value not in (ColorSpace.linear_srgb, ColorSpace.srgb):
+            raise ValueError("working_color_space must be either linear_srgb or srgb")
+        self._working_color_space = value
+
+    def convert_to_working_space(self, color: Color, colorspace):
+        """Convert a color from a given colorspace to the working color space."""
+        if colorspace == ColorSpace.no_colorspace:
+            return color
+
+        if colorspace == self._working_color_space:
+            return color
+
+        if colorspace == ColorSpace.srgb:
+            color.r = _srgb_to_linear(color.r)
+            color.g = _srgb_to_linear(color.g)
+            color.b = _srgb_to_linear(color.b)
+        elif colorspace == ColorSpace.linear_srgb:
+            color.r = _linear_to_srgb(color.r)
+            color.g = _linear_to_srgb(color.g)
+            color.b = _linear_to_srgb(color.b)
+
+
+ColorManagement = _ColorManagement()

--- a/pygfx/utils/color_management.py
+++ b/pygfx/utils/color_management.py
@@ -1,5 +1,4 @@
 from .enums import ColorSpace
-from .color import Color
 
 
 def _srgb_to_linear(c):
@@ -7,6 +6,7 @@ def _srgb_to_linear(c):
     # two steps in the range 0..255.
     # return c ** 2.2
     return c / 12.92 if c <= 0.04045 else ((c + 0.055) / 1.055) ** 2.4
+
 
 def _linear_to_srgb(c):
     # return c ** (1 / 2.2)
@@ -29,7 +29,7 @@ class _ColorManagement:
             raise ValueError("working_color_space must be either linear_srgb or srgb")
         self._working_color_space = value
 
-    def convert_to_working_space(self, color: Color, colorspace):
+    def convert_to_working_space(self, color, colorspace):
         """Convert a color from a given colorspace to the working color space."""
         if colorspace == ColorSpace.no_colorspace:
             return color
@@ -38,13 +38,17 @@ class _ColorManagement:
             return color
 
         if colorspace == ColorSpace.srgb:
-            color.r = _srgb_to_linear(color.r)
-            color.g = _srgb_to_linear(color.g)
-            color.b = _srgb_to_linear(color.b)
+            r = _srgb_to_linear(color.r)
+            g = _srgb_to_linear(color.g)
+            b = _srgb_to_linear(color.b)
+            color._set_from_rgba(r, g, b, color.a)
         elif colorspace == ColorSpace.linear_srgb:
-            color.r = _linear_to_srgb(color.r)
-            color.g = _linear_to_srgb(color.g)
-            color.b = _linear_to_srgb(color.b)
+            r = _linear_to_srgb(color.r)
+            g = _linear_to_srgb(color.g)
+            b = _linear_to_srgb(color.b)
+            color._set_from_rgba(r, g, b, color.a)
+
+        return color
 
 
 ColorManagement = _ColorManagement()

--- a/pygfx/utils/enums.py
+++ b/pygfx/utils/enums.py
@@ -28,6 +28,7 @@ from typing import TypeAlias, Literal
 __all__ = [
     "BindMode",
     "ColorMode",
+    "ColorSpace",
     "CoordSpace",
     "EdgeMode",
     "ElementFormat",
@@ -181,6 +182,12 @@ class TextAnchor(Enum):
     bottom_left = "bottom-left"
     bottom_center = "bottom-center"
     bottom_right = "bottom-right"
+
+
+class ColorSpace(Enum):
+    no_colorspace = ""
+    linear_srgb = "linear_srgb"
+    srgb = "srgb"
 
 
 # TODO: I experimented with using a Literal[] here, an idea discussed in https://github.com/pygfx/wgpu-py/issues/720.

--- a/pygfx/utils/load_gltf.py
+++ b/pygfx/utils/load_gltf.py
@@ -646,13 +646,14 @@ class _GLTF:
             pbr_metallic_roughness = material.pbrMetallicRoughness
             if pbr_metallic_roughness is not None:
                 if pbr_metallic_roughness.baseColorFactor is not None:
-                    gfx_material.color = gfx.Color.from_physical(
+                    gfx_material.color = gfx.Color(
                         *pbr_metallic_roughness.baseColorFactor
                     )
 
                 if pbr_metallic_roughness.baseColorTexture is not None:
                     gfx_material.map = self._load_gltf_texture_map(
-                        pbr_metallic_roughness.baseColorTexture
+                        pbr_metallic_roughness.baseColorTexture,
+                        colorspace=gfx.ColorSpace.srgb,
                     )
 
                 if pbr_metallic_roughness.metallicRoughnessTexture is not None:
@@ -688,13 +689,11 @@ class _GLTF:
                 )
 
             if material.emissiveFactor is not None:
-                gfx_material.emissive = gfx.Color.from_physical(
-                    *material.emissiveFactor
-                )
+                gfx_material.emissive = gfx.Color(*material.emissiveFactor)
 
             if material.emissiveTexture is not None:
                 gfx_material.emissive_map = self._load_gltf_texture_map(
-                    material.emissiveTexture
+                    material.emissiveTexture, colorspace=gfx.ColorSpace.srgb
                 )
 
         # todo alphaMode
@@ -708,7 +707,9 @@ class _GLTF:
 
         return gfx_material
 
-    def _load_gltf_texture_map(self, texture_info):
+    def _load_gltf_texture_map(
+        self, texture_info, colorspace=gfx.ColorSpace.no_colorspace
+    ):
         if isinstance(texture_info, dict):
             texture_index = texture_info["index"]
             uv_channel = texture_info.get("texCoord", 0)
@@ -718,7 +719,7 @@ class _GLTF:
             uv_channel = texture_info.texCoord or 0
             extensions = texture_info.extensions or {}
 
-        texture = self._load_gltf_texture(texture_index)
+        texture = self._load_gltf_texture(texture_index, colorspace=colorspace)
         if texture is None:
             return None
 
@@ -771,7 +772,9 @@ class _GLTF:
         return texture_map
 
     @lru_cache(maxsize=None)
-    def _load_gltf_texture(self, texture_index):
+    def _load_gltf_texture(
+        self, texture_index, colorspace=gfx.ColorSpace.no_colorspace
+    ):
         texture_desc = self._gltf.model.textures[texture_index]
 
         extensions = texture_desc.extensions or {}
@@ -785,7 +788,7 @@ class _GLTF:
         if source is None:
             return None
         image = self._load_image(source)
-        texture = gfx.Texture(image, dim=2)
+        texture = gfx.Texture(image, dim=2, colorspace=colorspace)
         return texture
 
     @lru_cache(maxsize=None)
@@ -1194,13 +1197,13 @@ class GLTFMaterialsSpecularExtension(GLTFBaseMaterialsExtension):
             )
 
         specular_color = extension.get("specularColorFactor", [1.0, 1.0, 1.0])
-        material.specular = gfx.Color.from_physical(*specular_color)
+        material.specular = gfx.Color(*specular_color)
 
         specular_color_texture = extension.get("specularColorTexture", None)
 
         if specular_color_texture is not None:
             material.specular_map = self.parser._load_gltf_texture_map(
-                specular_color_texture
+                specular_color_texture, colorspace=gfx.ColorSpace.srgb
             )
 
 
@@ -1333,12 +1336,12 @@ class GLTFMaterialsSheenExtension(GLTFBaseMaterialsExtension):
         sheen_color = extension.get("sheenColorFactor", None)
         if sheen_color is not None:
             material.sheen = 1.0
-            material.sheen_color = gfx.Color.from_physical(*sheen_color)
+            material.sheen_color = gfx.Color(*sheen_color)
 
         sheen_color_texture = extension.get("sheenColorTexture", None)
         if sheen_color_texture is not None:
             material.sheen_color_map = self.parser._load_gltf_texture_map(
-                sheen_color_texture
+                sheen_color_texture, colorspace=gfx.ColorSpace.srgb
             )
 
         sheen_roughness_factor = extension.get("sheenRoughnessFactor", None)
@@ -1386,13 +1389,12 @@ class GLTFMaterialsUnlitExtension(GLTFBaseMaterialsExtension):
         pbr_metallic_roughness = material_def.pbrMetallicRoughness
         if pbr_metallic_roughness is not None:
             if pbr_metallic_roughness.baseColorFactor is not None:
-                material.color = gfx.Color.from_physical(
-                    *pbr_metallic_roughness.baseColorFactor
-                )
+                material.color = gfx.Color(*pbr_metallic_roughness.baseColorFactor)
 
             if pbr_metallic_roughness.baseColorTexture is not None:
                 material.map = self.parser._load_gltf_texture_map(
-                    pbr_metallic_roughness.baseColorTexture
+                    pbr_metallic_roughness.baseColorTexture,
+                    colorspace=gfx.ColorSpace.srgb,
                 )
 
 
@@ -1430,7 +1432,7 @@ class GLTFLightsExtension(GLTFExtension):
             light_info = light_defs[light_index]
 
             color = light_info.get("color", [1, 1, 1])
-            light_color = gfx.Color.from_physical(*color)
+            light_color = gfx.Color(*color)
             light_range = light_info.get("range", 0)
             intensity = light_info.get("intensity", 1.0)
 

--- a/tests/animation/test_keyframe.py
+++ b/tests/animation/test_keyframe.py
@@ -36,3 +36,15 @@ def test_keyframe_track_optimize():
         track.values
         == np.array([[0, 0, 0], [0, 0, 0], [1, 1, 1], [1, 1, 1], [0, 0, 0], [0, 0, 0]])
     )
+
+
+if __name__ == "__main__":
+    times = np.array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13])
+    values = np.array([0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0])
+
+    track = KeyframeTrack("test", None, None, times, values, lambda *_: None)
+
+    print("Original times:", track.times)
+    print("Original values:", track.values)
+
+    test_keyframe_track_optimize()


### PR DESCRIPTION
**⚠️  This PR introduces significant changes to Pygfx and maybe has a broad impact.**

We have already discussed the color space issue many times. I apologize for submitting this PR so directly, but I believe that merely discussing it in words makes it difficult to fully convey the ideas, and can also cause misunderstandings.
By expressing the proposal directly in code, I can present it more clearly and unambiguously, while also showing the results.

## I. Background

### Current issues:
I have long believed that our current approach to color space management is overly simplistic, incorrect, and even somewhat chaotic. It is also not extensible, making it hard to support possible future HDR color spaces (e.g. Display-P3).

We currently lack the concept of a working color space.
We force Color values to be in sRGB space (as I understand, mainly for visualization use cases, since sRGB corresponds to perceptual linearity and is visually friendly).
However, for lighting calculations and PBR rendering, we require everything to work in linear space.

As a result, we are forced to assume shaders operate in linear space, but at the same time, in order to preserve visual friendliness for visualization use cases, we apply texture sampling interpolation in sRGB space. To be blunt, this is quite messy.

Currently, we only have one pipeline workflow, which is problematic in different scenarios and not entirely correct. I have listed some issues in past discussions, but to summarize briefly again here:

**Current workflow (example: input texture encoded in sRGB):**
```
Texture (sRGB space)
    --> GPU interpolation sampling (in sRGB encoded space)
    --> Shader srgb2physical conversion (but srgb2physical is often misused)
    --> Shading calculations, blending, etc.
    --> GPU OETF conversion to sRGB space for output
 ```
 
**Problems:**

- For 3D rendering use cases that require linear-space operation, interpolation results are incorrect (because they occur in the wrong space).On the CPU side, since colors are forced into sRGB space, any computation involving colors yields wrong results — such as light accumulation, intensity computation, or user-defined color processing.

- For visualization use cases (which are meant to work in perceptual linear space, i.e. sRGB), although interpolation is done in the right space, the subsequent conversion to linear space inside shaders again leads to incorrect results whenever computations (blending, etc.) are involved.

- In addition, the srgb2physical function is somewhat abused; we even see cases where conversions occur mid-calculation, which means the operations before and after are no longer in the same space.

- Finally, there is a lot of hard-coded color space logic in the code, making it very difficult to handle textures that may exist in different spaces (e.g. environment maps).

### I believe we should follow these principles:

1. All computations involving colors — including interpolation, sampling, CPU-side operations, GPU (shader) computations, blending, etc. — should happen in the same color space, i.e. the working color space.

2. Color space management should be simple, clear, and ideally transparent to the user.

3. Avoid unnecessary redundant conversions. For example, many models store color data in linear space (glTF specifies that all Color values are stored in linear space, and as far as I know, most formats like FBX do the same). Currently, we are forced to convert these into sRGB upon loading, then back into linear space inside shaders. This is especially cumbersome for vertex colors (which I haven’t even properly handled yet).

_Note: WGPU’s `-srgb` texture formats should be seen only as GPU-side EOTF/OETF helpers,, not as an indication of the texture’s inherent color space._ 

---

## II. What this PR does
### 1. Introduces color space management and the concept of a working color space.

The logic borrows some ideas from three.js, with simplifications and adaptations for Pygfx’s API design and use cases.

**Let's clarifying the concept of color spaces first:**
Color representation can be based on different models (RGB, CMYK, YUV, HSL/HSV, etc.). These are models — mathematical coordinate systems — not bounded color spaces, and they do not define physical gamut ranges.

The RGB model is the most common and hardware-oriented; displays operate in RGB.
When rendering engines or display devices refer to a “color space,” they always mean within the RGB model, but with specific definitions of primaries, white point, and transfer function (EOTF). For example:

sRGB = RGB model + Rec.709 primaries + D65 white point + sRGB gamma curve

Display-P3 = RGB model + P3 primaries + D65 white point + sRGB gamma curve

Rec.2020-PQ = RGB model + Rec.2020 primaries + D65 white point + PQ curve

The primaries and white point define a triangle in the CIE 1931 xy chromaticity diagram, which determines the gamut’s size and shape -- And this is the "Color Space".
Thus, although RGB values are always normalized to [0–1], their meaning (location in the chromaticity diagram) differs across color spaces.

In this PR (currently focused on SDR displays):

- ColorSpace includes three values: `no_color_space`, `srgb`, and `linear_srgb`.

- It is extensible to future HDR color spaces (e.g. Display-P3).

- **Working color space**: can be `linear_srgb` or `srgb`. Default: `linear_srgb`.

- **Renderer output color space**: can be `srgb` or `linear_srgb`. Default: `srgb`.

     - If working in linear_srgb, output can be either linear_srgb (for rendering/baking textures) or srgb (for display).

     - If working in srgb, output can only reasonably be srgb (otherwise likely user misconfiguration).

- **Texture color space**: can be `no_color_space`, `srgb`, or `linear_srgb`.

     - `no_color_space`: data is not color (e.g. normal maps, metallic/roughness maps), and is uploaded raw regardless of working color space.

     - `srgb` or `linear_srgb`: treated as color data, converted according to the working color space.

     - Special case: float textures. Float textures are almost never stored in sRGB (e.g. .hdr, .exr are linear). The engine assumes float textures are `linear_srgb` or `no_color_space`, and issues warnings if they are marked otherwise.

**Q: Why `linear_srgb` instead of `linear` or `physical`?**
Because “linear” or “physical” are ambiguous. `linear_srgb` explicitly refers to the linearized version of the sRGB space. Similarly, Display-P3 has its own linearized form (maybe linear-P3 ?). All these are linear spaces,  and physically correct for computation. And they can be transformed into each other through a simple 3x3 matrix transformation.

**Q: Why remove YUV from texture color spaces?**
Because YUV is a color model, not a fully defined color space. Rendering engines manage RGB-based spaces (primaries, white point, EOTF), not mathematical transforms. For YUV video, it is typically decoded to RGBA for rendering. If GPU-side conversion is needed, YUV data should be uploaded as `no_color_space` and handled by custom shaders or materials (e.g. YuvTexture, YuvMaterial).

### 2. Improves the Color utility class.

Currently, Color values are forced in sRGB space, As mentioned earlier, this has many issues and is not very convenient.
This PR introduces the concepts of **color space management** and **working_colorspace**, 
With this, the working color space determines how Color values are interpreted:
- A Color’s values are simply data in the current working color space.
- The Color class adds convenient conversion methods and initialization parameters.

Example usage:
```python
pygfx.ColorManagement.working_color_space = ColorSpace.linear_srgb

c = Color(0.5, 0.5, 0.5)   # By default,  it is in the current working_color_space

print(c.rgb)  #  =(0.5, 0.5, 0.5)

c = Color(
    0.5, 0.5, 0.5, colorspace=ColorSpace.linear_srgb
)  # Set as a color in linear_srgb color space, consistent with the current working_color_space
print(c.rgb)  # =(0.5, 0.5, 0.5)

c = Color(
    0.5, 0.5, 0.5, colorspace=ColorSpace.srgb
)  # Set as color in sRGB space, automatically convert to current workspace (linear_sgb)
print(c.rgb)  # # ~=(0.214, 0.214, 0.214)

pygfx.ColorManagement.working_color_space = ColorSpace.srgb

c = Color(0.5, 0.5, 0.5)  # By default,  it is in the current working_color_space
print(c.rgb)  # =(0.5, 0.5, 0.5)

c = Color(
    0.5, 0.5, 0.5, colorspace=ColorSpace.linear_srgb
)  # Set as a color in linear_srgb color space, consistent with the current working_color_space (sRGB)
print(c.rgb)  # # ~=(0.735, 0.735, 0.735)

c = Color(
    0.5, 0.5, 0.5, colorspace=ColorSpace.srgb
)  #  Set as a color in srgb color space, consistent with the current working_color_space
print(c.rgb)  # =(0.5, 0.5, 0.5)
```
**When using CSS or Hex strings to set colors, because CSS web colors are usually located in sRGB space, we assume by default that CSS or Hex strings are located in sRGB space, which means:**
```python
pygfx.ColorManagement.working_color_space = ColorSpace.linear_srgb

c = Color("#808080")  # Default in sRGB space, automatically converted to the current workspace (linear_sgb)
print(c.rgb)  # ~=(0.216, 0.216, 0.216)

c = Color(
    "#808080", colorspace=ColorSpace.linear_srgb
)  # Set as a color in linear_srgb color space, consistent with the current working_color_space
print(c.rgb)  # ~=（0.502, 0.502, 0.502）

c = Color(
    "#808080", colorspace=ColorSpace.srgb
)  # Set as a color in srgb color space, automatically convert to current workspace (linear_sgb)
print(c.rgb)  # ~=(0.216, 0.216, 0.216)

pygfx.ColorManagement.working_color_space = ColorSpace.srgb

c = Color("#808080")  # Default in sRGB space, consistent with the current workspace
print(c.rgb)  # =(0.502, 0.502, 0.502)

c = Color(
    "#808080", colorspace=ColorSpace.linear_srgb
)  # Set as a color in linear_srgb color space, automatically convert to current workspace sRGB)
print(c.rgb)  # ~=（0.737, 0.737, 0.737）

c = Color(
    "#808080", colorspace=ColorSpace.srgb
)  # Set as a color in srgb color space, consistent with the current working_color_space
print(c.rgb)  # ~=(0.502, 0.502, 0.502)
```
---

## III. Impact on Pygfx applications

1. 3D rendering apps (linear workflow):

Almost no changes required. The default working color space is `linear_srgb`.

The corrected workflow is now:
```
Texture (sRGB)
    --> GPU EOTF decode to linear
    --> GPU interpolation sampling (linear space)
    --> Shading, blending (linear space)
    --> GPU OETF to sRGB for output
```
This fixes the errors in the old pipeline. Results are now correct.
_Note: User-defined Color values are now in linear_srgb (direct rgb assignment), which may require small adjustments._

2..Visualization apps (expected in sRGB workflow):
There are subtle changes. By default (linear_srgb working color space), textures are sampled in linear space, which differs from the old behavior (in sRGB space). This is more correct, but is in linear workflow, not match expectations for visualization cases.

If `ColorManagement.working_color_space = ColorSpace.srgb` is set, the workflow becomes:
```
Texture/Color (sRGB)
    --> GPU interpolation sampling (sRGB space)
    --> Shading, blending (sRGB space)
    --> Direct output
```
This matches expectations perfectly (all in srgb), with no any color space conversions, and aligns with the web color model behavior.

---
### IV. Task list

- [ ] Clarify and restructure ColorSpace, introduce ColorSpaceManagement.
- [ ] Improve Color utility class behavior.
- [ ] Modify and add unit tests related to Color and ColorSpace.
- [ ] Review and update examples.
- [ ] Documentation, including a ColorSpace guide.
- [ ] (Optional) Support for YUV textures (Do we really need this?).