### PR TITLE
Turn off material.aa by default

### DIFF
--- a/examples/feature_demo/image_stitching.py
+++ b/examples/feature_demo/image_stitching.py
@@ -52,7 +52,12 @@ for image_name in ["wood.jpg", "bricks.jpg"]:
     x += rgba.shape[1] - 200
 
 # Text is rendered as an overlay (using render_queue)
-text = gfx.Text("Image stitching", font_size=64, anchor="top-left")
+text = gfx.Text(
+    "Image stitching",
+    font_size=64,
+    anchor="top-left",
+    material=gfx.TextMaterial(color="#fff", aa=True),
+)
 text.material.render_queue = 4000  # render the text as an overlay
 text.local.scale_y = -1
 scene.add(text)

--- a/examples/feature_demo/transparency1.py
+++ b/examples/feature_demo/transparency1.py
@@ -53,7 +53,7 @@ scene_overlay = gfx.Scene()
 blend_text = gfx.Text(
     text=f"alpha_mode: {plane1.material.alpha_mode}",
     anchor="bottom-left",
-    material=gfx.TextMaterial(outline_thickness=0.3),
+    material=gfx.TextMaterial(outline_thickness=0.3, aa=True),
 )
 scene_overlay.add(blend_text)
 

--- a/examples/feature_demo/transparency2.py
+++ b/examples/feature_demo/transparency2.py
@@ -49,7 +49,7 @@ scene_overlay = gfx.Scene()
 blend_text = gfx.Text(
     text=f"alpha_mode: {plane1.material.alpha_mode}",
     anchor="bottom-left",
-    material=gfx.TextMaterial(outline_thickness=0.3),
+    material=gfx.TextMaterial(outline_thickness=0.3, aa=True),
 )
 scene_overlay.add(blend_text)
 

--- a/examples/introductory/hello_text.py
+++ b/examples/introductory/hello_text.py
@@ -4,6 +4,8 @@ Hello text
 
 Example showing text in world and screen space. Also notice how the
 text is shown on top of the plane (due to its depth offset).
+
+Setting aa to True improves the quality of the text rendering.
 """
 
 # sphinx_gallery_pygfx_docs = 'animate 4s'
@@ -28,7 +30,7 @@ scene.add(plane)
 text1 = gfx.Text(
     text="Hello world",
     font_size=2.8,
-    material=gfx.TextMaterial(color="#ddd"),
+    material=gfx.TextMaterial(color="#ddd", aa=True),
 )
 text1.local.position = (0, 0, 0.5)
 plane.add(text1)
@@ -36,7 +38,7 @@ plane.add(text1)
 text2 = gfx.Text(
     text="Здравей свят",
     font_size=2.0,
-    material=gfx.TextMaterial(color="#ddd"),
+    material=gfx.TextMaterial(color="#ddd", aa=True),
 )
 text2.local.position = (0, 0, -0.5)
 text2.local.scale = (-1, 1, 1)
@@ -48,7 +50,7 @@ text3 = gfx.Text(
     screen_space=True,
     font_size=20,
     anchor="bottom-left",
-    material=gfx.TextMaterial(color="#0f4"),
+    material=gfx.TextMaterial(color="#0f4", aa=True),
 )
 text3.local.position = (10, 10, 0)
 plane.add(text3)

--- a/examples/other/hirez_screenshot.py
+++ b/examples/other/hirez_screenshot.py
@@ -76,7 +76,7 @@ text = gfx.Text(
     text="centered",
     anchor="middle-center",
     font_size=1,
-    material=gfx.TextMaterial("#000"),
+    material=gfx.TextMaterial("#000", aa=True),
 )
 text.local.y = y
 text.local.x = npoints
@@ -86,7 +86,7 @@ text = gfx.Text(
     text="inner",
     anchor="middle-center",
     font_size=1,
-    material=gfx.TextMaterial("#000"),
+    material=gfx.TextMaterial("#000", aa=True),
 )
 text.local.y = y
 text.local.x = 2 * npoints + npoints
@@ -96,7 +96,7 @@ text = gfx.Text(
     text="outer",
     anchor="middle-center",
     font_size=1,
-    material=gfx.TextMaterial("#000"),
+    material=gfx.TextMaterial("#000", aa=True),
 )
 text.local.y = y
 text.local.x = 4 * npoints + npoints
@@ -166,7 +166,7 @@ for marker in gfx.MarkerShape:
         anchor="middle-right",
         font_size=20,
         screen_space=True,
-        material=gfx.TextMaterial("#000"),
+        material=gfx.TextMaterial("#000", aa=True),
     )
     text.local.y = -y
     text.local.x = 0

--- a/examples/validation/validate_blend_dither.py
+++ b/examples/validation/validate_blend_dither.py
@@ -38,7 +38,7 @@ t = gfx.Text(
     text="dither",
     screen_space=True,
     font_size=20,
-    material=gfx.TextMaterial(),
+    material=gfx.TextMaterial(aa=True),
 )
 t.local.position = (0, 40, 0)
 

--- a/examples/validation/validate_blend_weighted.py
+++ b/examples/validation/validate_blend_weighted.py
@@ -38,7 +38,7 @@ t = gfx.Text(
     text="weighted",
     screen_space=True,
     font_size=20,
-    material=gfx.TextMaterial(),
+    material=gfx.TextMaterial(aa=True),
 )
 t.local.position = (0, 40, 0)
 

--- a/examples/validation/validate_culling.py
+++ b/examples/validation/validate_culling.py
@@ -45,7 +45,12 @@ def create_scene(title):
     obj1.local.rotation = la.quat_mul(rot, obj1.local.rotation)
     obj2.local.rotation = la.quat_mul(rot, obj2.local.rotation)
 
-    t = gfx.Text(text=title, screen_space=True, font_size=20)
+    t = gfx.Text(
+        text=title,
+        screen_space=True,
+        font_size=20,
+        material=gfx.TextMaterial(aa=True),
+    )
     t.local.position = (0, 4, 0)
     camera = gfx.OrthographicCamera(4.2, 6)
 

--- a/examples/validation/validate_depth_overlay1.py
+++ b/examples/validation/validate_depth_overlay1.py
@@ -50,7 +50,9 @@ positions = np.array(
 )
 line2 = gfx.Line(
     gfx.Geometry(positions=positions * 0.5),
-    gfx.LineMaterial(thickness=5.0, color="#f0f", depth_test=False, depth_write=False),
+    gfx.LineMaterial(
+        thickness=5.0, color="#f0f", depth_test=False, depth_write=False, aa=True
+    ),
 )
 scene2.add(line2)
 

--- a/examples/validation/validate_image1.py
+++ b/examples/validation/validate_image1.py
@@ -47,7 +47,7 @@ scene.add(plane)
 
 points = gfx.Points(
     gfx.Geometry(positions=[[0, 0, 1], [4, 4, 1]]),
-    gfx.PointsMaterial(color=(0, 1, 0, 1), size=20),
+    gfx.PointsMaterial(color=(0, 1, 0, 1), size=20, aa=True),
 )
 scene.add(points)
 

--- a/examples/validation/validate_image2.py
+++ b/examples/validation/validate_image2.py
@@ -40,7 +40,7 @@ scene.add(image)
 
 points = gfx.Points(
     gfx.Geometry(positions=[[0, 0, 1], [3, 3, 1]]),
-    gfx.PointsMaterial(color=(0, 1, 0, 1), size=20),
+    gfx.PointsMaterial(color=(0, 1, 0, 1), size=20, aa=True),
 )
 scene.add(points)
 

--- a/examples/validation/validate_line_2d.py
+++ b/examples/validation/validate_line_2d.py
@@ -88,6 +88,7 @@ line1 = gfx.Line(
         thickness_space="screen",
         color=(0.0, 1.0, 1.0),
         opacity=1.0,
+        aa=True,
     ),
 )
 
@@ -98,6 +99,7 @@ line2 = gfx.Line(
         thickness_space="screen",
         color_mode="vertex",
         opacity=0.5,
+        aa=True,
     ),
 )
 
@@ -110,6 +112,7 @@ line3 = gfx.Line(
         dash_pattern=[1, 1.2],
         color=(1.0, 0.0, 0.0),
         opacity=0.5,
+        aa=True,
     ),
 )
 

--- a/examples/validation/validate_line_dash.py
+++ b/examples/validation/validate_line_dash.py
@@ -33,6 +33,7 @@ line1 = gfx.Line(
         dash_pattern=[0, 2, 2, 2],
         color=(0.0, 1.0, 1.0, 0.4),
         dash_offset=0,
+        aa=True,
     ),
 )
 
@@ -43,6 +44,7 @@ line2 = gfx.Line(
         dash_pattern=[0, 2, 2, 2],
         color=(0.0, 1.0, 1.0, 0.4),
         dash_offset=2,
+        aa=True,
     ),
 )
 line3 = gfx.Line(
@@ -52,6 +54,7 @@ line3 = gfx.Line(
         dash_pattern=[0, 2, 2, 2],
         color=(0.0, 1.0, 1.0, 0.4),
         dash_offset=3,
+        aa=True,
     ),
 )
 
@@ -62,6 +65,7 @@ line4 = gfx.Line(
         dash_pattern=[0, 2, 2, 2],
         color=(0.0, 1.0, 1.0, 0.4),
         dash_offset=6,
+        aa=True,
     ),
 )
 

--- a/examples/validation/validate_line_inf.py
+++ b/examples/validation/validate_line_inf.py
@@ -57,7 +57,11 @@ colors2[2::2, :] = 0, 0, 1
 line1 = gfx.Line(
     gfx.Geometry(positions=positions1, colors=colors1),
     gfx.LineInfiniteSegmentMaterial(
-        thickness=5.0, color_mode="face", start_is_infinite=False, dash_pattern=[0, 2]
+        thickness=5.0,
+        color_mode="face",
+        start_is_infinite=False,
+        dash_pattern=[0, 2],
+        aa=True,
     ),
 )
 scene.add(line1)
@@ -65,7 +69,7 @@ scene.add(line1)
 line2 = gfx.Line(
     gfx.Geometry(positions=positions2, colors=colors2),
     gfx.LineInfiniteSegmentMaterial(
-        thickness=10, end_is_infinite=1, color_mode="vertex"
+        thickness=10, end_is_infinite=1, color_mode="vertex", aa=True
     ),
 )
 scene.add(line2)

--- a/examples/validation/validate_line_loop.py
+++ b/examples/validation/validate_line_loop.py
@@ -106,14 +106,14 @@ positions = np.vstack(
 
 line1 = gfx.Line(
     gfx.Geometry(positions=positions),
-    gfx.LineMaterial(thickness=14, color="red", opacity=0.7, loop=True),
+    gfx.LineMaterial(thickness=14, color="red", opacity=0.7, loop=True, aa=True),
 )
 scene.add(line1)
 
 
 line2 = gfx.Line(
     gfx.Geometry(positions=rect_points * 10),
-    gfx.LineMaterial(thickness=20, color="cyan", opacity=0.7, loop=True),
+    gfx.LineMaterial(thickness=20, color="cyan", opacity=0.7, loop=True, aa=True),
 )
 scene.add(line2)
 

--- a/examples/validation/validate_line_thickness.py
+++ b/examples/validation/validate_line_thickness.py
@@ -40,7 +40,7 @@ for x_offset, mode in enumerate(["noaa", "aa", "dashed"]):
     for thickness in [0.125, 0.25, 0.5, 1.0, 2.0, 4.0, 8.0]:
         line = gfx.Line(
             geometry,
-            gfx.LineMaterial(thickness=thickness, color=(1.0, 1.0, 1.0)),
+            gfx.LineMaterial(thickness=thickness, color=(1.0, 1.0, 1.0), aa=True),
         )
         y += 2
         line.local.y = -y

--- a/examples/validation/validate_line_thickness_space.py
+++ b/examples/validation/validate_line_thickness_space.py
@@ -108,6 +108,7 @@ add_three_cubes(
         dash_pattern=[0, 2],
         color=(1.0, 0.0, 0.0),
         opacity=0.5,
+        aa=True,
     ),
 )
 
@@ -119,6 +120,7 @@ add_three_cubes(
         dash_pattern=[0, 2],
         color=(0.0, 1.0, 0.0),
         opacity=0.5,
+        aa=True,
     ),
 )
 
@@ -130,6 +132,7 @@ add_three_cubes(
         dash_pattern=[0, 2],
         color=(0.0, 0.0, 1.0),
         opacity=0.5,
+        aa=True,
     ),
 )
 

--- a/examples/validation/validate_points_markers.py
+++ b/examples/validation/validate_points_markers.py
@@ -127,7 +127,7 @@ text = gfx.Text(
     text="centered",
     anchor="middle-center",
     font_size=1,
-    material=gfx.TextMaterial("#000"),
+    material=gfx.TextMaterial("#000", aa=True),
 )
 text.local.y = y
 text.local.x = npoints
@@ -137,7 +137,7 @@ text = gfx.Text(
     text="inner",
     anchor="middle-center",
     font_size=1,
-    material=gfx.TextMaterial("#000"),
+    material=gfx.TextMaterial("#000", aa=True),
 )
 text.local.y = y
 text.local.x = 2 * npoints + npoints
@@ -147,7 +147,7 @@ text = gfx.Text(
     text="outer",
     anchor="middle-center",
     font_size=1,
-    material=gfx.TextMaterial("#000"),
+    material=gfx.TextMaterial("#000", aa=True),
 )
 text.local.y = y
 text.local.x = 4 * npoints + npoints
@@ -167,6 +167,7 @@ for i, marker in enumerate(gfx.MarkerShape):
             edge_color="#000",
             edge_width=0.1 if not marker == "custom" else 0.033333,
             custom_sdf=pygfx_sdf if marker == "custom" else None,
+            aa=True,
         ),
     )
     line.local.y = -y
@@ -185,6 +186,7 @@ for i, marker in enumerate(gfx.MarkerShape):
             edge_width=0.1 if not marker == "custom" else 0.033333,
             edge_mode="inner",
             custom_sdf=pygfx_sdf if marker == "custom" else None,
+            aa=True,
         ),
     )
 
@@ -212,6 +214,7 @@ for i, marker in enumerate(gfx.MarkerShape):
             # If your heart is broken, it won't be upright!!!!
             rotation_mode="uniform" if marker != "heart" else "vertex",
             custom_sdf=pygfx_sdf if marker == "custom" else None,
+            aa=True,
         ),
     )
 
@@ -225,7 +228,7 @@ for i, marker in enumerate(gfx.MarkerShape):
         text=marker,
         anchor="middle-right",
         font_size=1,
-        material=gfx.TextMaterial("#000"),
+        material=gfx.TextMaterial("#000", aa=True),
     )
     text.local.y = -y
     text.local.x = 0

--- a/examples/validation/validate_points_size_space.py
+++ b/examples/validation/validate_points_size_space.py
@@ -107,6 +107,7 @@ add_three_cubes(
         size_space="screen",
         color=(1.0, 0.0, 0.0),
         opacity=0.5,
+        aa=True,
     ),
 )
 
@@ -117,6 +118,7 @@ add_three_cubes(
         size_space="world",
         color=(0.0, 1.0, 0.0),
         opacity=0.5,
+        aa=True,
     ),
 )
 
@@ -127,6 +129,7 @@ add_three_cubes(
         size_space="model",
         color=(0.0, 0.0, 1.0),
         opacity=0.5,
+        aa=True,
     ),
 )
 

--- a/examples/validation/validate_ruler.py
+++ b/examples/validation/validate_ruler.py
@@ -26,7 +26,7 @@ positions = np.column_stack([x, y, np.ones_like(x)])
 
 line = gfx.Line(
     gfx.Geometry(positions=positions),
-    gfx.LineMaterial(thickness=4.0, color="#aaf"),
+    gfx.LineMaterial(thickness=4.0, color="#aaf", aa=True),
 )
 scene.add(background, line)
 

--- a/examples/validation/validate_send_data.py
+++ b/examples/validation/validate_send_data.py
@@ -57,7 +57,7 @@ del position_data
 
 points = gfx.Points(
     gfx.Geometry(positions=buf),
-    gfx.PointsMaterial(color="cyan", size=15),
+    gfx.PointsMaterial(color="cyan", size=15, aa=True),
 )
 
 

--- a/examples/validation/validate_text_align.py
+++ b/examples/validation/validate_text_align.py
@@ -37,7 +37,7 @@ text_bottom_right = gfx.Text(
     text_align="right",
     anchor="bottom-right",
     material=gfx.TextMaterial(
-        color="#DA9DFF", outline_color="#000", outline_thickness=0.15
+        color="#DA9DFF", outline_color="#000", outline_thickness=0.15, aa=True
     ),
 )
 
@@ -48,7 +48,7 @@ text_top_right = gfx.Text(
     text_align="end",
     anchor="top-right",
     material=gfx.TextMaterial(
-        color="#FFA99D", outline_color="#000", outline_thickness=0.15
+        color="#FFA99D", outline_color="#000", outline_thickness=0.15, aa=True
     ),
 )
 
@@ -59,7 +59,7 @@ text_bottom_left = gfx.Text(
     text_align="start",
     anchor="bottom-left",
     material=gfx.TextMaterial(
-        color="#C2FF9D", outline_color="#000", outline_thickness=0.15
+        color="#C2FF9D", outline_color="#000", outline_thickness=0.15, aa=True
     ),
 )
 
@@ -70,13 +70,13 @@ text_top_left = gfx.Text(
     text_align="left",
     anchor="top-left",
     material=gfx.TextMaterial(
-        color="#9DF3FF", outline_color="#000", outline_thickness=0.15
+        color="#9DF3FF", outline_color="#000", outline_thickness=0.15, aa=True
     ),
 )
 
 points = gfx.Points(
     gfx.Geometry(positions=[(0, 0, 0)]),
-    gfx.PointsMaterial(color="#f00", size=10),
+    gfx.PointsMaterial(color="#f00", size=10, aa=True),
 )
 scene.add(
     text_bottom_right,

--- a/examples/validation/validate_text_anchor.py
+++ b/examples/validation/validate_text_anchor.py
@@ -23,7 +23,7 @@ def add_text(anchor, pos):
         anchor=anchor,
         font_size=20,
         screen_space=True,
-        material=gfx.TextMaterial(color="#0f0"),
+        material=gfx.TextMaterial(color="#0f0", aa=True),
     )
     obj.local.position = pos
     scene.add(obj)
@@ -34,7 +34,7 @@ line_positions += [(-1, -1), (1, -1), (-1, 1), (1, 1)]
 line_positions += [(-1, -1), (-1, 1), (1, -1), (1, 1)]
 line = gfx.Line(
     gfx.Geometry(positions=[(p[0] * 50, p[1] * 50, -1) for p in line_positions]),
-    gfx.LineSegmentMaterial(color="#00f"),
+    gfx.LineSegmentMaterial(color="#00f", aa=True),
 )
 scene.add(line)
 

--- a/examples/validation/validate_text_direction.py
+++ b/examples/validation/validate_text_direction.py
@@ -33,7 +33,7 @@ other text on another line
 """.strip()
 
 
-material = gfx.TextMaterial(color="#000")
+material = gfx.TextMaterial(color="#000", aa=True)
 
 
 text1 = gfx.Text(

--- a/examples/validation/validate_text_md.py
+++ b/examples/validation/validate_text_md.py
@@ -30,7 +30,7 @@ normal *italic*, loose * stays
 also partial**bold**wordpart
 """
 
-material = gfx.TextMaterial(color="#000")
+material = gfx.TextMaterial(color="#000", aa=True)
 
 text1 = gfx.Text(anchor="top-left", material=material)
 text2 = gfx.Text(anchor="top-left", material=material)

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -93,7 +93,7 @@ class LineMaterial(Material):
 
         However, because semi-transparent fragments are introduced, artifacts
         may occur if certain cases. For the same reason, aa only works for the
-        "composite" and "weighted" alpha methods.
+        "blended" and "weighted" alpha methods.
 
         Note that by default, pygfx already uses SSAA and/or PPAA to anti-alias
         the total renderered result. Line-based aa is an *additional* visual
@@ -107,7 +107,7 @@ class LineMaterial(Material):
 
     @property
     def _gfx_effective_aa(self):
-        aa_able_methods = ("composite", "weighted")
+        aa_able_methods = ("blended", "weighted")
         return self._store.aa and self._store.alpha_config["method"] in aa_able_methods
 
     @property

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -26,7 +26,7 @@ class LineMaterial(Material):
     loop : bool
         Whether the line's end should be connected. Default False.
     aa : bool
-        Whether or not the line is anti-aliased in the shader. Default True.
+        Whether the line is anti-aliased in the shader. Default False.
     kwargs : Any
         Additional kwargs will be passed to the :class:`material base class <pygfx.Material>`.
     """
@@ -49,7 +49,7 @@ class LineMaterial(Material):
         dash_pattern=(),
         dash_offset=0,
         loop=False,
-        aa=True,
+        aa=False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -91,17 +91,24 @@ class LineMaterial(Material):
         at the edges. Lines thinner than one physical pixel are also diminished
         by making them more transparent.
 
-        Note that by default, pygfx uses SSAA to anti-alias the total renderered
-        result. Line-based aa results in additional improvement.
+        However, because semi-transparent fragments are introduced, artifacts
+        may occur if certain cases. For the same reason, aa only works for the
+        "composite" and "weighted" alpha methods.
 
-        Because semi-transparent fragments are introduced, it may affect how the
-        line blends with other (semi-transparent) objects.
+        Note that by default, pygfx already uses SSAA and/or PPAA to anti-alias
+        the total renderered result. Line-based aa is an *additional* visual
+        improvement.
         """
         return self._store.aa
 
     @aa.setter
     def aa(self, aa):
         self._store.aa = bool(aa)
+
+    @property
+    def _gfx_effective_aa(self):
+        aa_able_methods = ("composite", "weighted")
+        return self._store.aa and self._store.alpha_config["method"] in aa_able_methods
 
     @property
     def color_mode(self):

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -33,7 +33,7 @@ class PointsMaterial(Material):
     map : TextureMap | Texture
         The texture map specifying the color for each texture coordinate.
     aa : bool
-        Whether or not the points are anti-aliased in the shader. Default True.
+        Whether the points are anti-aliased in the shader. Default False.
     rotation : float
         The rotation of the point marker in radians. Default 0.
     rotation_mode : str | RotationMode
@@ -61,7 +61,7 @@ class PointsMaterial(Material):
         color_mode="auto",
         edge_mode="centered",
         map=None,
-        aa=True,
+        aa=False,
         rotation=0,
         rotation_mode="uniform",
         **kwargs,
@@ -103,20 +103,27 @@ class PointsMaterial(Material):
         """Whether the point's visual edge is anti-aliased.
 
         Aliasing gives prettier results by producing semi-transparent fragments
-        at the edges. Points smaller than one physical pixel are also diminished
+        at the edges. Lines thinner than one physical pixel are also diminished
         by making them more transparent.
 
-        Note that by default, pygfx uses SSAA to anti-alias the total renderered
-        result. Point-based aa results in additional improvement.
+        However, because semi-transparent fragments are introduced, artifacts
+        may occur if certain cases. For the same reason, aa only works for the
+        "composite" and "weighted" alpha methods.
 
-        Because semi-transparent fragments are introduced, it may affect how the
-        points blends with other (semi-transparent) objects.
+        Note that by default, pygfx already uses SSAA and/or PPAA to anti-alias
+        the total renderered result. Point-based aa is an *additional* visual
+        improvement.
         """
         return self._store.aa
 
     @aa.setter
     def aa(self, aa):
         self._store.aa = bool(aa)
+
+    @property
+    def _gfx_effective_aa(self):
+        aa_able_methods = ("composite", "weighted")
+        return self._store.aa and self._store.alpha_config["method"] in aa_able_methods
 
     @property
     def color_mode(self):

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -108,7 +108,7 @@ class PointsMaterial(Material):
 
         However, because semi-transparent fragments are introduced, artifacts
         may occur if certain cases. For the same reason, aa only works for the
-        "composite" and "weighted" alpha methods.
+        "blended" and "weighted" alpha methods.
 
         Note that by default, pygfx already uses SSAA and/or PPAA to anti-alias
         the total renderered result. Point-based aa is an *additional* visual
@@ -122,7 +122,7 @@ class PointsMaterial(Material):
 
     @property
     def _gfx_effective_aa(self):
-        aa_able_methods = ("composite", "weighted")
+        aa_able_methods = ("blended", "weighted")
         return self._store.aa and self._store.alpha_config["method"] in aa_able_methods
 
     @property

--- a/pygfx/materials/_text.py
+++ b/pygfx/materials/_text.py
@@ -19,8 +19,7 @@ class TextMaterial(Material):
         the range 100-900, so this value should be in the same order of
         magnitude. Can be negative to make text thinner. Default zero.
     aa : bool
-        If True, use anti-aliasing while rendering glyphs. Aliasing gives
-        prettier results, but may affect performance for very large texts.
+        Whether the glyphs is anti-aliased in the shader. Default False.
     kwargs : Any
         Additional kwargs will be passed to the :class:`material base class
         <pygfx.Material>`.
@@ -48,7 +47,7 @@ class TextMaterial(Material):
         outline_color="#000",
         outline_thickness=0,
         weight_offset=0,
-        aa=True,
+        aa=False,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -72,15 +71,30 @@ class TextMaterial(Material):
 
     @property
     def aa(self):
-        """Whether or not the glyphs should be anti-aliased. Aliasing
-        gives prettier results, but may affect performance for very large
-        texts. Default True.
+        """Whether the glyphs edges are anti-aliased.
+
+        Aliasing gives prettier results by producing semi-transparent fragments
+        at the edges. Lines thinner than one physical pixel are also diminished
+        by making them more transparent.
+
+        However, because semi-transparent fragments are introduced, artifacts
+        may occur if certain cases. For the same reason, aa only works for the
+        "composite" and "weighted" alpha methods.
+
+        Note that by default, pygfx already uses SSAA and/or PPAA to anti-alias
+        the total renderered result. Text-based aa is an *additional* visual
+        improvement.
         """
         return self._store.aa
 
     @aa.setter
     def aa(self, aa):
         self._store.aa = bool(aa)
+
+    @property
+    def _gfx_effective_aa(self):
+        aa_able_methods = ("composite", "weighted")
+        return self._store.aa and self._store.alpha_config["method"] in aa_able_methods
 
     @property
     def color(self):

--- a/pygfx/materials/_text.py
+++ b/pygfx/materials/_text.py
@@ -79,7 +79,7 @@ class TextMaterial(Material):
 
         However, because semi-transparent fragments are introduced, artifacts
         may occur if certain cases. For the same reason, aa only works for the
-        "composite" and "weighted" alpha methods.
+        "blended" and "weighted" alpha methods.
 
         Note that by default, pygfx already uses SSAA and/or PPAA to anti-alias
         the total renderered result. Text-based aa is an *additional* visual
@@ -93,7 +93,7 @@ class TextMaterial(Material):
 
     @property
     def _gfx_effective_aa(self):
-        aa_able_methods = ("composite", "weighted")
+        aa_able_methods = ("blended", "weighted")
         return self._store.aa and self._store.alpha_config["method"] in aa_able_methods
 
     @property

--- a/pygfx/objects/_ruler.py
+++ b/pygfx/objects/_ruler.py
@@ -14,6 +14,7 @@ class Ruler(WorldObject):
     """An object to represent a ruler with tickmarks.
 
     Can be used to measure distances in a scene, or as an axis in a plot.
+    The ruler object is a "compound" object; it has text, lines, and points as child objects.
 
     Usage:
 
@@ -32,6 +33,7 @@ class Ruler(WorldObject):
         tick_side="left",
         min_tick_distance=50,
         ticks_at_end_points=False,
+        aa=True,
     ):
         super().__init__()
 
@@ -45,12 +47,23 @@ class Ruler(WorldObject):
         self.min_tick_distance = min_tick_distance
         self.ticks_at_end_points = ticks_at_end_points
 
+        aa = bool(aa)
+
         # Create a line and points object, with a shared geometry
-        self._text = MultiText(material=TextMaterial(), screen_space=True)
+        self._text = MultiText(
+            material=TextMaterial(color="#f00", aa=aa),
+            screen_space=True,
+        )
         geometry = self._text.geometry  # has .positions buffer
         geometry.sizes = Buffer(np.zeros(geometry.positions.nitems, "f4"))
-        self._line = Line(geometry, LineMaterial(color="w", thickness=2))
-        self._points = Points(geometry, PointsMaterial(color="w", size_mode="vertex"))
+        self._line = Line(
+            geometry,
+            LineMaterial(color="w", thickness=2, aa=aa),
+        )
+        self._points = Points(
+            geometry,
+            PointsMaterial(color="w", size_mode="vertex", aa=aa),
+        )
 
         self.add(self._line, self._points, self._text)
 

--- a/pygfx/objects/_ruler.py
+++ b/pygfx/objects/_ruler.py
@@ -51,7 +51,7 @@ class Ruler(WorldObject):
 
         # Create a line and points object, with a shared geometry
         self._text = MultiText(
-            material=TextMaterial(color="#f00", aa=aa),
+            material=TextMaterial(color="#fff", aa=aa),
             screen_space=True,
         )
         geometry = self._text.geometry  # has .positions buffer

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -44,7 +44,7 @@ class LineShader(BaseShader):
         self["line_type"] = "line"
         self["dashing"] = False
         self["thickness_space"] = material.thickness_space
-        self["aa"] = material.aa
+        self["aa"] = material._gfx_effective_aa
         self["loop"] = False
         self["debug"] = False
 

--- a/pygfx/renderers/wgpu/shaders/pointsshader.py
+++ b/pygfx/renderers/wgpu/shaders/pointsshader.py
@@ -87,7 +87,7 @@ class PointsShader(BaseShader):
 
         self["size_mode"] = str(material.size_mode).split(".")[-1]
         self["size_space"] = material.size_space
-        self["aa"] = material.aa
+        self["aa"] = material._gfx_effective_aa
 
         self["draw_line_on_edge"] = False
         if isinstance(material, PointsMarkerMaterial):

--- a/pygfx/renderers/wgpu/shaders/textshader.py
+++ b/pygfx/renderers/wgpu/shaders/textshader.py
@@ -23,7 +23,7 @@ class TextShader(BaseShader):
         material = wobject.material
         self["is_screen_space"] = wobject.screen_space
         self["is_multi_text"] = wobject.is_multi
-        self["aa"] = material.aa
+        self["aa"] = material._gfx_effective_aa
         self["REF_GLYPH_SIZE"] = REF_GLYPH_SIZE
 
     def get_bindings(self, wobject, shared):


### PR DESCRIPTION
Ref #1065

As planned, turning off shader-based aa. 

We can afford it, because we have pretty good post-processing anti-aliasing now.

It avoids a range of artifacts by avoiding objects that produce a mix of opaque and transparent fragments.