### PR TITLE
Rename  alpha-method 'composite' to 'blended'

### DIFF
--- a/docs/transparency.rst
+++ b/docs/transparency.rst
@@ -52,7 +52,7 @@ These provide configurations for common cases. Examples are "solid",
 3. Set the ``alpha_config`` dictionary to have full control:
 
 In this advanced approach you can choose between four methods ("opaque",
-"composite", "stochastic", "weighted"), which each have a set of options.
+"blended", "stochastic", "weighted"), which each have a set of options.
 You probably also want to set ``material.depth_write``, and maybe
 ``material.render_queue`` and/or ``ob.render_order``.
 
@@ -102,7 +102,7 @@ Method "opaque" (overwrites the value in the output texture):
 * "solid": alpha is ignored.
 * "solid_premul": the alpha is multiplied with the color (making it darker).
 
-Method "composite" (per-fragment blending of the object's color and the color in the output texture):
+Method "blended" (per-fragment blending of the object's color and the color in the output texture):
 
 * "auto": classic alpha blending, with ``depth_write`` defaulting to True if ``.opacity==1``.
 * "blend": classic alpha blending using the over-operator.
@@ -128,7 +128,7 @@ Most users don't have to worry much about what the alpha-methods mean. Though it
 that the "opaque" and "stochastic" methods produce opaque fragments, and by default have ``depth_write=True``.
 The renderer sorts these objects front-to-back to avoid overdraw (for performance).
 
-In contrast, the "composite" and "weighted" methods result in semi-transparent fragments,
+In contrast, the "blended" and "weighted" methods result in semi-transparent fragments,
 and by default have ``depth_write=False``. The renderer sorts these object back-to-front to
 improve the chance of correct blending. Note that with the 'auto' mode, the default ``depth_write`` depends
 on the ``opacity``.
@@ -140,12 +140,12 @@ Alpha methods in detail
 **Alpha method 'opaque'** represents no transparency. The fragment color
 overwrites the value in the output texture. A very common method in render engines.
 
-**Alpha method 'composite'** represents alpha compositing: a common method in render
-engines in which objects are combined on a per-fragment basis. The object's
-fragment color and the current color in the output texture are blended using a
-configurable operator. There are several common compositing configurations, the
-most-used being the "over operator" (also known as normal blending). When alpha
-compositing is used, the result will depend on the order in which the objects are
+**Alpha method 'blended'** represents alpha compositing: a common method in
+render engines in which objects are combined on a per-fragment basis. The
+object's fragment color and the current color in the output texture are blended
+using a configurable operator. There are several common blending configurations,
+the most-used being the "over operator" (also known as normal blending). When
+blending is used, the result will depend on the order in which the objects are
 rendered.
 
 **Alpha method 'stochastic'** represents stochastic transparency. The alpha
@@ -315,7 +315,7 @@ Here's a list of both common and special use-cases, explaining how to implement 
 
         # Pygfx
         m.alpha_config = {
-            "method": "composite",
+            "method": "blended",
             "color_op": ..,  # wgpu.BlendOperation, default "add".
             "color_src": ..,  # wgpu.BlendFactor
             "color_dst": ..,  # wgpu.BlendFactor

--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -37,7 +37,7 @@ ALPHA_MODES = {
         "seed": "object",  # bc not enough variation to do 'element'
     },
     "blend": {
-        "method": "git ",
+        "method": "blended",
         "color_op": "add",
         "alpha_op": "add",
         "color_constant": (0, 0, 0),

--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -37,7 +37,7 @@ ALPHA_MODES = {
         "seed": "object",  # bc not enough variation to do 'element'
     },
     "blend": {
-        "method": "composite",
+        "method": "git ",
         "color_op": "add",
         "alpha_op": "add",
         "color_constant": (0, 0, 0),
@@ -48,7 +48,7 @@ ALPHA_MODES = {
         "alpha_dst": "one-minus-src-alpha",
     },
     "add": {
-        "method": "composite",
+        "method": "blended",
         "color_op": "add",
         "alpha_op": "add",
         "color_constant": (0, 0, 0),
@@ -59,7 +59,7 @@ ALPHA_MODES = {
         "alpha_dst": "one",
     },
     "subtract": {
-        "method": "composite",
+        "method": "blended",
         "color_op": "add",
         "alpha_op": "add",
         "color_constant": (0, 0, 0),
@@ -70,7 +70,7 @@ ALPHA_MODES = {
         "alpha_dst": "one",
     },
     "multiply": {
-        "method": "composite",
+        "method": "blended",
         "color_op": "add",
         "alpha_op": "add",
         "color_constant": (0, 0, 0),
@@ -331,7 +331,7 @@ class Material(Trackable):
         * "solid": alpha is ignored.
         * "solid_premul": the alpha is multipled with the color (making it darker).
 
-        Modes for method "composite" (per-fragment blending of the object's color and the color in the output texture):
+        Modes for method "blended" (per-fragment blending of the object's color and the color in the output texture):
 
         * "auto": classic alpha blending, with ``depth_write`` defaulting to True if ``.opacity==1``. See note below.
         * "blend": classic alpha blending using the over-operator. ``depth_write`` defaults to False.
@@ -360,7 +360,7 @@ class Material(Trackable):
         "blend", "dither", or "weighted_blend" is then recommended.
 
         Note that for methods 'opaque' and 'stochastic', the ``depth_write``
-        defaults to True, and for methods 'composite' and 'weighted' the
+        defaults to True, and for methods 'blended' and 'weighted' the
         ``depth_write`` defaults to False. Mode "auto" is an exception to this rule.
 
         Note that the value of ``material.alpha_mode`` can be "custom" in case
@@ -382,7 +382,7 @@ class Material(Trackable):
             m = {
                 "opaque": "solid",
                 "stochastic": "dither",
-                "composie": "blemd",
+                "blended": "blend",
                 "weighted": "weighted_blend",
             }
             suggestion = m.get(alpha_mode, "solid")
@@ -411,7 +411,7 @@ class Material(Trackable):
 
         * "opaque": colors simply overwrite the texture, no transparency.
         * "stochastic": stochastic transparency, alpha represents the chance of a fragment being visible.
-        * "composite": colors are blended with the buffer per-fragment.
+        * "blended": colors are blended with the buffer per-fragment.
         * "weighted": weighted blended order independent transparency, and variants thereof.
 
         The ``alpha_config`` dict has at least the following fields:
@@ -434,7 +434,7 @@ class Material(Trackable):
           use a per-object seed, and 'element' to have a per-element seed.
           The default is 'element' for  the noise patterns and 'object' for the bayer pattern.
 
-        Options for method 'composite':
+        Options for method 'blended':
 
         * "color_op": the blend operation/equation, any value from ``wgpu.BlendOperation``. Default "add".
         * "color_src": source factor, any value of ``wgpu.BlendFactor``. Mandatory.
@@ -484,7 +484,7 @@ class Material(Trackable):
         elif method == "stochastic":
             keys = ["pattern", "seed"]
             defaults = {"pattern": "blue_noise", "seed": "screen"}
-        elif method == "composite":
+        elif method == "blended":
             keys = [
                 "color_op",
                 "color_src",
@@ -578,7 +578,7 @@ class Material(Trackable):
                     render_queue = 2400
             elif alpha_method == "stochastic":
                 render_queue = 2400
-            else:  # alpha_method in ["composite", "weighted"]
+            else:  # alpha_method in ["blended", "weighted"]
                 if depth_write:
                     render_queue = 2600
                 else:

--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -276,7 +276,7 @@ class WorldObject(EventTarget, Trackable):
         The final sort order is typically determined by:
             1. the ``material.render_queue``
             2. effective ``render_order``
-            3. distance to camera (for transparent/composite passes)
+            3. distance to camera
 
         """
         # Note: the render order is on the object, not the material, because it affects

--- a/pygfx/renderers/wgpu/engine/blender.py
+++ b/pygfx/renderers/wgpu/engine/blender.py
@@ -240,7 +240,7 @@ class Blender:
                     "alpha": blend_dict(bf.one, bf.zero, bo.add),
                     "color": blend_dict(bf.one, bf.zero, bo.add),
                 }
-        elif alpha_method == "composite":
+        elif alpha_method == "blended":
             color_blend = {
                 "color": blend_dict(
                     alpha_config["color_src"],
@@ -433,7 +433,7 @@ class Blender:
 
         alpha_method = alpha_config["method"]
 
-        if alpha_method in ("opaque", "composite"):
+        if alpha_method in ("opaque", "blended"):
             fragment_output_code = """
             struct FragmentOutput {
                 @location(0) color: vec4<f32>,

--- a/pygfx/renderers/wgpu/engine/pipeline.py
+++ b/pygfx/renderers/wgpu/engine/pipeline.py
@@ -376,7 +376,7 @@ class PipelineContainer:
                 self.wobject_info["depth_test"] = wobject.material.depth_test
                 self.wobject_info["depth_compare"] = wobject.material.depth_compare
                 self.wobject_info["depth_write"] = wobject.material.depth_write
-                # For composite, the details need a new pipeline, but not a new shader
+                # For 'blended', the details need a new pipeline, but not a new shader
                 self.wobject_info["alpha_config"] = wobject.material.alpha_config
             self._check_pipeline_info()
             changed.add("render_info")

--- a/pygfx/renderers/wgpu/engine/utils.py
+++ b/pygfx/renderers/wgpu/engine/utils.py
@@ -245,7 +245,7 @@ jsonencoder = JsonEncoderWithWgpuSupport()
 
 
 def hash_from_value(value):
-    """Simple way to create a hash from a (possibly composite) object.
+    """Simple way to create a hash from a (possibly compound) object.
     Assumes JSON encodable objects and GPU objects.
     """
     # Encode the value to string using json. The JSON encoder is so fast that

--- a/pygfx/utils/enums.py
+++ b/pygfx/utils/enums.py
@@ -49,7 +49,7 @@ class AlphaMethod(Enum):
 
     opaque = None  #: opaque object
     stochastic = None  #: stochastic transparency
-    composite = None  #: per-fragment blending
+    blended = None  #: per-fragment blending
     weighted = None  #: weighted blending
 
 

--- a/tests/usecases/test_wobject_updates.py
+++ b/tests/usecases/test_wobject_updates.py
@@ -131,7 +131,7 @@ def test_updating_mesh_blending():
 
     # Same for custom classic blending
     mesh.material.alpha_config = {
-        "method": "composite",
+        "method": "blended",
         "color_src": "one",
         "color_dst": "zero",
         "alpha_src": "src",


### PR DESCRIPTION
I propose to rename the alpha-method 'composite' to 'blended'. I feel that the word 'composite' is not an easy word; I find myself having to recall it every time that I write it, and that feels weird for the method that is very standard. The name 'blended' reflects clearly what is meant in a simpler way; its the word that we tend to use in discussions to describe this method, and I think it avoids confusion to just call it that.

FWIW: I originally chose 'composite' to free up the word 'blend' for `SomeMaterial(alpha_mode='blend')`.