### PR TITLE
Access `alpha_config` will cause the bindings to be rebuilt?

### DIFF
--- a/pygfx/renderers/wgpu/shaders/meshshader.py
+++ b/pygfx/renderers/wgpu/shaders/meshshader.py
@@ -66,6 +66,9 @@ class MeshShader(BaseShader):
 
         color_mode = str(material.color_mode).split(".")[-1]
 
+        # access alpha config will cause the bindings to be rebuilt?
+        material.alpha_config
+
         self["color_mode"] = color_mode
         self["use_uniform_color"] = color_mode in ("auto", "uniform")
 


### PR DESCRIPTION
While working on #974, I encountered a very strange bug.

In the `MeshShader`, simply accessing (without making any modifications) `material.alpha_config` causes the bindings to be rebuilt, which leads to unit test failures.
I suspect this is related to the tracker mechanism, but it’s definitely not the behavior we would expect.