### PR TITLE
Add material.alpha_method (readonly)

### DIFF
--- a/docs/transparency.rst
+++ b/docs/transparency.rst
@@ -52,7 +52,7 @@ These provide configurations for common cases. Examples are "solid",
 3. Set the ``alpha_config`` dictionary to have full control:
 
 In this advanced approach you can choose between four methods ("opaque",
-"blended", "stochastic", "weighted"), which each have a set of options.
+"blended", "weighted", "stochastic"), which each have a set of options.
 You probably also want to set ``material.depth_write``, and maybe
 ``material.render_queue`` and/or ``ob.render_order``.
 
@@ -110,15 +110,15 @@ Method "blended" (per-fragment blending of the object's color and the color in t
 * "subtract": subtractive blending that removes the fragment color.
 * "multiply": multiplicative blending that multiplies the fragment color.
 
-Method "stochastic" (alpha represents the chance of a fragment being visible):
-
-* "dither": stochastic transparency with blue noise.
-* "bayer": stochastic transparency with a Bayer pattern.
-
 Method "weighted" (order independent blending):
 
 * "weighted_blend": weighted blended order independent transparency.
 * "weighted_solid": fragments are combined based on alpha, but the final alpha is always 1. Great for e.g. image stitching.
+
+Method "stochastic" (alpha represents the chance of a fragment being visible):
+
+* "dither": stochastic transparency with blue noise.
+* "bayer": stochastic transparency with a Bayer pattern.
 
 
 Alpha methods
@@ -148,19 +148,19 @@ the most-used being the "over operator" (also known as normal blending). When
 blending is used, the result will depend on the order in which the objects are
 rendered.
 
-**Alpha method 'stochastic'** represents stochastic transparency. The alpha
-represents the chance of a fragment being visible (i.e. not discarded). Visible
-fragments are opaque. This blend method is less common, but has interesting properties.
-Although the result has a somewhat noisy appearance, it handles transparency perfectly,
-capable of rendering multiple layers of transparent objects, and correctly handling
-objects that have a mix of opaque and transparent fragments.
-
 **Alpha method 'weighted'** represents (variants of) weighted blended order
 independent transparency. The order of objects does not matter for the
 end-result. One use-case being order independent transparency (OIT).
 The order-independent property is advantageous in some use-cases, but produces
 unfavourable results in others. It's use extends beyond transparency though, and
 can also be used for e.g. image stiching.
+
+**Alpha method 'stochastic'** represents stochastic transparency. The alpha
+represents the chance of a fragment being visible (i.e. not discarded). Visible
+fragments are opaque. This blend method is less common, but has interesting properties.
+Although the result has a somewhat noisy appearance, it handles transparency perfectly,
+capable of rendering multiple layers of transparent objects, and correctly handling
+objects that have a mix of opaque and transparent fragments.
 
 
 Alpha config
@@ -171,7 +171,7 @@ This dictionary has at least two keys: the 'method' and 'mode'. It has additiona
 available for the used method. The different presets represent common combinations of these options.
 
 Most users just set ``material.alpha_mode`` which implicitly sets
-``material.alpha_config``. In advanced/special cases, users can set the
+``material.alpha_method`` and ``material.alpha_config``. In advanced/special cases, users can set the
 ``material.alpha_config`` directly to take full control over all available
 options. In this case the 'mode' field and ``material.alpha_mode`` become "custom".
 

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -108,7 +108,7 @@ class LineMaterial(Material):
     @property
     def _gfx_effective_aa(self):
         aa_able_methods = ("blended", "weighted")
-        return self._store.aa and self._store.alpha_config["method"] in aa_able_methods
+        return self._store.aa and self.alpha_method in aa_able_methods
 
     @property
     def color_mode(self):

--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -123,7 +123,7 @@ class PointsMaterial(Material):
     @property
     def _gfx_effective_aa(self):
         aa_able_methods = ("blended", "weighted")
-        return self._store.aa and self._store.alpha_config["method"] in aa_able_methods
+        return self._store.aa and self.alpha_method in aa_able_methods
 
     @property
     def color_mode(self):

--- a/pygfx/materials/_text.py
+++ b/pygfx/materials/_text.py
@@ -94,7 +94,7 @@ class TextMaterial(Material):
     @property
     def _gfx_effective_aa(self):
         aa_able_methods = ("blended", "weighted")
-        return self._store.aa and self._store.alpha_config["method"] in aa_able_methods
+        return self._store.aa and self.alpha_method in aa_able_methods
 
     @property
     def color(self):

--- a/pygfx/renderers/wgpu/engine/pipeline.py
+++ b/pygfx/renderers/wgpu/engine/pipeline.py
@@ -353,7 +353,7 @@ class PipelineContainer:
             self.wobject_info = {}
             with tracker.track_usage("reset"):
                 self.wobject_info["pick_write"] = wobject.material.pick_write
-                alpha_method = wobject.material._store.alpha_method
+                alpha_method = wobject.material.alpha_method
                 self.wobject_info["alpha_method"] = alpha_method
                 if alpha_method in ["opaque", "stochastic", "weighted"]:
                     self.wobject_info["alpha_config"] = wobject.material.alpha_config

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -93,7 +93,7 @@ class LineShader(BaseShader):
         # if (
         #     self["color_mode"] == "uniform"
         #     and not self["dashing"]
-        #     and material.alpha_config['mode'] == "opaque"
+        #     and material.alpha_method == "opaque"
         #     and not_using_colors_that_may_have_alpha
         # ):
         #     # self["line_type"] = "quickline"


### PR DESCRIPTION
* Adds `material.alpha_method` so it can be inspected without getting `material.alpha_config`.
  * Getting `material.alpha_config` in a shader would trigger a rebuilt earlier than needed, see #1182 
* Changes `material.alpha_mode` to return `material._store.alpha_mode`. Again to avoid querying `alpha_config`.
* I found the order of methods to be quite pleasant like this: "opaque", "blended", "weighted", "stochastic", so I changed the docs to use that order in several places.
* Small tweaks to docs here and there.