### PR TITLE
Add arg to Ruler for alpha_mode of child objects

### DIFF
--- a/pygfx/materials/_base.py
+++ b/pygfx/materials/_base.py
@@ -153,7 +153,7 @@ class Material(Trackable):
         opacity: float = 1,
         clipping_planes: Sequence[ABCDTuple] = (),
         clipping_mode: Literal["ANY", "ALL"] = "ANY",
-        alpha_mode: str = "auto",
+        alpha_mode: Optional[str] = "auto",
         alpha_config: Optional[dict] = None,
         depth_test: bool = True,
         depth_compare: str = "<",
@@ -175,7 +175,7 @@ class Material(Trackable):
         self.clipping_planes = clipping_planes
         self.clipping_mode = clipping_mode
         if alpha_config is None:
-            self.alpha_mode = alpha_mode
+            self.alpha_mode = alpha_mode or "auto"
         else:
             self.alpha_config = alpha_config
         self.depth_test = depth_test

--- a/pygfx/objects/_ruler.py
+++ b/pygfx/objects/_ruler.py
@@ -33,8 +33,9 @@ class Ruler(WorldObject):
         tick_side="left",
         min_tick_distance=50,
         ticks_at_end_points=False,
-        alpha_mode="auto",
+        alpha_mode=None,
         aa=True,
+        render_queue=None,
     ):
         super().__init__()
 
@@ -48,36 +49,27 @@ class Ruler(WorldObject):
         self.min_tick_distance = min_tick_distance
         self.ticks_at_end_points = ticks_at_end_points
 
-        aa = bool(aa)
+        # Common kwargs for the materials of the child objects
+        material_kwargs = dict(
+            alpha_mode=alpha_mode,
+            aa=bool(aa),
+            render_queue=render_queue,
+        )
 
         # Create a line and points object, with a shared geometry
         self._text = MultiText(
-            material=TextMaterial(
-                color="#fff",
-                alpha_mode=alpha_mode,
-                aa=aa,
-            ),
+            material=TextMaterial(color="#fff", **material_kwargs),
             screen_space=True,
         )
         geometry = self._text.geometry  # has .positions buffer
         geometry.sizes = Buffer(np.zeros(geometry.positions.nitems, "f4"))
         self._line = Line(
             geometry,
-            LineMaterial(
-                color="w",
-                thickness=2,
-                alpha_mode=alpha_mode,
-                aa=aa,
-            ),
+            LineMaterial(color="w", thickness=2, **material_kwargs),
         )
         self._points = Points(
             geometry,
-            PointsMaterial(
-                color="w",
-                size_mode="vertex",
-                alpha_mode=alpha_mode,
-                aa=aa,
-            ),
+            PointsMaterial(color="w", size_mode="vertex", **material_kwargs),
         )
 
         self.add(self._line, self._points, self._text)

--- a/pygfx/objects/_ruler.py
+++ b/pygfx/objects/_ruler.py
@@ -33,6 +33,7 @@ class Ruler(WorldObject):
         tick_side="left",
         min_tick_distance=50,
         ticks_at_end_points=False,
+        alpha_mode="auto",
         aa=True,
     ):
         super().__init__()
@@ -51,18 +52,32 @@ class Ruler(WorldObject):
 
         # Create a line and points object, with a shared geometry
         self._text = MultiText(
-            material=TextMaterial(color="#fff", aa=aa),
+            material=TextMaterial(
+                color="#fff",
+                alpha_mode=alpha_mode,
+                aa=aa,
+            ),
             screen_space=True,
         )
         geometry = self._text.geometry  # has .positions buffer
         geometry.sizes = Buffer(np.zeros(geometry.positions.nitems, "f4"))
         self._line = Line(
             geometry,
-            LineMaterial(color="w", thickness=2, aa=aa),
+            LineMaterial(
+                color="w",
+                thickness=2,
+                alpha_mode=alpha_mode,
+                aa=aa,
+            ),
         )
         self._points = Points(
             geometry,
-            PointsMaterial(color="w", size_mode="vertex", aa=aa),
+            PointsMaterial(
+                color="w",
+                size_mode="vertex",
+                alpha_mode=alpha_mode,
+                aa=aa,
+            ),
         )
 
         self.add(self._line, self._points, self._text)


### PR DESCRIPTION
Makes it easier for libs like Fastplotlib to use the same `alpha_mode` and `render_queue` for all objects.