### PR TITLE
Switch to trusted publishing for PyPI publish in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-builds, release-build]
     if: success() && startsWith(github.ref, 'refs/tags/v')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/pygfx
+    permissions:
+      id-token: write
     steps:
     - uses: actions/checkout@v4
     - name: Download assets
@@ -223,5 +228,4 @@ jobs:
     - name: Publish to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        user: __token__
-        password: ${{ secrets.PYPI_PASSWORD }}
+        print-hash: true


### PR DESCRIPTION
You'll need to create a new GitHub environment called `pypi` ([GitHub docs](https://docs.github.com/en/actions/how-tos/deploy/configure-and-manage-deployments/manage-environments#creating-an-environment)), and add it to PyPI ([PyPI docs](https://docs.pypi.org/trusted-publishers/adding-a-publisher/#github-actions)).

Also enables computing and displaying published files' hashes.

Resolves #1175 