### PR TITLE
Update for new imgui

### DIFF
--- a/examples/feature_demo/animation_mixer.py
+++ b/examples/feature_demo/animation_mixer.py
@@ -85,10 +85,7 @@ actions = [idle_action, walk_action, run_action]
 gui_renderer = ImguiRenderer(renderer.device, canvas)
 
 fonts = gfx.font_manager.select_font("Controls", FontProps())
-fonts_file = fonts[0][1]._filename
-font = gui_renderer.backend.io.fonts.add_font_from_file_ttf(fonts_file, 16)
-gui_renderer.backend.create_fonts_texture()
-
+font = gui_renderer.backend.io.fonts.add_font_from_file_ttf(fonts[0][1]._filename, 16)
 gui_renderer.backend.io.font_default = font
 
 state = {
@@ -179,7 +176,6 @@ next_step_size = 0.05
 
 
 def draw_imgui():
-    imgui.new_frame()
     imgui.set_next_window_size((300, 0), imgui.Cond_.always)
     imgui.set_next_window_pos(
         (gui_renderer.backend.io.display_size.x - 300, 0), imgui.Cond_.always
@@ -287,9 +283,6 @@ def draw_imgui():
                 animation_mixer.time_scale = speed
 
     imgui.end()
-    imgui.end_frame()
-    imgui.render()
-    return imgui.get_draw_data()
 
 
 gui_renderer.set_gui(draw_imgui)

--- a/examples/feature_demo/clearcoat.py
+++ b/examples/feature_demo/clearcoat.py
@@ -89,7 +89,6 @@ gui_renderer = ImguiRenderer(renderer.device, canvas)
 
 
 def draw_imgui():
-    imgui.new_frame()
     imgui.set_next_window_size((250, 0), imgui.Cond_.always)
     imgui.set_next_window_pos(
         (gui_renderer.backend.io.display_size.x - 250, 0), imgui.Cond_.always
@@ -119,9 +118,6 @@ def draw_imgui():
             m.material.clearcoat_roughness = clearcoat_roughness
 
     imgui.end()
-    imgui.end_frame()
-    imgui.render()
-    return imgui.get_draw_data()
 
 
 gui_renderer.set_gui(draw_imgui)

--- a/examples/feature_demo/compute_cloth.py
+++ b/examples/feature_demo/compute_cloth.py
@@ -611,7 +611,6 @@ show_verlet_system = False
 def draw_ui():
     global wireframe_mode, show_sphere, show_verlet_system
 
-    imgui.new_frame()
     imgui.set_next_window_size((350, 0), imgui.Cond_.always)
     imgui.set_next_window_pos((0, 0), imgui.Cond_.always)
 
@@ -646,9 +645,6 @@ def draw_ui():
         )
 
     imgui.end()
-    imgui.end_frame()
-    imgui.render()
-    return imgui.get_draw_data()
 
 
 gui_renderer.set_gui(draw_ui)

--- a/examples/feature_demo/gltf_animations.py
+++ b/examples/feature_demo/gltf_animations.py
@@ -37,7 +37,7 @@ import pygfx as gfx
 from rendercanvas.auto import RenderCanvas, loop
 
 from wgpu.utils.imgui import ImguiRenderer
-from imgui_bundle import imgui, icons_fontawesome_6, hello_imgui  # type: ignore
+from imgui_bundle import imgui  # type: ignore
 
 gltf_path = model_dir / "Soldier.glb"
 
@@ -85,15 +85,21 @@ state = {
     "selected_action": 2,
 }
 
-fa_loading_params = hello_imgui.FontLoadingParams()
-fa_loading_params.use_full_glyph_range = True
-fa = hello_imgui.load_font("fonts/fontawesome-webfont.ttf", 14, fa_loading_params)
-# fa = gui_renderer.backend.io.fonts.add_font_from_file_ttf("fonts/fontawesome-webfont.ttf", 16)
-gui_renderer.backend.create_fonts_texture()
+# It looks like the loading the FA fonts will use them anywhere? So I disabled it.
+# Feel free to try to re-enabled it.
+# fa_loading_params = hello_imgui.FontLoadingParams()
+# # fa_loading_params.use_full_glyph_range = True
+# fa = hello_imgui.load_font("fonts/fontawesome-webfont.ttf", 14, fa_loading_params)
+# # fa = gui_renderer.backend.io.fonts.add_font_from_file_ttf("fonts/fontawesome-webfont.ttf", 16)
+
+# Load a proper font.
+# I'm pretty sure that '▶'  and '⏸' are in the Noto font, but these chars dont work ...
+fonts = gfx.font_manager.select_font("Controls", gfx.utils.text.FontProps())
+font = gui_renderer.backend.io.fonts.add_font_from_file_ttf(fonts[0][1]._filename, 16)
+gui_renderer.backend.io.font_default = font
 
 
 def draw_imgui():
-    imgui.new_frame()
     imgui.set_next_window_size((250, 0), imgui.Cond_.always)
     imgui.set_next_window_pos(
         (gui_renderer.backend.io.display_size.x - 250, 0), imgui.Cond_.always
@@ -148,15 +154,17 @@ def draw_imgui():
 
     duration = clips[state["selected_action"]].duration
 
-    imgui.push_font(fa)
+    # imgui.push_font(fa, 0)
     if actions[state["selected_action"]].paused:
-        if imgui.button(icons_fontawesome_6.ICON_FA_PLAY, size=(24, 20)):
+        # > or ▶ or icons_fontawesome_6.ICON_FA_PLAY
+        if imgui.button(">", size=(24, 20)):
             actions[state["selected_action"]].paused = False
     else:
-        if imgui.button(icons_fontawesome_6.ICON_FA_PAUSE, size=(24, 20)):
+        # || or ⏸ or icons_fontawesome_6.ICON_FA_PAUSE
+        if imgui.button("||", size=(24, 20)):
             actions[state["selected_action"]].paused = True
 
-    imgui.pop_font()
+    # imgui.pop_font()
     imgui.same_line()
     avail_size = imgui.get_content_region_avail()
     imgui.set_next_item_width(avail_size.x)
@@ -167,10 +175,6 @@ def draw_imgui():
         actions[state["selected_action"]].time = v
         actions[state["selected_action"]].paused = True
     imgui.end()
-
-    imgui.end_frame()
-    imgui.render()
-    return imgui.get_draw_data()
 
 
 gui_renderer.set_gui(draw_imgui)

--- a/examples/feature_demo/gltf_animations.py
+++ b/examples/feature_demo/gltf_animations.py
@@ -90,13 +90,7 @@ state = {
 # fa_loading_params = hello_imgui.FontLoadingParams()
 # # fa_loading_params.use_full_glyph_range = True
 # fa = hello_imgui.load_font("fonts/fontawesome-webfont.ttf", 14, fa_loading_params)
-# # fa = gui_renderer.backend.io.fonts.add_font_from_file_ttf("fonts/fontawesome-webfont.ttf", 16)
-
-# Load a proper font.
-# I'm pretty sure that '▶'  and '⏸' are in the Noto font, but these chars dont work ...
-fonts = gfx.font_manager.select_font("Controls", gfx.utils.text.FontProps())
-font = gui_renderer.backend.io.fonts.add_font_from_file_ttf(fonts[0][1]._filename, 16)
-gui_renderer.backend.io.font_default = font
+# fa = gui_renderer.backend.io.fonts.add_font_from_file_ttf("fonts/fontawesome-webfont.ttf", 16)
 
 
 def draw_imgui():
@@ -156,12 +150,12 @@ def draw_imgui():
 
     # imgui.push_font(fa, 0)
     if actions[state["selected_action"]].paused:
-        # > or ▶ or icons_fontawesome_6.ICON_FA_PLAY
-        if imgui.button(">", size=(24, 20)):
+        # if imgui.button("▶", size=(24, 20)):
+        if imgui.button(">", size=(24, 24)):
             actions[state["selected_action"]].paused = False
     else:
-        # || or ⏸ or icons_fontawesome_6.ICON_FA_PAUSE
-        if imgui.button("||", size=(24, 20)):
+        # if imgui.button("⏸", size=(24, 20)):
+        if imgui.button("||", size=(24, 24)):
             actions[state["selected_action"]].paused = True
 
     # imgui.pop_font()

--- a/examples/feature_demo/gltf_unlit.py
+++ b/examples/feature_demo/gltf_unlit.py
@@ -88,7 +88,6 @@ state = {"ibl": True}
 
 
 def draw_imgui():
-    imgui.new_frame()
     imgui.set_next_window_size((250, 0), imgui.Cond_.always)
     imgui.set_next_window_pos(
         (gui_renderer.backend.io.display_size.x - 250, 0), imgui.Cond_.always
@@ -115,9 +114,6 @@ def draw_imgui():
                 pbr_model.traverse(lambda obj: add_env_map(obj, None))
 
     imgui.end()
-    imgui.end_frame()
-    imgui.render()
-    return imgui.get_draw_data()
 
 
 gui_renderer.set_gui(draw_imgui)

--- a/examples/feature_demo/gltf_viewer.py
+++ b/examples/feature_demo/gltf_viewer.py
@@ -157,7 +157,6 @@ def load_model(model_path):
 
 def draw_imgui():
     global model_obj, skeleton_helper, actions, open_file_dialog
-    imgui.new_frame()
     imgui.set_next_window_size((250, 0), imgui.Cond_.always)
     imgui.set_next_window_pos(
         (gui_renderer.backend.io.display_size.x - 250, 0), imgui.Cond_.always
@@ -252,9 +251,6 @@ def draw_imgui():
                         actions[state["selected_action"]].play()
 
     imgui.end()
-    imgui.end_frame()
-    imgui.render()
-    return imgui.get_draw_data()
 
 
 gui_renderer.set_gui(draw_imgui)

--- a/examples/feature_demo/morph_facecap.py
+++ b/examples/feature_demo/morph_facecap.py
@@ -83,7 +83,6 @@ action.play()
 
 
 def draw_imgui():
-    imgui.new_frame()
     imgui.set_next_window_size((400, 0), imgui.Cond_.always)
     imgui.set_next_window_pos(
         (gui_renderer.backend.io.display_size.x - 400, 0), imgui.Cond_.always
@@ -99,9 +98,6 @@ def draw_imgui():
             imgui.slider_float(name, face_mesh.morph_target_influences[i], 0, 1)
 
     imgui.end()
-    imgui.end_frame()
-    imgui.render()
-    return imgui.get_draw_data()
 
 
 gui_renderer.set_gui(draw_imgui)

--- a/examples/feature_demo/skinning_animation.py
+++ b/examples/feature_demo/skinning_animation.py
@@ -91,13 +91,7 @@ state = {"pause": False}
 # fa_loading_params = hello_imgui.FontLoadingParams()
 # # fa_loading_params.use_full_glyph_range = True
 # fa = hello_imgui.load_font("fonts/fontawesome-webfont.ttf", 14, fa_loading_params)
-# # fa = gui_renderer.backend.io.fonts.add_font_from_file_ttf("fonts/fontawesome-webfont.ttf", 16)
-
-# Load a proper font.
-# I'm pretty sure that '▶'  and '⏸' are in the Noto font, but these chars dont work ...
-fonts = gfx.font_manager.select_font("Controls", gfx.utils.text.FontProps())
-font = gui_renderer.backend.io.fonts.add_font_from_file_ttf(fonts[0][1]._filename, 16)
-gui_renderer.backend.io.font_default = font
+# fa = gui_renderer.backend.io.fonts.add_font_from_file_ttf("fonts/fontawesome-webfont.ttf", 16)
 
 
 def draw_imgui():
@@ -119,10 +113,10 @@ def draw_imgui():
     duration = action_clip.duration
 
     if action.paused:
-        if imgui.button(">", size=(24, 20)):
+        if imgui.button(">", size=(24, 24)):
             action.paused = False
     else:
-        if imgui.button("||", size=(24, 20)):
+        if imgui.button("||", size=(24, 24)):
             action.paused = True
 
     imgui.same_line()

--- a/examples/feature_demo/skinning_animation.py
+++ b/examples/feature_demo/skinning_animation.py
@@ -35,7 +35,7 @@ import pygfx as gfx
 from rendercanvas.auto import RenderCanvas, loop
 
 from wgpu.utils.imgui import ImguiRenderer
-from imgui_bundle import imgui, hello_imgui, icons_fontawesome_6  # type: ignore
+from imgui_bundle import imgui  # type: ignore
 
 gltf_path = model_dir / "Michelle.glb"
 
@@ -86,15 +86,21 @@ gui_renderer = ImguiRenderer(renderer.device, canvas)
 
 state = {"pause": False}
 
-fa_loading_params = hello_imgui.FontLoadingParams()
-fa_loading_params.use_full_glyph_range = True
-fa = hello_imgui.load_font("fonts/fontawesome-webfont.ttf", 14, fa_loading_params)
-gui_renderer.backend.create_fonts_texture()
+# It looks like the loading the FA fonts will use them anywhere? So I disabled it.
+# Feel free to try to re-enabled it.
+# fa_loading_params = hello_imgui.FontLoadingParams()
+# # fa_loading_params.use_full_glyph_range = True
+# fa = hello_imgui.load_font("fonts/fontawesome-webfont.ttf", 14, fa_loading_params)
+# # fa = gui_renderer.backend.io.fonts.add_font_from_file_ttf("fonts/fontawesome-webfont.ttf", 16)
+
+# Load a proper font.
+# I'm pretty sure that '▶'  and '⏸' are in the Noto font, but these chars dont work ...
+fonts = gfx.font_manager.select_font("Controls", gfx.utils.text.FontProps())
+font = gui_renderer.backend.io.fonts.add_font_from_file_ttf(fonts[0][1]._filename, 16)
+gui_renderer.backend.io.font_default = font
 
 
 def draw_imgui():
-    imgui.new_frame()
-
     imgui.set_next_window_size(
         (gui_renderer.backend.io.display_size.x, 0), imgui.Cond_.always
     )
@@ -112,15 +118,13 @@ def draw_imgui():
 
     duration = action_clip.duration
 
-    imgui.push_font(fa)
     if action.paused:
-        if imgui.button(icons_fontawesome_6.ICON_FA_PLAY, size=(24, 20)):
+        if imgui.button(">", size=(24, 20)):
             action.paused = False
     else:
-        if imgui.button(icons_fontawesome_6.ICON_FA_PAUSE, size=(24, 20)):
+        if imgui.button("||", size=(24, 20)):
             action.paused = True
 
-    imgui.pop_font()
     imgui.same_line()
     avail_size = imgui.get_content_region_avail()
     imgui.set_next_item_width(avail_size.x)
@@ -128,10 +132,6 @@ def draw_imgui():
     if changed:
         action.time = v
     imgui.end()
-
-    imgui.end_frame()
-    imgui.render()
-    return imgui.get_draw_data()
 
 
 gui_renderer.set_gui(draw_imgui)

--- a/examples/other/background_subtraction.py
+++ b/examples/other/background_subtraction.py
@@ -117,8 +117,6 @@ def draw_imgui():
     global current_image_index
     global im, image_texture
 
-    imgui.new_frame()
-
     imgui.set_next_window_size((400, 0), imgui.Cond_.always)
     imgui.set_next_window_pos((0, 0), imgui.Cond_.always)
 
@@ -140,9 +138,6 @@ def draw_imgui():
             )
 
     imgui.end()
-    imgui.end_frame()
-    imgui.render()
-    return imgui.get_draw_data()
 
 
 # Create GUI renderer

--- a/examples/other/compare_images.py
+++ b/examples/other/compare_images.py
@@ -199,8 +199,6 @@ gui_renderer = ImguiRenderer(renderer.device, canvas)
 
 
 def draw_imgui():
-    imgui.new_frame()
-
     imgui.set_next_window_size((300, 0), imgui.Cond_.always)
     imgui.set_next_window_pos((0, 0), imgui.Cond_.always)
 
@@ -261,9 +259,6 @@ def draw_imgui():
                 gfx_image.geometry = geometry_image
 
     imgui.end()
-    imgui.end_frame()
-    imgui.render()
-    return imgui.get_draw_data()
 
 
 def animate():

--- a/examples/other/image_histogram.py
+++ b/examples/other/image_histogram.py
@@ -276,8 +276,6 @@ current_image_index = 0
 def draw_imgui():
     global current_image_index
 
-    imgui.new_frame()
-
     imgui.set_next_window_size((300, 0), imgui.Cond_.always)
     imgui.set_next_window_pos((0, 0), imgui.Cond_.always)
 
@@ -304,9 +302,6 @@ def draw_imgui():
             histogram_object.local.scale_x = image_texture.size[0] / (nbins - 1)
 
     imgui.end()
-    imgui.end_frame()
-    imgui.render()
-    return imgui.get_draw_data()
 
 
 # Create GUI renderer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 requires-python = ">= 3.10"
 dependencies = [
     "rendercanvas >= 2.2",
-    "wgpu >=0.24.0 <0.25",
+    "wgpu >=0.24.0, <0.25",
     "pylinalg >=0.6.7,<0.7.0",
     "numpy",
     "freetype-py",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ keywords = [
 requires-python = ">= 3.10"
 dependencies = [
     "rendercanvas >= 2.2",
-    "wgpu >=0.19.0,<0.24.0",
+    "wgpu >=0.24.0 <0.25",
     "pylinalg >=0.6.7,<0.7.0",
     "numpy",
     "freetype-py",
@@ -39,7 +39,7 @@ examples = [
     "scikit-image",
     "trimesh <4.6",
     "gltflib",
-    "imgui-bundle >=1.6,<1.92",
+    "imgui-bundle >=1.92",
     "httpx",
 ]
 docs = [
@@ -52,7 +52,7 @@ docs = [
     "scikit-image",
     "trimesh <4.6",
     "gltflib",
-    "imgui-bundle >=1.6,<1.92",
+    "imgui-bundle >=1.92",
     "httpx",
 ]
 tests = ["pytest", "psutil", "trimesh <4.6", "httpx", "gltflib", "imageio"]


### PR DESCRIPTION
There are two examples that use FontAwesome to show a play/pause button ("skinning_animation.py" and "gltf_animations.py"). I spent some time trying to revive them, but I could not get it to work so I just used ">" for play 🤷. If anyone wants to try have a look at that, here are some things I found:

* The `imgui.push_font(fa)` now has a mandatory extra arg to scale the text. Zero means same size: `imgui.push_font(fa, 0)`. Why they did not make it optional is beyond me.
* Loading the fa font with `hello_imgui.load_font()` works, except no text is rendered, so something is off.
* The  `fa_loading_params.use_full_glyph_range = True` no longer works (not a valid attribute).
* I now set it to use the Noto font, with the idea that we can use Unicode symbols, but for some odd reason they also don't work???
