### PR TITLE
Encode face coords as 2x9 bits instead of 3x6 bits

### DIFF
--- a/pygfx/renderers/wgpu/wgsl/mesh.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/mesh.wgsl
@@ -642,9 +642,8 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
     out.pick = (
         pick_pack(varyings.pick_id, 20) +
         pick_pack(varyings.pick_idx, 26) +
-        pick_pack(u32(varyings.pick_coords.x * 63.0), 6) +
-        pick_pack(u32(varyings.pick_coords.y * 63.0), 6) +
-        pick_pack(u32(varyings.pick_coords.z * 63.0), 6)
+        pick_pack(u32(varyings.pick_coords.x * 511.0), 9) +
+        pick_pack(u32(varyings.pick_coords.y * 511.0), 9)
     );
     $$ endif
 

--- a/tests/renderers/test_renderer_picking.py
+++ b/tests/renderers/test_renderer_picking.py
@@ -74,7 +74,7 @@ def test_render_picking_simple():
 
     # Assert sub-info
     assert info1["face_index"] == 0
-    assert np.allclose(info1["face_coord"], (0.0161, 0.483, 0.5), atol=0.001)
+    assert np.allclose(info1["face_coord"], (0.0196, 0.487, 0.493), atol=0.001)
 
     assert info2["index"] == (4, 4)
     assert np.allclose(info2["pixel_coord"], (0.275, 0.425), atol=0.001)


### PR DESCRIPTION
I saw this bug report https://github.com/pygfx/pygfx/issues/1147 and this fix https://github.com/pygfx/pygfx/pull/1179 and thought there is a better solution:

Since the face coords sum up to one, encoding all three is redundant. If we encode only two of the coordinates instead, and then compute the third one, not only do we ensure they always add up to one, we also get an 8x increase in accuracy, as we can encode them as 2x9 bits instead of 3x6 bits.