### PR TITLE
Support for proper tick marks by adding a 'tick' marker and rotation_mode 'curve'

### DIFF
--- a/examples/feature_demo/line_segments.py
+++ b/examples/feature_demo/line_segments.py
@@ -25,9 +25,9 @@ positions = np.column_stack([x, y, np.zeros_like(x)])
 colors = np.random.uniform(0, 1, (x.size, 4)).astype(np.float32)
 colors[:, 3] = 1
 
-line = gfx.Line(
+line = gfx.Points(
     gfx.Geometry(positions=positions, colors=colors),
-    gfx.LineSegmentMaterial(thickness=6.0, color_mode="face", map=gfx.cm.viridis),
+    gfx.PointsMarkerMaterial(size=20, marker="pin", rotation_mode="curve"),
 )
 scene.add(line)
 

--- a/pygfx/renderers/wgpu/wgsl/points.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/points.wgsl
@@ -65,6 +65,23 @@ fn vs_main(in: VertexInput) -> Varyings {
     // Convert to logical screen coordinates
     let pos_s = (pos_n.xy / pos_n.w + 1.0) * screen_factor;
 
+    $$ if need_neighbours
+        let node_index_prev = max(node_index - 1, 0);
+        var node_index_next = min(u_renderer.last_i, node_index + 1);
+
+        let pos_m_prev = load_s_positions(node_index_prev);
+        let pos_w_prev = u_wobject.world_transform * vec4<f32>(pos_m_prev.xyz, 1.0);
+        let pos_c_prev = u_stdinfo.cam_transform * pos_w_prev;
+        let pos_n_prev = u_stdinfo.projection_transform * pos_c_prev;
+        let pos_s_prev = (pos_n_prev.xy / pos_n_prev.w + 1.0) * screen_factor;
+
+        let pos_m_next = load_s_positions(node_index_next);
+        let pos_w_next = u_wobject.world_transform * vec4<f32>(pos_m_next.xyz, 1.0);
+        let pos_c_next = u_stdinfo.cam_transform * pos_w_next;
+        let pos_n_next = u_stdinfo.projection_transform * pos_c_next;
+        let pos_s_next = (pos_n_next.xy / pos_n_next.w + 1.0) * screen_factor;
+    $$ endif
+
     // Get reference size
     $$ if size_mode == 'vertex'
         let size_ref = load_s_sizes(node_index);
@@ -149,6 +166,9 @@ fn vs_main(in: VertexInput) -> Varyings {
 
     $$ if rotation_mode == 'vertex'
     let rotation = load_s_rotations(node_index);
+    $$ elif rotation_mode == 'curve'
+    let dpos = pos_s_next - pos_s_prev;
+    let rotation = atan2(dpos.y, dpos.x);
     $$ else
     let rotation = u_material.rotation;
     $$ endif

--- a/pygfx/renderers/wgpu/wgsl/points.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/points.wgsl
@@ -494,6 +494,12 @@ fn get_signed_distance_to_shape_edge(coord: vec2<f32>, varyings:Varyings) -> f32
         let r4 = max(abs(y1)- size/2.0, abs(x1)- size/10.0);
         return min( min(r1,r2), min(r3,r4));
 
+
+    } else if (marker == {{ markerenum_tick }}) {
+        // A tick is an infinitely thin line (only the edge is visible)
+        let d = abs(coord.xy) - vec2f(0.0, 0.5 * size);
+        return length(max(d, vec2<f32>(0.0))) + min(max(d.x, d.y), 0.0);
+
     } else if ( marker == {{ markerenum_triangle_down }} ||
                 marker == {{ markerenum_triangle_left }} ||
                 marker == {{ markerenum_triangle_right }} ||

--- a/pygfx/utils/enums.py
+++ b/pygfx/utils/enums.py
@@ -139,6 +139,7 @@ class MarkerShape(Enum):
     plus = None  #: + A plus symbol.
     cross = None  #: x A rotated plus symbol.
     asterix = None  #: ✳️ A plus and a cross combined.
+    tick = None  #: A tickmark: an infinitely thin line so only the marker edge is drawn. The width and length can be controller with 'edge_width' and 'size' respectively.
     triangle_up = None  #: ▲
     triangle_down = None  #: ▼
     triangle_left = None  #: ◀
@@ -160,6 +161,7 @@ class MarkerInt(Enum):
     plus = 203
     cross = 204
     asterix = 205
+    tick = 206
     triangle_up = 301
     triangle_down = 302
     triangle_left = 303

--- a/pygfx/utils/enums.py
+++ b/pygfx/utils/enums.py
@@ -118,6 +118,7 @@ class RotationMode(Enum):
 
     uniform = None  #: Use a uniform rotation.
     vertex = None  #: Use a per-vertex rotation specified with ``geometry.rotations``.
+    curve = None  #: The rotation follows the curve of the line defined by the points (in screen space).
 
 
 class CoordSpace(Enum):


### PR DESCRIPTION
Closes #1145 

* [x] Add `PointsMarkerMaterial.rotation_mode` 'curve', which calculates the rotation of the current marker by following the curve of the line defined by the vertices. 
* [x] Add `PointsMarkerMaterial.marker` 'tick', which is an infinitely thin line piece; the edge of the marker is the tick. This is nice, because now the `edge_width` and `size` of the marker can be used to control the width and length of the tickmarks.
* [x] Update the ruler to use the above.
* [x] Also some improvements to ruler in terms of input args, typing, and docs.  