### PR TITLE
No upper bounds on versions of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,12 +23,9 @@ dependencies = [
     "pylinalg >=0.6.7,<0.7.0",
     "numpy",
     "freetype-py",
-    # ttb font shaping was brokein in uharfbuzz 0.51.0
-    # https://github.com/harfbuzz/uharfbuzz/issues/248
-    # https://github.com/pygfx/pygfx/issues/1149
-    "uharfbuzz !=0.51.0",
+    "uharfbuzz !=0.51.0",      # https://github.com/harfbuzz/uharfbuzz/issues/248
     "jinja2",
-    "hsluv >=5.0.0,<6.0.0",
+    "hsluv >=5",
 ]
 
 [project.optional-dependencies]
@@ -37,7 +34,7 @@ examples = [
     "pytest",
     "imageio[pyav]",
     "scikit-image",
-    "trimesh <4.6",
+    "trimesh",
     "gltflib",
     "imgui-bundle >=1.92",
     "httpx",
@@ -50,12 +47,12 @@ docs = [
     # Duplicate from 'examples'
     "imageio[pyav]",
     "scikit-image",
-    "trimesh <4.6",
+    "trimesh",
     "gltflib",
     "imgui-bundle >=1.92",
     "httpx",
 ]
-tests = ["pytest", "psutil", "trimesh <4.6", "httpx", "gltflib", "imageio"]
+tests = ["pytest", "psutil", "trimesh", "httpx", "gltflib", "imageio"]
 dev = ["pygfx[lint,tests,examples,docs]"]
 
 [project.entry-points."pyinstaller40"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,12 +18,16 @@ keywords = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
+    # Packages under the PyGfx umbrella.
+    # For some of these we set an upper bound because (for now) they regularly break their API.
+    # Packages that depend on PyGfx should not set an upper bound on e.g. wgpu, unless really needed!
     "rendercanvas >= 2.2",
     "wgpu >=0.24.0, <0.26",
     "pylinalg >=0.6.7,<0.7.0",
+    # External dependencies
     "numpy",
     "freetype-py",
-    "uharfbuzz !=0.51.0",      # https://github.com/harfbuzz/uharfbuzz/issues/248
+    "uharfbuzz !=0.51.0", # https://github.com/harfbuzz/uharfbuzz/issues/248
     "jinja2",
     "hsluv >=5",
 ]


### PR DESCRIPTION
For some of our dependencies we have set an upper bound version, but this is considered bad practice, see e.g. https://iscinumpy.dev/post/bound-version-constraints/. To be *very* brief, it holds downstream software and users back from upgrading to newer versions of these software.

For packages that we don't control, we should just fix it so it works with the latest version. 

For our own upstream packages (wgpu-py, pylinalg, rendercanvas), we can either follow that same approach (like we do for rendercanvas), or we can apply an upper-bound (like we do for wgpu-py and pylinalg). Since we control both packages, this is fine, and makes it more plug-and-play for users. But downstream sofware should not put bounds on wgpu-py unless its really needed.

In time, when wgpu-py is more stable, we can probably remove the upper bound again.