### PR TITLE
add regular asterisk symobl

### DIFF
--- a/pygfx/materials/_points.py
+++ b/pygfx/materials/_points.py
@@ -341,7 +341,7 @@ class PointsMarkerMaterial(PointsMaterial):
         Supported values:
 
         * A string from :obj:`pygfx.utils.enums.MarkerShape`.
-        * Matplotlib compatible characters: "osD+x^v<>".
+        * Matplotlib compatible characters: "osD+x^v<>*".
         * Unicode symbols: "●○■♦♥♠♣✳▲▼◀▶".
         * Emojis: "❤️♠️♣️♦️💎💍✳️📍".
         * A string containing the value "custom". In this case, the WGSL
@@ -368,6 +368,7 @@ class PointsMarkerMaterial(PointsMaterial):
             "<": "triangle_left",
             ">": "triangle_right",
             "v": "triangle_down",
+            "*": "asterix",
             # Unicode
             "●": "circle",
             "○": "ring",


### PR DESCRIPTION
`*` is available on a US keyboard, whereas `✳` is not, and `*` is also what matplotlib uses.

by the way, it might be useful for the "alt_names" dict to be public, in fastplotlib I just copy pasted it. 

minor, but "asterix" is the french cartoon and "asterisk" is the symbol :sweat_smile: 
