### PR TITLE
account for transform of instanced objects for calculating bbox

### DIFF
--- a/pygfx/objects/_base.py
+++ b/pygfx/objects/_base.py
@@ -553,7 +553,7 @@ class WorldObject(EventTarget, Trackable):
         # Combine
         if _aabbs:
             aabbs = np.stack(_aabbs)
-            final_aabb = np.zeros((2, 3), dtype=float)
+            final_aabb = np.empty((2, 3), dtype=float)
             final_aabb[0] = np.min(aabbs[:, 0, :], axis=0)
             final_aabb[1] = np.max(aabbs[:, 1, :], axis=0)
         else:

--- a/pygfx/objects/_instanced.py
+++ b/pygfx/objects/_instanced.py
@@ -81,7 +81,7 @@ class InstancedObject(WorldObject):
         transforms = self.instance_buffer.data["matrix"].transpose(0, 2, 1)
         aabbs = la.aabb_transform(aabb[None], transforms)
 
-        final_aabb = np.zeros((2, 3), dtype=float)
+        final_aabb = np.empty((2, 3), dtype=float)
         final_aabb[0] = np.min(aabbs[:, 0, :], axis=0)
         final_aabb[1] = np.max(aabbs[:, 1, :], axis=0)
 


### PR DESCRIPTION
Not sure if this is the best way to do it, works for my use case.

Minimal example:

```python
import numpy as np
import pygfx as gfx
import pylinalg as la

scene = gfx.Scene()

geometry = gfx.cylinder_geometry(10, 0, 100, 12)
material = gfx.MeshBasicMaterial(color="#336699")
cones = gfx.Group()

instance_count = 100
mesh = gfx.InstancedMesh(geometry, material, instance_count)
mesh.cast_shadow = mesh.receive_shadow = True

for i in range(instance_count):
    mesh.set_matrix_at(
        i,
        la.mat_compose(
            np.random.rand(3) * 4000 - 2000, (0, 0, 0, 1), np.random.rand() * 4 + 2
        ),
    )

scene.add(mesh)

print(mesh.get_world_bounding_box())

if __name__ == "__main__":
    disp = gfx.Display()
    disp.show(scene)
```

Without this PR the bbox is:

```
[[-10. -10. -50.]
 [ 10.  10.  50.]]
```

With this PR the bbox is around:

```
[[-1940.6628418  -1995.28747559 -1975.10424805]
 [ 1945.44067383  1944.54223633  1980.64733887]]
```