### PR TITLE
use `pylinalg>=0.6.8,<7.0`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     # Packages that depend on PyGfx should not set an upper bound on e.g. wgpu, unless really needed!
     "rendercanvas >= 2.2",
     "wgpu >=0.24.0, <0.26",
-    "pylinalg >=0.6.7,<0.7.0",
+    "pylinalg >=0.6.8,<0.7.0",
     # External dependencies
     "numpy",
     "freetype-py",


### PR DESCRIPTION
After #1220 , the `look_at_instanced.py` example will fail without https://github.com/pygfx/pylinalg/pull/107 which was added in pylinalg v0.6.8. Sorry I should've added this in #1220.

I think after this a release would be great :smile: 
