### PR TITLE
fix docstring formatting

### DIFF
--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -69,7 +69,6 @@ class Texture(Resource):
     Notes
     -----
     Performance tips:
-    
         * If the given data is not c_contiguous, extra memory-copies may be needed
           at upload time, which reduces performance when the data is changed often.
         * RGB textures do not exist in wgpu, but are emulated with an RGBA texture.


### PR DESCRIPTION
the performance tips in `pygfx.Texture` show up as arguments :joy: . I'm impressed at how it gets parse into this.

<img width="627" height="383" alt="image" src="https://github.com/user-attachments/assets/3a920860-e597-4c04-bf35-c250fd4741a7" />

This puts them in a "Notes" section and formats them to show as a list.