### PR TITLE
Demonstrate that adding pixel_scale parameter to WgpuRenderer causes a crash

### DIFF
--- a/examples/other/cube_qt.py
+++ b/examples/other/cube_qt.py
@@ -21,7 +21,7 @@ from rendercanvas.pyside6 import RenderCanvas, loop
 
 
 canvas = RenderCanvas()
-renderer = gfx.renderers.WgpuRenderer(canvas)
+renderer = gfx.renderers.WgpuRenderer(canvas, pixel_ratio=1.)
 scene = gfx.Scene()
 
 cube = gfx.Mesh(

--- a/examples/other/integration_qt.py
+++ b/examples/other/integration_qt.py
@@ -31,7 +31,7 @@ class Main(QtWidgets.QWidget):
 
         # Create canvas, renderer and a scene object
         self._canvas = QRenderWidget(parent=self)
-        self._renderer = gfx.WgpuRenderer(self._canvas)
+        self._renderer = gfx.WgpuRenderer(self._canvas, pixel_ratio=1)
         self._scene = gfx.Scene()
         self._camera = gfx.OrthographicCamera(110, 110)
 

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -366,7 +366,9 @@ class WgpuRenderer(RootEventHandler, Renderer):
         else:
             pixel_scale = float(pixel_scale)
             if pixel_scale < 0.1 or pixel_scale > 10:
-                raise ValueError("renderer.pixel_scale must be bwteen 0.1 and 10.")
+                raise ValueError(
+                    f"renderer.pixel_scale must be bwteen 0.1 and 10. Got {pixel_scale}."
+                )
             self._pixel_scale = pixel_scale
 
     @property


### PR DESCRIPTION
We sometimes set the pixel scale in our renderer to avoid rendering at 8k for 4k screens.

I guess we have different opinions than the default.

```
$ python examples/other/integration_qt.py 
pygfx version from git (0.13.0) and __version__ (0.15.0) don't match.
Traceback (most recent call last):
  File "/home/mark/git/pygfx/examples/other/integration_qt.py", line 61, in <module>
    m = Main()
        ^^^^^^
  File "/home/mark/git/pygfx/examples/other/integration_qt.py", line 34, in __init__
    self._renderer = gfx.WgpuRenderer(self._canvas, pixel_ratio=1)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/mark/git/pygfx/pygfx/renderers/wgpu/engine/renderer.py", line 263, in __init__
    self.pixel_ratio = pixel_ratio
    ^^^^^^^^^^^^^^^^
  File "/home/mark/git/pygfx/pygfx/renderers/wgpu/engine/renderer.py", line 408, in pixel_ratio
    self.pixel_scale = pixel_scale
    ^^^^^^^^^^^^^^^^
  File "/home/mark/git/pygfx/pygfx/renderers/wgpu/engine/renderer.py", line 369, in pixel_scale
    raise ValueError(
ValueError: renderer.pixel_scale must be bwteen 0.1 and 10. Got 640.0.
sys:1: RuntimeWarning: coroutine 'BaseLoop.add_task.<locals>.wrapper' was never awaited
```

However, I feel like this should work?

The problem seems to be that in the setup `self._target.get_pixel_ratio()` is something like 1/640, which is due to the physical size is 1 while the logical size is 640 x 480 or something