### PR TITLE
Fix picking index for volume

### DIFF
--- a/pygfx/objects/_more.py
+++ b/pygfx/objects/_more.py
@@ -327,8 +327,8 @@ class Mesh(WorldObject):
 class Image(WorldObject):
     """A 2D image.
 
-    The geometry for this object consists only of ``geometry.grid``: a
-    texture with the 2D data.
+    The geometry for this object consists only of ``geometry.grid``: a texture
+    with the 2D data.
 
     If no colormap is applied to the material, the data are interpreted as
     colors in sRGB space. To use physical space instead, set the texture's
@@ -336,7 +336,8 @@ class Image(WorldObject):
 
     The picking info of an Image (the result of ``renderer.get_pick_info()``)
     will for most materials include ``index`` (tuple of 2 int), and
-    ``pixel_coord`` (tuple of float subpixel coordinates).
+    ``pixel_coord`` (tuple of float subpixel coordinates, zero at the center of
+    the pixel and 0.5 at the edge).
 
     Parameters
     ----------
@@ -362,9 +363,9 @@ class Image(WorldObject):
         # This should match with the shader
         values = unpack_bitfield(pick_value, wobject_id=20, x=22, y=22)
         size = tex.size
-        x = values["x"] / 4194303 * size[0]
-        y = values["y"] / 4194303 * size[1]
-        ix, iy = (min(int(x), size[0] - 1), min(int(y), size[1] - 1))
+        x = values["x"] / 4194303 * size[0] - 0.5
+        y = values["y"] / 4194303 * size[1] - 0.5
+        ix, iy = (min(int(x + 0.5), size[0] - 1), min(int(y + 0.5), size[1] - 1))
         info["index"] = (ix, iy)
         info["pixel_coord"] = (x - ix, y - iy)
         return info
@@ -378,7 +379,8 @@ class Volume(WorldObject):
 
     The picking info of a Volume (the result of ``renderer.get_pick_info()``)
     will for most materials include ``index`` (tuple of 3 int), and
-    ``voxel_coord`` (tuple of float subpixel coordinates).
+    ``voxel_coord``  (tuple of float subpixel coordinates, zero at the center of
+    the voxel and 0.5 at the edge).
 
     Parameters
     ----------
@@ -406,12 +408,12 @@ class Volume(WorldObject):
         texcoords_encoded = values["x"], values["y"], values["z"]
         size = tex.size
         x, y, z = [
-            (v / 16383) * s for v, s in zip(texcoords_encoded, size, strict=True)
+            (v / 16383) * s - 0.5 for v, s in zip(texcoords_encoded, size, strict=True)
         ]
         ix, iy, iz = (
-            min(int(x), size[0] - 1),
-            min(int(y), size[1] - 1),
-            min(int(z), size[2] - 1),
+            min(int(x + 0.5), size[0] - 1),
+            min(int(y + 0.5), size[1] - 1),
+            min(int(z + 0.5), size[2] - 1),
         )
         info["index"] = (ix, iy, iz)
         info["voxel_coord"] = (x - ix, y - iy, z - iz)


### PR DESCRIPTION
Closes #1251

The problem was that the encoded value was exactly at the edge of the volume, causing the index to become invalid. Fixed with a well-placed max.

I was a bit confused at first at what the value of the subpixel/subvoxel should be, I clarified this in the docs.

I took the `paint_to_texture.py` example to test the behavior, modifying it to paint to a mip-volume to make sure that the image and volume picking are consistent.