### PR TITLE
Improve Bounding Box Computation for SkinnedMesh

### DIFF
--- a/examples/feature_demo/gltf_viewer.py
+++ b/examples/feature_demo/gltf_viewer.py
@@ -32,8 +32,8 @@ scene = gfx.Scene()
 
 ambient_light = gfx.AmbientLight(intensity=0.3)
 scene.add(ambient_light)
-directional_light = gfx.DirectionalLight(intensity=2.5)
-directional_light.local.position = (0.5, 0, 0.866)
+directional_light = gfx.DirectionalLight(intensity=1.0)
+directional_light.local.position = (1, 1, 1)
 scene.add(directional_light)
 
 camera = gfx.PerspectiveCamera(45, 1280 / 720)
@@ -134,7 +134,7 @@ def load_model(model_path):
         scene.add(model_obj)
         state["selected_action"] = 0
 
-        camera.show_object(model_obj, scale=1.4)
+        camera.show_object(model_obj, scale=1.2)
 
         if actions:
             for action in actions:


### PR DESCRIPTION
For `SkinnedMesh`, we cannot directly rely on the geometry’s bounding box or bounding sphere.

This is especially problematic when the mesh and its bound skeleton use different scales: computing the bounding box from the static geometry vertices can result in a large mismatch from the actual visible bounds.

As a consequence, features that depend on bounding volumes—such as automatic camera framing (e.g. `camera.show_object()`)—may not work correctly.  More critically, an incorrect bounding box directly affects the camera’s depth_range calculation, which may lead to clipping failures or severe depth precision issues, such as Z-fighting.

To address this issue, we estimate the bounds of a SkinnedMesh based on the spatial distribution of its skeleton bones.

---

The two videos below demonstrate the difference before and after this change.

https://github.com/user-attachments/assets/606f8f40-2ded-44bf-abce-11431843f071

On the current main branch, when a SkinnedMesh has a skeleton whose scale does not match the original mesh, the computed bounding box can be significantly inaccurate. As a result, camera states cannot be automatically computed correctly.

---

https://github.com/user-attachments/assets/50414af5-b6fc-4d3f-a58b-733387cacc51

With this PR, we are able to obtain a relatively accurate bounding box for SkinnedMesh, allowing camera-related features to work as expected.
