### PR TITLE
BF: Updated the pick location for stochastic alpha_method.

### DIFF
--- a/pygfx/renderers/wgpu/engine/blender.py
+++ b/pygfx/renderers/wgpu/engine/blender.py
@@ -498,7 +498,7 @@ class Blender:
                 // virtualfield objectId: u32 = u_wobject.renderer_id;
                 // virtualfield elementIndex: u32 = varyings.elementIndex;
                 @location(0) color: vec4<f32>,
-                MAYBE_PICK@location(1) pick: vec4<u 32>,
+                MAYBE_PICK@location(1) pick: vec4<u32>,
             };
 
             fn apply_virtual_fields_of_fragment_output(outp: ptr<function,FragmentOutput>, position: vec3f, objectId: u32, elementIndex: u32) {


### PR DESCRIPTION
### Fix for `pick_write=True` with stochastic alpha_methods.

**PR Contents**
Just a typo fix in the definition of the pick variable.

**Reproduce the Error**
- Use any object with stochastic alpha_method and pick_write=True in the material.

**Error**
```
  File "C:\Users\magor\AppData\Local\miniforge3\envs\dipy-skyline\Lib\site-packages\wgpu\backends\wgpu_native\_api.py", line 1901, in create_shader_module
    id = libf.wgpuDeviceCreateShaderModule(self._internal, struct)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\magor\AppData\Local\miniforge3\envs\dipy-skyline\Lib\site-packages\wgpu\backends\wgpu_native\_helpers.py", line 373, in proxy_func
    raise wgpu_error
  File "C:\Users\magor\AppData\Local\miniforge3\envs\dipy-skyline\Lib\site-packages\wgpu\backends\wgpu_native\_api.py", line 1901, in create_shader_module
    id = libf.wgpuDeviceCreateShaderModule(self._internal, struct)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
wgpu._classes.GPUValidationError: Validation Error

Caused by:
  In wgpuDeviceCreateShaderModule

Shader '' parsing error: expected `>`, found "32"
    ┌─ wgsl:226:43
    │
226 │                 @location(1) pick: vec4<u 32>,
    │                                           ^^ expected `>`
```

