### PR TITLE
Controller.handle_event: Redraw on resize

### DIFF
--- a/pygfx/controllers/_base.py
+++ b/pygfx/controllers/_base.py
@@ -256,6 +256,7 @@ class Controller:
             "key_up",
             "wheel",
             "before_render",
+            "resize",
         )
 
     def tick(self):
@@ -445,6 +446,9 @@ class Controller:
         elif type == "key_up":
             # End key presses, regardless of modifier state
             need_update = self._handle_button_up(f"{event.key.lower()}")
+        elif type == "resize":
+            # Draw a fresh frame on resize
+            need_update = True
 
         if need_update and self.auto_update:
             viewport.renderer.request_draw()


### PR DESCRIPTION
Since the resize will affect things like view aspect ratio, it seems natural that a resize should trigger a new draw to allow the controller to react. 

See pyapp-kit/ndv#239 for some related discussion.

I looked around for a natural spot to include a tests, but didn't see any spot that made sense. Let me know if you can think of one!