### PR TITLE
Exploring nonlinear transformations (Log, Polar, and map projections)

### DIFF
--- a/examples/feature_demo/log_plot.py
+++ b/examples/feature_demo/log_plot.py
@@ -1,0 +1,87 @@
+"""
+Line plot
+=========
+
+Show a line plot, with axii and a grid.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+import numpy as np
+from rendercanvas.auto import RenderCanvas, loop
+import pygfx as gfx
+from pylinalg import vec_transform, vec_unproject
+
+
+canvas = RenderCanvas()
+renderer = gfx.WgpuRenderer(canvas)
+
+scene = gfx.Scene()
+
+background = gfx.Background.from_color("#000")
+
+grid = gfx.Grid(
+    None,
+    gfx.GridMaterial(
+        major_step=1,
+        minor_step=0,
+        thickness_space="screen",
+        major_thickness=2,
+        minor_thickness=0.5,
+        infinite=True,
+    ),
+    orientation="xy",
+)
+grid.local.z = -10
+
+rulerx = gfx.Ruler(tick_side="right", tick_marker="tick_left", min_tick_distance=50)
+rulery = gfx.Ruler(tick_side="left", tick_marker="tick_right", min_tick_distance=40)
+
+x = np.linspace(20, 980, 200, dtype=np.float32)
+y = np.sin(x / 100) * 4 + 5 + np.random.uniform(-0.8, 0.8, x.shape).astype("f4")
+y = 2 ** y
+positions = np.column_stack([x, y, np.zeros_like(x)])
+
+line = gfx.Line(
+    gfx.Geometry(positions=positions),
+    gfx.LineMaterial(thickness=4.0, color="#aaf"),
+)
+scene.add(background, grid, rulerx, rulery, line)
+
+camera = gfx.OrthographicCamera(maintain_aspect=False,
+        nonlinear='ylog10'
+)
+camera.show_object(scene, match_aspect=True, scale=1.1)
+
+
+controller = gfx.PanZoomController(camera, register_events=renderer)
+
+
+# A user may prefer to hard-code the ticks, but the ruler does a pretty good
+# job at selection approproate ticks for log scales.s
+# rulery.ticks = [1, 5, 10, 50, 100, 500, 1000]
+
+rulerx.start_pos = 0, 1, 10
+rulerx.end_pos = x.max(), 1, 10
+rulery.start_pos = 0.1, 0, 10
+rulery.end_pos = 0.1, y.max(), 10
+
+
+def animate():
+
+    statsx = rulerx.update(camera, canvas.get_logical_size())
+    statsy = rulery.update(camera, canvas.get_logical_size())
+
+    # Note that the grid lives in linear-space, i.e. it does not apply the log scale.
+    # So in y we set a step of 1 which means every factor 10.
+    major_step_x, major_step_y = statsx["tick_step"], 1
+    grid.material.major_step = major_step_x, major_step_y
+    grid.material.minor_step = 0.2 * major_step_x, 1
+
+    renderer.render(scene, camera)
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    loop.run()

--- a/examples/feature_demo/polar_plot.py
+++ b/examples/feature_demo/polar_plot.py
@@ -1,8 +1,8 @@
 """
-Logarithmic plot
-================
+Polar plot
+==========
 
-Show a line plot, with the y-axis log10.
+Show a polar plot.
 """
 
 # sphinx_gallery_pygfx_docs = 'screenshot'
@@ -21,64 +21,47 @@ scene = gfx.Scene()
 
 background = gfx.Background.from_color("#000")
 
-grid = gfx.Grid(
-    None,
-    gfx.GridMaterial(
-        major_step=1,
-        minor_step=0,
-        thickness_space="screen",
-        major_thickness=2,
-        minor_thickness=0.5,
-        infinite=True,
-    ),
-    orientation="xy",
-)
-grid.local.z = -10
 
 rulerx = gfx.Ruler(tick_side="right", tick_marker="tick_left", min_tick_distance=50)
 rulery = gfx.Ruler(tick_side="left", tick_marker="tick_right", min_tick_distance=40)
 
-x = np.linspace(20, 980, 200, dtype=np.float32)
-y = np.sin(x / 100) * 4 + 5 + np.random.uniform(-0.8, 0.8, x.shape).astype("f4")
-y = 2 ** y
-positions = np.column_stack([x, y, np.zeros_like(x)])
+radius = np.arange(0, 2, 0.01, dtype=np.float32)
+theta = 2 * np.pi * radius
+positions = np.column_stack([theta, radius, np.zeros_like(radius)])
 
 line = gfx.Line(
     gfx.Geometry(positions=positions),
     gfx.LineMaterial(thickness=4.0, color="#aaf"),
 )
-scene.add(background, grid, rulerx, rulery, line)
+scene.add(background, rulerx, rulery, line)
 
-camera = gfx.OrthographicCamera(maintain_aspect=False,
-        nonlinear='polar'
-)
+camera = gfx.OrthographicCamera(maintain_aspect=False, nonlinear="polar")
 camera.show_object(scene, match_aspect=True, scale=1.1)
 
 
 controller = gfx.PanZoomController(camera, register_events=renderer)
 
 
-
 # A user may prefer to hard-code the ticks, but the ruler does a pretty good
 # job at selection approproate ticks for log scales.s
 # rulery.ticks = [1, 5, 10, 50, 100, 500, 1000]
 
-rulerx.start_pos = 0, 1, 10
-rulerx.end_pos = x.max(), 1, 10
-rulery.start_pos = 0.1, 0, 10
-rulery.end_pos = 0.1, y.max(), 10
+rulerx.start_pos = 0,  radius.max(), 10
+rulerx.end_pos = 2*np.pi,  radius.max(), 10
+rulery.start_pos = 0, 0, 10
+rulery.end_pos = 0,  radius.max(), 10
 
+rulerx.ticks = {r*np.pi/180: f"{r} deg" for r in np.linspace(0, 360, 36)}
 
 def animate():
-
     statsx = rulerx.update(camera, canvas.get_logical_size())
     statsy = rulery.update(camera, canvas.get_logical_size())
 
     # Note that the grid lives in linear-space, i.e. it does not apply the log scale.
     # So in y we set a step of 1 which means every factor 10.
     major_step_x, major_step_y = statsx["tick_step"], 1
-    grid.material.major_step = major_step_x, major_step_y
-    grid.material.minor_step = 0.2 * major_step_x, 1
+    # grid.material.major_step = major_step_x, major_step_y
+    # grid.material.minor_step = 0.2 * major_step_x, 1
 
     renderer.render(scene, camera)
 

--- a/examples/feature_demo/world_map.py
+++ b/examples/feature_demo/world_map.py
@@ -1,0 +1,96 @@
+"""Example showing a world map.
+
+The idea is that you can switch between different map projections like
+Mercator, Hammer, etc, and also 3D spherical and ellipsoid.
+
+The cool think is that you can express all your data in lat/lon, and it will
+be nicely projected along.
+"""
+
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+import numpy as np
+from rendercanvas.auto import RenderCanvas, loop
+import pygfx as gfx
+
+
+# Read data from CSV
+# Original source: https://naturalearth.s3.amazonaws.com/110m_physical/ne_110m_coastline.zip
+
+# import geopandas as gpd
+# import pandas as pd
+#
+# # Download Natural Earth coastline (low-res ~110m)
+# url = "https://naturalearth.s3.amazonaws.com/110m_physical/ne_110m_coastline.zip"
+#
+# gdf = gpd.read_file(url)
+#
+# # Break multi-lines into simple segments
+# gdf = gdf.explode(index_parts=False)
+#
+# rows = []
+# for geom in gdf.geometry:
+#     coords = list(geom.coords)
+#     for lon, lat in coords:
+#         rows.append((lon, lat))
+#     rows.append((None, None))  # separator between segments
+#
+# df = pd.DataFrame(rows, columns=["lon", "lat"])
+#
+# # Optional: drop separators if you don't need segmentation
+# # df = df.dropna()
+#
+# df.to_csv("real_coastline.csv", index=False)
+
+longlat = []
+with open("real_coastline.csv", "rt") as f:
+    for line in f.readlines():
+        if line.startswith("lon") or "," not in line:
+            continue
+        parts = line.strip().split(",")
+        assert len(parts) == 2
+        try:
+            val = float(parts[0]), float(parts[1])
+        except ValueError:
+            val = np.nan, np.nan
+        longlat.append(val)
+
+longlat = np.array(longlat, np.float32)
+
+
+# Setup visuzaliation
+
+canvas = RenderCanvas()
+renderer = gfx.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+background = gfx.Background.from_color("#000")
+
+
+long = longlat[:, 0]
+lat = longlat[:, 1]
+positions = np.column_stack([long, lat, np.zeros_like(long)])
+
+line = gfx.Line(
+    gfx.Geometry(positions=positions),
+    gfx.LineMaterial(thickness=4.0, color="#aaf"),
+)
+scene.add(background, line)
+
+camera = gfx.OrthographicCamera(maintain_aspect=True, nonlinear="ll2sphere")
+
+camera.show_object((0, 0, 0, 60_00_000))
+
+controller = gfx.OrbitController(camera, register_events=renderer)
+
+
+
+def animate():
+    renderer.render(scene, camera)
+
+
+if __name__ == "__main__":
+    canvas.request_draw(animate)
+    loop.run()

--- a/pygfx/cameras/_orthographic.py
+++ b/pygfx/cameras/_orthographic.py
@@ -42,6 +42,7 @@ class OrthographicCamera(PerspectiveCamera):
         maintain_aspect=True,
         depth=None,
         depth_range=None,
+        nonlinear=None,
     ):
         super().__init__(
             0,
@@ -52,4 +53,5 @@ class OrthographicCamera(PerspectiveCamera):
             maintain_aspect=maintain_aspect,
             depth=depth,
             depth_range=depth_range,
+            nonlinear=nonlinear,
         )

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -74,14 +74,37 @@ class NonlinearTransforms:
 
     @classmethod
     def polar(cls, pp):
-        return pp
-        # pp2 = pp.copy()
-        # pp2[0] =
-        # pp2[1] = np.log10(pp[1])
-        # return pp2
+        theta = pp[:, 0]
+        radius = pp[:, 1]
+        pp2 = pp.copy()
+        pp2[:, 0] = radius * np.cos(theta)
+        pp2[:, 1] = radius * np.sin(theta)
+        return pp2
+
+    @classmethod
+    def polar_inv(cls, pp):
+        radius = np.linalg.norm(pp[:, :2], axis=1)
+        theta = np.atan2(pp[:, 1], pp[:, 0])
+        pp2 = pp.copy()
+        pp2[:, 0] = theta
+        pp2[:, 1] = radius
+        return pp2
 
     xdouble_index = 1024
     # todo: suffixes trans/inv/index
+
+    @classmethod
+    def ll2sphere(cls, pp):
+        lon = pp[:, 0] * np.pi / 180
+        lat = pp[:, 1] * np.pi / 180
+        elevation = pp[:, 2]
+        clat = np.cos(lat)
+        radius = 40_000_000 + elevation
+        pp2 = pp.copy()
+        pp2[:, 0] = radius * clat * np.cos(lon)
+        pp2[:, 1] = radius * clat * np.sin(lon)
+        pp2[:, 2] = radius * np.sin(lat)
+        return pp2
 
     @classmethod
     def xdouble(cls, pp):
@@ -208,7 +231,15 @@ class PerspectiveCamera(Camera):
             value = ""
         if not isinstance(value, str):
             raise TypeError(f"camera.nonlinear must be str, got {value!r}")
-        elif value not in ("", "xlog10", "ylog10", "xylog10", "polar", "xdouble"):
+        elif value not in (
+            "",
+            "xlog10",
+            "ylog10",
+            "xylog10",
+            "polar",
+            "ll2sphere",
+            "xdouble",
+        ):
             raise ValueError(f"camera.nonlinear {value!r} is an unknown projection.")
         # TODO: use an enum
         self._nonlinear = value
@@ -222,6 +253,7 @@ class PerspectiveCamera(Camera):
             "xylog10": 3,
             "polar": 4,
             "xdouble": 1024,
+            "ll2sphere": 100,
         }[self._nonlinear]
 
     @property
@@ -621,25 +653,26 @@ class PerspectiveCamera(Camera):
         if self._nonlinear:
             trans = getattr(NonlinearTransforms, self._nonlinear)
             if bsphere is not None:
+                pass
                 # TODO: this transform of the bsphere does not work for xlog10, maybe remove, or are there transforms where its strongly preferred?
-                bsphere = np.array(bsphere)
-                positions = np.array(
-                    [
-                        (bsphere[:3] - (bsphere[3], 0, 0)),
-                        (bsphere[:3] + (bsphere[3], 0, 0)),
-                        (bsphere[:3] - (0, bsphere[3], 0)),
-                        (bsphere[:3] + (0, bsphere[3], 0)),
-                        (bsphere[:3] - (0, 0, bsphere[3])),
-                        (bsphere[:3] + (0, 0, bsphere[3])),
-                    ]
-                )
-                positions = trans(positions)
-                xyz = positions.mean(axis=0)
-                r = np.linalg.norm(positions - xyz, axis=1).max()
-                bsphere = float(xyz[0]), float(xyz[1]), float(xyz[2]), float(r)
+                # bsphere = np.array(bsphere)
+                # positions = np.array(
+                #     [
+                #         (bsphere[:3] - (bsphere[3], 0, 0)),
+                #         (bsphere[:3] + (bsphere[3], 0, 0)),
+                #         (bsphere[:3] - (0, bsphere[3], 0)),
+                #         (bsphere[:3] + (0, bsphere[3], 0)),
+                #         (bsphere[:3] - (0, 0, bsphere[3])),
+                #         (bsphere[:3] + (0, 0, bsphere[3])),
+                #     ]
+                # )
+                # positions = trans(positions)
+                # xyz = positions.mean(axis=0)
+                # r = np.linalg.norm(positions - xyz, axis=1).max()
+                # bsphere = float(xyz[0]), float(xyz[1]), float(xyz[2]), float(r)
             if bbox is not None:
                 bbox = trans(bbox)
-            bsphere = la.aabb_to_sphere(bbox)
+                bsphere = la.aabb_to_sphere(bbox)
 
         # Obtain view direction
         if view_dir is None:

--- a/pygfx/cameras/_perspective.py
+++ b/pygfx/cameras/_perspective.py
@@ -24,6 +24,78 @@ from ._base import Camera
 # time-series plots. And avoids the scene clipping away (becoming invisible) of you zoom out too much.
 
 
+# todo: in the unit tests, check that this class has forward and inverse method for each transform.
+class NonlinearTransforms:
+    @classmethod
+    def linear(cls, pp):
+        return pp
+
+    @classmethod
+    def linear_inv(cls, pp):
+        return pp
+
+    @classmethod
+    def xlog10(cls, pp):
+        pp2 = pp.copy()
+        pp2[:, 0] = np.log10(pp[:, 0].clip(1e-6))
+        return pp2
+
+    @classmethod
+    def xlog10_inv(cls, pp):
+        pp2 = pp.copy()
+        pp2[:, 0] = np.pow(10, pp[:, 0])
+        return pp2
+
+    @classmethod
+    def ylog10(cls, pp):
+        pp2 = pp.copy()
+        pp2[:, 1] = np.log10(pp[:, 1].clip(1e-6))
+        return pp2
+
+    @classmethod
+    def ylog10_inv(cls, pp):
+        pp2 = pp.copy()
+        pp2[:, 1] = np.pow(10, pp[:, 1])
+        return pp2
+
+    @classmethod
+    def xylog10(cls, pp):
+        pp2 = pp.copy()
+        pp2[:, 0] = np.log10(pp[:, 0].clip(1e-6))
+        pp2[:, 1] = np.log10(pp[:, 1].clip(1e-6))
+        return pp2
+
+    @classmethod
+    def xylog10_inv(cls, pp):
+        pp2 = pp.copy()
+        pp2[:, 0] = np.pow(10, pp[:, 0])
+        pp2[:, 1] = np.pow(10, pp[:, 1])
+        return pp2
+
+    @classmethod
+    def polar(cls, pp):
+        return pp
+        # pp2 = pp.copy()
+        # pp2[0] =
+        # pp2[1] = np.log10(pp[1])
+        # return pp2
+
+    xdouble_index = 1024
+    # todo: suffixes trans/inv/index
+
+    @classmethod
+    def xdouble(cls, pp):
+        pp2 = pp.copy()
+        pp2[:, 0] = pp[:, 0] * 2
+        return pp2
+
+    @classmethod
+    def xdouble_inv(cls, pp):
+        pp2 = pp.copy()
+        pp2[:, 0] = pp[:, 0] / 2
+        return pp2
+
+
 class PerspectiveCamera(Camera):
     """A generic 3D camera with a configurable field of view (fov).
 
@@ -82,11 +154,12 @@ class PerspectiveCamera(Camera):
         maintain_aspect=True,
         depth=None,
         depth_range=None,
+        nonlinear=None,
     ):
         super().__init__()
 
         self.fov = fov
-
+        self.nonlinear = nonlinear
         # Set width and height. Note that if both width and height are given, it overrides aspect
         aspect = aspect or 1
         if width is None and height is None:
@@ -120,6 +193,36 @@ class PerspectiveCamera(Camera):
         fov = fov_limit(fov)  # Constraint to numerically stable values
         self._fov = fov
         self.flag_update()
+
+    @property
+    def nonlinear(self):
+        """The nonlinear projection of the data.
+
+        This projection is applied to the vertices of all rendered objects. The resulting space is a linear space in which the camera can pan and zoom.
+        """
+        return self._nonlinear
+
+    @nonlinear.setter
+    def nonlinear(self, value):
+        if value is None:
+            value = ""
+        if not isinstance(value, str):
+            raise TypeError(f"camera.nonlinear must be str, got {value!r}")
+        elif value not in ("", "xlog10", "ylog10", "xylog10", "polar", "xdouble"):
+            raise ValueError(f"camera.nonlinear {value!r} is an unknown projection.")
+        # TODO: use an enum
+        self._nonlinear = value
+
+    @property
+    def _nonlinear_type(self):
+        return {
+            "": 0,
+            "xlog10": 1,
+            "ylog10": 2,
+            "xylog10": 3,
+            "polar": 4,
+            "xdouble": 1024,
+        }[self._nonlinear]
 
     @property
     def width(self):
@@ -512,6 +615,31 @@ class PerspectiveCamera(Camera):
             raise TypeError(
                 "show_object target must be a WorldObject, or a (x, y, z, radius) tuple."
             )
+
+        # Transform the bounding area with the nonlinear transform.
+        # After this, we are in the 'linear space'.
+        if self._nonlinear:
+            trans = getattr(NonlinearTransforms, self._nonlinear)
+            if bsphere is not None:
+                # TODO: this transform of the bsphere does not work for xlog10, maybe remove, or are there transforms where its strongly preferred?
+                bsphere = np.array(bsphere)
+                positions = np.array(
+                    [
+                        (bsphere[:3] - (bsphere[3], 0, 0)),
+                        (bsphere[:3] + (bsphere[3], 0, 0)),
+                        (bsphere[:3] - (0, bsphere[3], 0)),
+                        (bsphere[:3] + (0, bsphere[3], 0)),
+                        (bsphere[:3] - (0, 0, bsphere[3])),
+                        (bsphere[:3] + (0, 0, bsphere[3])),
+                    ]
+                )
+                positions = trans(positions)
+                xyz = positions.mean(axis=0)
+                r = np.linalg.norm(positions - xyz, axis=1).max()
+                bsphere = float(xyz[0]), float(xyz[1]), float(xyz[2]), float(r)
+            if bbox is not None:
+                bbox = trans(bbox)
+            bsphere = la.aabb_to_sphere(bbox)
 
         # Obtain view direction
         if view_dir is None:

--- a/pygfx/objects/_ruler.py
+++ b/pygfx/objects/_ruler.py
@@ -2,6 +2,7 @@ from math import floor, ceil, log10
 from typing import Literal, Callable
 
 import numpy as np
+import pylinalg as la
 
 from ._base import WorldObject
 from ._more import Line, Points
@@ -9,6 +10,7 @@ from ._text import MultiText
 from ..resources import Buffer
 from ..materials import LineMaterial, PointsMarkerMaterial, TextMaterial
 from ..utils.compgeo import get_visible_part_of_line_ndc
+from ..cameras._perspective import NonlinearTransforms
 
 
 class Ruler(WorldObject):
@@ -371,7 +373,7 @@ class Ruler(WorldObject):
 
         # Get the dict with visible ticks
         tick_auto_step = self._calculate_tick_step()
-        visible_ticks = self._get_ticks_dict(tick_auto_step)
+        visible_ticks = self._get_ticks_dict(tick_auto_step, camera)
 
         # Update objects to show these ticks
         self._update_sub_objects(visible_ticks, tick_auto_step)
@@ -382,44 +384,64 @@ class Ruler(WorldObject):
             "tick_values": list(visible_ticks.keys()),
         }
 
+
     def _configure_for_screen(self, camera, canvas_size):
         """Make the ruler aware of the camera and viewport size."""
 
         half_canvas_size = 0.5 * np.array(canvas_size, np.float64).reshape(1, 2)
 
+        linear_to_ndc = camera.camera_matrix @ self.world.matrix
+        ndc_to_linear = la.mat_inverse(linear_to_ndc, raise_err=False)
+
         # Get ndc coords for begin and end pos. Use numpy broadcasting for performance and compactness.
-        positions = np.column_stack(
-            [
-                np.vstack([self._start_pos, self._end_pos]),
-                np.ones((2, 1), np.float64),
-            ]
+        world1 = np.column_stack(
+            [np.vstack([self._start_pos, self._end_pos]), np.ones((2, 1), np.float64)]
         )
-        ndc_full = (
-            camera.camera_matrix @ self.world.matrix @ positions[..., None]
-        ).reshape(-1, 4)
-        screen_full = (ndc_full[:, :2] / ndc_full[:, 3:4]) * half_canvas_size
+        linear1 = world1
+        if camera.nonlinear:
+            trans = getattr(NonlinearTransforms, camera.nonlinear)
+            linear1 = trans(world1)
+
+        ndc1 = (linear_to_ndc @ linear1[..., None]).reshape(-1, 4)
+
+        screen1 = (ndc1[:, :2] / ndc1[:, 3:4]) * half_canvas_size
 
         # Get what part of the line is visible
-        t1, t2 = get_visible_part_of_line_ndc(ndc_full[0], ndc_full[1])
+        t1, t2 = get_visible_part_of_line_ndc(ndc1[0], ndc1[1])
 
-        # Get screen coords for visible selection.
-        ndc_sel = np.array(
-            [
-                ndc_full[0] * (1 - t1) + ndc_full[1] * t1,
-                ndc_full[0] * (1 - t2) + ndc_full[1] * t2,
-            ]
+       # But the t1 and t2 are in screen-space
+
+        ndc2 = np.vstack(
+            [(1 - t1) * ndc1[0] + t1 * ndc1[1], (1 - t2) * ndc1[0] + t2 * ndc1[1]]
         )
-        screen_sel = (ndc_sel[:, :2] / ndc_sel[:, 3:4]) * half_canvas_size
+        screen2 = (ndc2[:, :2] / ndc2[:, 3:4]) * half_canvas_size
+        linear2 = (ndc_to_linear @ ndc2[..., None]).reshape(-1, 4)
+        world2 = linear2
+        if camera.nonlinear:
+            trans = getattr(NonlinearTransforms, camera.nonlinear + "_inv")
+            world2 = trans(linear2)
+
+        # Recalculate t1 and t2
+        full_length = np.linalg.norm(world1[0, :3] - world1[1, :3])
+        t1 = np.linalg.norm(world1[0, :3] - world2[0, :3]) / full_length
+        t2 = np.linalg.norm(world1[0, :3] - world2[1, :3]) / full_length
+
+        # TODO: do this or not?
+        t1, t2 = min(max(t1, 0.0), 1.0), min(max(t2, 0.0), 1.0)
+
+        # print(world1)
+        # print(world2)
+        # self._old_configure_for_screen(camera, canvas_size)
 
         # Store values
-        self._screen_vec = screen_full[1] - screen_full[0]
+        self._screen_vec = screen1[1] - screen1[0]
         start_value, end_value = self._start_value, self.end_value
         self._visible_part_coords = t1, t2
         self._visible_part_values = (
             start_value * (1.0 - t1) + end_value * t1,
             start_value * (1.0 - t2) + end_value * t2,
         )
-        self._visible_part_screen_vec = screen_sel[1] - screen_sel[0]
+        self._visible_part_screen_vec = screen2[1] - screen2[0]
 
     def _calculate_text_anchor(self, angle):
         """Calculate the best place to anchor the text labels.
@@ -453,7 +475,7 @@ class Ruler(WorldObject):
                 self._text_anchor = "middle-left"
                 self._text_anchor_offset = 10
 
-    def _get_ticks_dict(self, tick_auto_step):
+    def _get_ticks_dict(self, tick_auto_step, camera=None):
         """Get a tick-dict, derived from the user-given tick value,
         and constrained to the visual part of the ruler.
         """
@@ -467,7 +489,7 @@ class Ruler(WorldObject):
             else:
                 return format(val, tick_format)
 
-        # Select funtion to format the tick values
+        # Select function to format the tick values
         if tick_format == "km":
             tick_format_func = kmg_tick_format_func
         elif isinstance(tick_format, str):
@@ -482,7 +504,20 @@ class Ruler(WorldObject):
         ticks = self._ticks
         if ticks is None:
             # Auto-ticks
-            tick_values = self._get_ticks_uniform(min_value, max_value, tick_auto_step)
+            tick_values = self._get_ticks_uniform(
+                min_value, max_value, tick_auto_step
+            )
+            if camera.nonlinear:
+                vec = self._end_pos - self._start_pos
+                vec_len = np.linalg.norm(vec)
+                if (camera.nonlinear == 'xylog10' or
+                (camera.nonlinear == 'xlog10' and vec[0] > 0.5 * vec_len)
+                or (camera.nonlinear == 'ylog10' and vec[1] > 0.5 * vec_len)
+                ):
+                    tick_values = self._get_ticks_log10(
+                        min_value, max_value, tick_auto_step
+                    )
+
             return {t: tick_format_func(t, min_value, max_value) for t in tick_values}
 
         elif isinstance(ticks, list):
@@ -511,8 +546,8 @@ class Ruler(WorldObject):
         min_tick_dist = self._min_tick_dist
 
         # Determine distances for visible selection
-        world_dist = self._visible_part_values[1] - self._visible_part_values[0]
         screen_dist = float(np.linalg.norm(self._visible_part_screen_vec))
+        world_dist = self._visible_part_values[1] - self._visible_part_values[0]
 
         # Fall back to full size if selection is zero. This way, the
         # value of step still makes sense, even when the ruler itself
@@ -552,6 +587,54 @@ class Ruler(WorldObject):
             t += step
 
         return ticks
+
+    def _get_ticks_log10(self, min_value, max_value, step):
+
+        # Determine distances for visible selection
+        log_dist = log10(max(self._visible_part_values[1], 1e-6)) - log10(max(self._visible_part_values[0], 1e-6))
+        screen_dist = float(np.linalg.norm(self._visible_part_screen_vec))
+        nticks = floor(screen_dist / self._min_tick_dist)
+        nticks = max(1, nticks)
+
+        first_factor_10 = floor(log10(max(min_value, 1e-6)))
+        last_factor_10 = ceil(log10(max(max_value, 1e-6)))
+
+        # Get initial ticks, but expressed in 'log-space'
+        log_ticks = list(range(first_factor_10, last_factor_10+1))
+
+        tick_count_factor = nticks / len(log_ticks)
+        tick_count_factor *= (last_factor_10 - first_factor_10) / max(1, log_dist)
+
+        # Decimate
+        if tick_count_factor < 1:
+            decimation_factor = round(1/tick_count_factor)
+            if decimation_factor > 1:
+                log_ticks = log_ticks[::decimation_factor]
+
+        # Add values, but in world space
+        tick_factors = [1.0]
+        if tick_count_factor > 1.2:
+            if tick_count_factor > 7.5:
+                tick_factors = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+            elif tick_count_factor > 4.5:
+                tick_factors = [1, 2, 4, 6, 8]
+            elif tick_count_factor > 2.5:
+                tick_factors = [1, 2.5, 5, 7.5]
+            else:
+                tick_factors = [1, 5]
+
+        # Go to normal scale
+        ticks = []
+        for log_tick in log_ticks:
+            tick = 10 ** log_tick
+            for f in tick_factors:
+                t = tick * f
+                if min_value <= t <= max_value:
+                    ticks.append(tick * f)
+
+        return ticks
+
+
 
     def _update_sub_objects(self, ticks, tick_auto_step):
         """Update the sub-objects to show the given ticks."""
@@ -623,6 +706,7 @@ class Ruler(WorldObject):
             text_blocks[index].set_text("")
 
         # Hide the ticks close to the ends?
+        # TODO: don't use tick_auto_step here, but solve this problem earlier?
         if self._ticks_at_end_points and ticks:
             tick_values = list(ticks.keys())
             if abs(tick_values[0] - start_value) < 0.5 * tick_auto_step:

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -933,6 +933,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
         stdinfo_data["projection_transform"] = camera.projection_matrix.T
         stdinfo_data["projection_transform_inv"] = camera.projection_matrix_inverse.T
         # stdinfo_data["ndc_to_world"].flat = la.mat_inverse(stdinfo_data["cam_transform"] @ stdinfo_data["projection_transform"])
+        stdinfo_data["nonlinear_type"] = camera._nonlinear_type
         stdinfo_data["ndc_offset"] = ndc_offset
         stdinfo_data["physical_size"] = physical_size
         stdinfo_data["logical_size"] = logical_size

--- a/pygfx/renderers/wgpu/engine/shared.py
+++ b/pygfx/renderers/wgpu/engine/shared.py
@@ -22,6 +22,7 @@ stdinfo_uniform_type = dict(
     cam_transform_inv="4x4xf4",
     projection_transform="4x4xf4",
     projection_transform_inv="4x4xf4",
+    nonlinear_type="u4",
     ndc_offset="4xf4",
     physical_size="2xf4",
     logical_size="2xf4",

--- a/pygfx/renderers/wgpu/wgsl/line.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/line.wgsl
@@ -202,6 +202,14 @@ fn vs_main(in: VertexInput) -> Varyings {
     var pos_w_prev = world_transform * vec4<f32>(pos_m_prev.xyz, 1.0);
     var pos_w_node = world_transform * vec4<f32>(pos_m_node.xyz, 1.0);
     var pos_w_next = world_transform * vec4<f32>(pos_m_next.xyz, 1.0);
+    // Convert to linear
+    pos_w_prev = nonlinear_transform(pos_w_prev);
+    pos_w_node = nonlinear_transform(pos_w_node);
+    pos_w_next = nonlinear_transform(pos_w_next);
+
+    // TODO: the cam_transform is now expressed in the linear space, not the world space, is that what we want?
+    // If not, we should transform its relative position too. I guess its ok if the camera 'lives' in linear space, since it only applies to nonlinear cases, and these are kinda special anyway?
+
     // Convert to camera view
     var pos_c_prev = u_stdinfo.cam_transform * pos_w_prev;
     var pos_c_node = u_stdinfo.cam_transform * pos_w_node;

--- a/pygfx/renderers/wgpu/wgsl/points.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/points.wgsl
@@ -59,7 +59,9 @@ fn vs_main(in: VertexInput) -> Varyings {
     // Sample the current node/point.
     let pos_m = load_s_positions(node_index);
     // Convert to world
-    let pos_w = u_wobject.world_transform * vec4<f32>(pos_m.xyz, 1.0);
+    var pos_w = u_wobject.world_transform * vec4<f32>(pos_m.xyz, 1.0);
+    // Convert to linear
+    pos_w = nonlinear_transform(pos_w);
     // Convert to camera view
     let pos_c = u_stdinfo.cam_transform * pos_w;
     // convert to NDC
@@ -67,18 +69,23 @@ fn vs_main(in: VertexInput) -> Varyings {
     // Convert to logical screen coordinates
     let pos_s = (pos_n.xy / pos_n.w + 1.0) * screen_factor;
 
+
+
+
     $$ if need_neighbours
         let node_index_prev = max(node_index - 1, 0);
         var node_index_next = min(u_renderer.last_i, node_index + 1);
 
         let pos_m_prev = load_s_positions(node_index_prev);
-        let pos_w_prev = u_wobject.world_transform * vec4<f32>(pos_m_prev.xyz, 1.0);
+        var pos_w_prev = u_wobject.world_transform * vec4<f32>(pos_m_prev.xyz, 1.0);
+        pos_w_prev = nonlinear_transform(pos_w_prev);
         let pos_c_prev = u_stdinfo.cam_transform * pos_w_prev;
         let pos_n_prev = u_stdinfo.projection_transform * pos_c_prev;
         let pos_s_prev = (pos_n_prev.xy / pos_n_prev.w + 1.0) * screen_factor;
 
         let pos_m_next = load_s_positions(node_index_next);
-        let pos_w_next = u_wobject.world_transform * vec4<f32>(pos_m_next.xyz, 1.0);
+        var pos_w_next = u_wobject.world_transform * vec4<f32>(pos_m_next.xyz, 1.0);
+        pos_w_next = nonlinear_transform(pos_w_next);
         let pos_c_next = u_stdinfo.cam_transform * pos_w_next;
         let pos_n_next = u_stdinfo.projection_transform * pos_c_next;
         let pos_s_next = (pos_n_next.xy / pos_n_next.w + 1.0) * screen_factor;

--- a/pygfx/renderers/wgpu/wgsl/std.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/std.wgsl
@@ -23,7 +23,7 @@
 const PI = 3.141592653589793;
 const RECIPROCAL_PI = 0.3183098861837907;
 const SQRT_2 = 1.4142135623730951;
-
+const INVLOG10 = 1.0 / log(10.0);
 const ALPHA_COMPARE_EPSILON : f32 = 1e-6;
 const EPSILON = 1e-6;
 
@@ -51,6 +51,43 @@ fn ndc_to_world_pos(ndc_pos: vec4<f32>) -> vec3<f32> {
 
 fn is_orthographic() -> bool {
     return u_stdinfo.projection_transform[2][3] == 0.0;
+}
+
+
+fn nonlinear_transform(pos: vec4f) -> vec4f {
+    // Apply the camera's nonlinear transform. The numbers here refer to the nonlinear_type in _perspective.py
+    // TODO: allow objects (materials?) to opt-out of this transform, e.g. objects attached to the camera.
+
+    switch u_stdinfo.nonlinear_type {
+        case 0: {
+            return pos;
+        }
+        case default: {
+            return pos;
+        }
+        case 1: {  // xlog10
+            let x = log(pos.x) * INVLOG10;
+            return vec4f(x, pos.y, pos.z, pos.w);
+        }
+        case 2 {  // ylog10
+            let y = log(pos.y) * INVLOG10;
+            return vec4f(pos.x, y, pos.z, pos.w);
+        }
+        case 3 {  // xylog10
+           let x = log(pos.x) * INVLOG10;
+           let y = log(pos.y) * INVLOG10;
+           return vec4f(x, y, pos.z, pos.w);
+        }
+        case 4 {  // polar
+            let radius = length(pos.xy);
+            let theta = atan2(pos.y, pos.x);    // in radians
+            return vec4f(theta, radius, pos.z, pos.w);
+        }
+        case 1024 {  // xdouble
+            let x = pos.x * 2.0;
+            return vec4f(x, pos.y, pos.z, pos.w);
+        }
+    }
 }
 
 // ----- Bindings

--- a/pygfx/renderers/wgpu/wgsl/std.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/std.wgsl
@@ -79,14 +79,32 @@ fn nonlinear_transform(pos: vec4f) -> vec4f {
            return vec4f(x, y, pos.z, pos.w);
         }
         case 4 {  // polar
-            let radius = length(pos.xy);
-            let theta = atan2(pos.y, pos.x);    // in radians
-            return vec4f(theta, radius, pos.z, pos.w);
+            let theta = pos.x;
+            let radius = pos.y;
+            let x = radius * cos(theta);
+            let y = radius * sin(theta);
+            return vec4f(x, y, pos.z, pos.w);
+        }
+        case 100 { // ll2sphere
+            // Assumes a sphere, expressed in meters
+            let lon = pos.x * PI / 180;
+            let lat = pos.y * PI / 180;
+            let elevation = pos.z;
+            let clat = cos(lat);
+            let radius = 6367444.0 + elevation;
+            return vec4f(
+                radius * clat * cos(lon),
+                radius * clat * sin(lon),
+                radius * sin(lat),
+                pos.w,
+            );
+
         }
         case 1024 {  // xdouble
             let x = pos.x * 2.0;
             return vec4f(x, pos.y, pos.z, pos.w);
         }
+
     }
 }
 

--- a/pygfx/renderers/wgpu/wgsl/text.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/text.wgsl
@@ -103,7 +103,8 @@ fn vs_main(in: VertexInput) -> Varyings {
             let vertex_pos = block_pos.xy + glyph_vertex_pos;
         $$ endif
 
-        let world_pos = u_wobject.world_transform * vec4<f32>(model_pos, 1.0);
+        var world_pos = u_wobject.world_transform * vec4<f32>(model_pos, 1.0);
+        world_pos = nonlinear_transform(world_pos);
         let ndc_pos = u_stdinfo.projection_transform * u_stdinfo.cam_transform * world_pos;
         let vertex_pos_rotated_and_scaled = u_wobject.rot_scale_transform * vec2<f32>(vertex_pos);
         let delta_ndc = vertex_pos_rotated_and_scaled.xy / screen_factor;
@@ -118,7 +119,8 @@ fn vs_main(in: VertexInput) -> Varyings {
         let model_pos = block_pos + vec3<f32>(glyph_vertex_pos, 0.0);
         let vertex_pos = model_pos.xy;
 
-        let world_pos = u_wobject.world_transform * vec4<f32>(model_pos, 1.0);
+        var world_pos = u_wobject.world_transform * vec4<f32>(model_pos, 1.0);
+        world_pos = nonlinear_transform(world_pos);
         let ndc_pos = u_stdinfo.projection_transform * u_stdinfo.cam_transform * world_pos;
         let delta_ndc = vec2<f32>(0.0, 0.0);
 


### PR DESCRIPTION
Also see #118 and https://github.com/vispy/vispy/issues/1400

In this PR I explore a possible way to implement nonlinear projections.

### Design

The idea is that the camera gets a `.nonlinear` prop, that is a string with any of the supported projections (e.g. "ylog", "polar", "logpolar", "mercator").

Each nonlinear transform has a corresponding wgsl implementation, and some also a Python/numpy implementation.

In the shader, the nonlinear transform is applied to the world-space coordinates. In effect, we introduce a new space, the 'linear-space'. When there is no nonlinear transform, it is the same as the world-space. The camera operates in this linear space. This means that all panning and zooming works unchanged; it's `camera.position` is expressed in this linear space.

The `cmara.show_object()` can transform the bounding-box with the same non-linear transform to get a nice fit. This works for log plots, but not for any of the other transforms 🙃 

The ruler is made aware of these transforms as well, so that it can produce better auto-ticks. I implemented this for the log scale, which works petty well. It's currently broken for the polar plot. If a user provides explicit ticks, the ruler remains unaware of the nonlinear transform; it lives itself in the world space.

### Preliminary screenshots 

A log plot:
<img width="594" height="446" alt="image" src="https://github.com/user-attachments/assets/7bebc096-26c5-48d0-8ee6-8db9325e1272" />

A polar plot similar to [this mpl example](https://matplotlib.org/stable/gallery/pie_and_polar_charts/polar_demo.html), but the rulers need work:

<img width="286" height="288" alt="image" src="https://github.com/user-attachments/assets/cb43c4ec-d504-4e22-8598-c514740cd41e" />

Drawing world coastal lines in lon/lat:

<img width="573" height="292" alt="image" src="https://github.com/user-attachments/assets/f6435764-a66f-499f-8768-c1ea9a369baf" />

Drawing the same data with a spherical projection:

<img width="466" height="429" alt="image" src="https://github.com/user-attachments/assets/29b689ef-1f56-4855-97b3-44387abc4787" />

## Discussion

The high-level goal is that PyGfx is suited for (scientific) use-cases where these nonlinear transform play a role. We should in any case have examples that demonstrate how these cases are covered in PyGfx.

I'm not entirely sure if this PR is the best approach though. Let's also discuss alternatives. Maybe we can cover such cases with a few small features in the right places.

It's also worth mentioning that we don't necessarily need to cover log/polar/maps with the same solution. 

### The cool stuff

What's cool is that the data stays expressed in the native coordinate frame, and by changing the `camera.nonlinear`, you get a different view. You could show the same scene with different camera's using different transforms.

Any data that you add, like clouds, satellite imagery, plane trajectories, in the world map example would simply scale along.

### What's not so great

The new 'linear space' does introduce more complexity, and I'm not sure if all shaders will behave as expected, e.g. lights. We may need to make adjustments later on. But maybe that's fine, since these cases are kinda special?

The camera operates in this linear space. So in what space does e.g. `camera.look_at()` work?

The transform happens at the vertices. So for some objects we'd need to introduce a finer grid of vertices for this to work well, e.g. Image. Some objects, like the `Grid` cannot be transformed this way. It may be good to eventually have a grid based on a line object.

### Alternatives

For log transforms, users or plotting libs can easily transform their data with `np.log10()`, and set custom ticks. We can add an option to the ruler to show log10 ticks to make this use-case friendlier. Since this transform is relatively cheap, I think this is a very viable (and much simpler) alternative.

Polar transforms are rather special. Users and plotting libs could also construct them with some numpy transforms and  PyGfx primitives. We can add an option for the ruler to follow a curved path to accommodate this case. And maybe a grid that follows a specific curve, or applies a certain transform?

For maps, I think a similar story holds? Not sure, need to talk to some geo-persons.

Vispy took a pretty extreme route, in that every node can have any kind of transform. So you can have a `Group`, and everything in that group is transformed with log/polar/whatever. This can be very powerful but also the cause for complexity. I'm not sure how many users actually make use of this.






















