### PR TITLE
Add weak event handlers and clear_event_handlers to EventTarget

### DIFF
--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -93,7 +93,7 @@ an object registers one of its own bound methods on an object it owns (e.g. a
 controller registering ``self._on_pointer_down`` on a scene it holds), this
 forms a reference cycle::
 
-    owner -> child -> _event_handlers -> bound method -> owner
+    owner -> child -> owner._event_handlers -> bound method -> owner
 
 Reference counting cannot break a cycle, so dropping your last reference to the
 owner frees nothing until the *cyclic* garbage collector runs. That collector

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -91,7 +91,7 @@ Event handlers and memory
 By default ``add_event_handler`` keeps a *strong* reference to the handler. If
 an object registers one of its own bound methods on an object it owns (e.g. a
 controller registering ``self._on_pointer_down`` on a scene it holds), this
-forms a reference cycle::
+may form a reference cycle if the event handler is a class::
 
     owner -> child -> owner._event_handlers -> bound method -> owner
 

--- a/docs/performance.rst
+++ b/docs/performance.rst
@@ -85,6 +85,34 @@ Doing a lot of work on certain events can affect performance. Especially events 
 Some seemingly hamless things, like using ``print()`` on every draw, are more expensive than you might think.
 
 
+Event handlers and memory
+-------------------------
+
+By default ``add_event_handler`` keeps a *strong* reference to the handler. If
+an object registers one of its own bound methods on an object it owns (e.g. a
+controller registering ``self._on_pointer_down`` on a scene it holds), this
+forms a reference cycle::
+
+    owner -> child -> _event_handlers -> bound method -> owner
+
+Reference counting cannot break a cycle, so dropping your last reference to the
+owner frees nothing until the *cyclic* garbage collector runs. That collector
+is scheduled by allocation thresholds that count Python objects and are unaware
+of GPU memory, so any textures and buffers the owner keeps alive can linger far
+longer than expected -- long enough to exhaust VRAM in workflows that create
+and discard many scenes.
+
+Two tools help reclaim such resources promptly:
+
+* Pass ``weak=True`` to ``add_event_handler``. The handler is then stored via a
+  weak reference, so the registration no longer keeps the callback (or, for a
+  bound method, its instance) alive, and the owner is reclaimed by reference
+  counting alone. Keep a reference to the callback yourself, otherwise it is
+  collected and never fires (see :meth:`~pygfx.objects.EventTarget.add_event_handler`).
+* Call :meth:`~pygfx.objects.EventTarget.clear_event_handlers` to deterministically
+  detach all handlers from an object before discarding it.
+
+
 Probably more
 -------------
 

--- a/pygfx/objects/_events.py
+++ b/pygfx/objects/_events.py
@@ -370,9 +370,17 @@ class EventTarget:
 
             obj.add_event_handler(self._on_pointer_down, "pointer_down", weak=True)
 
-        Note that with ``weak=True`` the caller is responsible for keeping
-        a reference to the callback alive; a handler whose only remaining
-        reference is this registration will be collected and never fire.
+        .. warning::
+
+            With ``weak=True`` the registration does not keep the callback
+            alive, so the caller must keep a reference to it. A handler whose
+            only remaining reference is this registration is collected and
+            never fires. This is safe for the common case above (a bound
+            method registered on an object the instance owns, since the
+            instance keeps the method's owner -- itself -- alive), but a
+            standalone function, a ``lambda``, or a bound method of an object
+            you do not otherwise hold on to will silently disappear. Use the
+            default ``weak=False`` for those.
         """
 
         decorating = not callable(args[0])

--- a/pygfx/objects/_events.py
+++ b/pygfx/objects/_events.py
@@ -324,6 +324,9 @@ class EventTarget:
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._event_handlers = defaultdict(set)
+        # Finalizer shared by all weakly-stored handlers (see add_event_handler
+        # with weak=True). Created lazily, since most objects never use it.
+        self._weak_handler_remover = None
 
     def add_event_handler(self, *args, weak=False):
         """Register an event handler.
@@ -393,7 +396,16 @@ class EventTarget:
             raise TypeError("All types must be string.")
 
         def decorator(_callback):
-            handler = self._wrap_weak_handler(_callback) if weak else _callback
+            if weak:
+                remover = self._get_weak_handler_remover()
+                if inspect.ismethod(_callback):
+                    # A plain weakref to a bound method dies immediately,
+                    # because the bound method is recreated on each access.
+                    handler = WeakMethod(_callback, remover)
+                else:
+                    handler = ref(_callback, remover)
+            else:
+                handler = _callback
             for type in types:
                 self._event_handlers[type].add(handler)
             return _callback
@@ -402,25 +414,23 @@ class EventTarget:
             return decorator
         return decorator(callback)
 
-    def _wrap_weak_handler(self, callback):
-        # Wrap a callback in a weak reference so that storing it as a handler
-        # does not keep it (or, for a bound method, its instance) alive. The
-        # finalizer prunes the dead wrapper from every type it was registered
-        # for. It only holds a weak reference to self, so it does not turn the
+    def _get_weak_handler_remover(self):
+        # The finalizer for weakly-stored handlers. It receives the dead
+        # weakref and discards it from every event type, so dead handlers do
+        # not pile up. Following pygfx.utils.weak, it captures only a weak
+        # reference to self (via the default argument), so it does not turn the
         # registration into a reference cycle of its own.
-        selfref = ref(self)
+        remover = self._weak_handler_remover
+        if remover is None:
 
-        def prune(dead_ref, selfref=selfref):
-            target = selfref()
-            if target is not None:
-                for handlers in target._event_handlers.values():
-                    handlers.discard(dead_ref)
+            def remove(dead_ref, selfref=ref(self)):  # noqa: B008
+                self = selfref()
+                if self is not None:
+                    for handlers in self._event_handlers.values():
+                        handlers.discard(dead_ref)
 
-        if inspect.ismethod(callback):
-            # A plain weakref to a bound method dies immediately, because the
-            # bound method object is recreated on every attribute access.
-            return WeakMethod(callback, prune)
-        return ref(callback, prune)
+            remover = self._weak_handler_remover = remove
+        return remover
 
     def remove_event_handler(self, callback, *types):
         """Unregister an event handler.

--- a/pygfx/objects/_events.py
+++ b/pygfx/objects/_events.py
@@ -428,8 +428,8 @@ class EventTarget:
                     for handlers in self._event_handlers.values():
                         handlers.discard(dead_ref)
 
-            remover = self._weak_handler_remover = remove
-        return remover
+            self._weak_handler_remover = remove
+        return self._weak_handler_remover
 
     def remove_event_handler(self, callback, *types):
         """Unregister an event handler.

--- a/pygfx/objects/_events.py
+++ b/pygfx/objects/_events.py
@@ -420,8 +420,7 @@ class EventTarget:
         # not pile up. Following pygfx.utils.weak, it captures only a weak
         # reference to self (via the default argument), so it does not turn the
         # registration into a reference cycle of its own.
-        remover = self._weak_handler_remover
-        if remover is None:
+        if self._weak_handler_remover is None:
 
             def remove(dead_ref, selfref=ref(self)):  # noqa: B008
                 self = selfref()

--- a/pygfx/objects/_events.py
+++ b/pygfx/objects/_events.py
@@ -1,8 +1,9 @@
+import inspect
 from collections import defaultdict
 from enum import Enum
 from time import perf_counter
 from typing import Union, Optional
-from weakref import ref
+from weakref import ref, WeakMethod
 
 from rendercanvas.base import log_exception
 
@@ -324,13 +325,19 @@ class EventTarget:
         super().__init__(*args, **kwargs)
         self._event_handlers = defaultdict(set)
 
-    def add_event_handler(self, *args):
+    def add_event_handler(self, *args, weak=False):
         """Register an event handler.
 
         Arguments:
             callback (callable): The event handler. Must accept a
                 single event argument.
             *types (list of strings): A list of event types.
+            weak (bool): If True, the handler is stored using a weak
+                reference, so that registering it does not keep the
+                callback alive. For a bound method this means the object
+                the method is bound to is not kept alive either. Once the
+                callback is garbage collected the handler is skipped and
+                pruned automatically. Defaults to False.
 
         For the available event types, see
         https://jupyter-rfb.readthedocs.io/en/stable/events.html
@@ -353,6 +360,19 @@ class EventTarget:
             @obj.add_event_handler("pointer_up", "pointer_down")
             def my_handler(event):
                 print(event)
+
+        Storing the handler weakly lets the registering object be garbage
+        collected by reference counting (without waiting for the cyclic
+        collector) even when it registers one of its own bound methods on
+        an object it owns:
+
+        .. code-block:: py
+
+            obj.add_event_handler(self._on_pointer_down, "pointer_down", weak=True)
+
+        Note that with ``weak=True`` the caller is responsible for keeping
+        a reference to the callback alive; a handler whose only remaining
+        reference is this registration will be collected and never fire.
         """
 
         decorating = not callable(args[0])
@@ -365,13 +385,34 @@ class EventTarget:
             raise TypeError("All types must be string.")
 
         def decorator(_callback):
+            handler = self._wrap_weak_handler(_callback) if weak else _callback
             for type in types:
-                self._event_handlers[type].add(_callback)
+                self._event_handlers[type].add(handler)
             return _callback
 
         if decorating:
             return decorator
         return decorator(callback)
+
+    def _wrap_weak_handler(self, callback):
+        # Wrap a callback in a weak reference so that storing it as a handler
+        # does not keep it (or, for a bound method, its instance) alive. The
+        # finalizer prunes the dead wrapper from every type it was registered
+        # for. It only holds a weak reference to self, so it does not turn the
+        # registration into a reference cycle of its own.
+        selfref = ref(self)
+
+        def prune(dead_ref, selfref=selfref):
+            target = selfref()
+            if target is not None:
+                for handlers in target._event_handlers.values():
+                    handlers.discard(dead_ref)
+
+        if inspect.ismethod(callback):
+            # A plain weakref to a bound method dies immediately, because the
+            # bound method object is recreated on every attribute access.
+            return WeakMethod(callback, prune)
+        return ref(callback, prune)
 
     def remove_event_handler(self, callback, *types):
         """Unregister an event handler.
@@ -381,7 +422,36 @@ class EventTarget:
             *types (list of strings): A list of event types.
         """
         for type in types:
-            self._event_handlers[type].remove(callback)
+            handlers = self._event_handlers[type]
+            if callback in handlers:
+                # Registered strongly (the common case).
+                handlers.discard(callback)
+                continue
+            # The handler may have been registered weakly; find the wrapper
+            # whose referent is the given callback and remove that.
+            for handler in handlers:
+                if isinstance(handler, ref) and handler() == callback:
+                    handlers.discard(handler)
+                    break
+            else:
+                raise KeyError(callback)
+
+    def clear_event_handlers(self, *types):
+        """Unregister all event handlers.
+
+        Arguments:
+            *types (list of strings): The event types to clear. If no types
+                are given, the handlers for all event types are removed.
+
+        This is useful to deterministically detach an object before
+        discarding it, so that it does not linger as part of a reference
+        cycle through the objects it registered handlers on.
+        """
+        if types:
+            for type in types:
+                self._event_handlers[type].clear()
+        else:
+            self._event_handlers.clear()
 
     def handle_event(self, event: Event):
         """Handle an incoming event.
@@ -390,9 +460,18 @@ class EventTarget:
             event: The event to handle
         """
         event_type = event.type
-        for callback in self._event_handlers[event_type].copy():
+        handlers = self._event_handlers[event_type]
+        for handler in handlers.copy():
             if event.cancelled:
                 break
+            if isinstance(handler, ref):
+                callback = handler()
+                if callback is None:
+                    # Weakly-referenced handler was collected; prune it.
+                    handlers.discard(handler)
+                    continue
+            else:
+                callback = handler
             with log_exception(f"Error during handling {event_type} event"):
                 callback(event)
 

--- a/tests/objects/test_events.py
+++ b/tests/objects/test_events.py
@@ -1,3 +1,6 @@
+import gc
+import weakref
+
 from pygfx import Scene, WorldObject
 from pygfx.objects._events import EventTarget, Event, PointerEvent, RootEventHandler
 
@@ -37,6 +40,79 @@ def test_event_target():
     c.handle_event(event_with_val(type="spam", value=9))
 
     assert events == [1, 2, 5]
+
+
+def test_weak_event_handler_fires_and_can_be_removed():
+    c = EventTarget()
+    events = []
+
+    class Listener:
+        def on_event(self, event):
+            events.append(event.value)
+
+    listener = Listener()
+
+    def event_with_val(type, value):
+        ev = Event(type)
+        ev.value = value
+        return ev
+
+    c.add_event_handler(listener.on_event, "foo", weak=True)
+    c.handle_event(event_with_val("foo", 1))
+    assert events == [1]
+
+    # A weakly stored bound method can still be removed explicitly.
+    c.remove_event_handler(listener.on_event, "foo")
+    c.handle_event(event_with_val("foo", 2))
+    assert events == [1]
+
+
+def test_weak_event_handler_does_not_keep_owner_alive():
+    # The whole point: a weak handler must not keep its owner alive, so the
+    # owner can be reclaimed by reference counting alone (cyclic gc disabled).
+    c = EventTarget()
+
+    class Listener:
+        def on_event(self, event):
+            pass
+
+    gc.disable()
+    try:
+        listener = Listener()
+        wr = weakref.ref(listener)
+        c.add_event_handler(listener.on_event, "foo", weak=True)
+
+        del listener
+        # No cyclic collector involved; refcounting alone must reclaim it.
+        assert wr() is None
+
+        # The dead handler is pruned on dispatch and does not raise.
+        c.handle_event(Event("foo"))
+        assert c._event_handlers["foo"] == set()
+    finally:
+        gc.enable()
+
+
+def test_strong_event_handler_keeps_owner_alive():
+    # By default (weak=False) the handler keeps the owner alive, which is the
+    # pre-existing behaviour and the reason a reference cycle can form.
+    c = EventTarget()
+
+    class Listener:
+        def on_event(self, event):
+            pass
+
+    gc.disable()
+    try:
+        listener = Listener()
+        wr = weakref.ref(listener)
+        c.add_event_handler(listener.on_event, "foo")
+
+        del listener
+        # Strong reference from the handler keeps it alive.
+        assert wr() is not None
+    finally:
+        gc.enable()
 
 
 def test_event_bubbling():


### PR DESCRIPTION
Working to find some memory leaks, these event handlers seem like strong candidates.

I need to cleanup the implementation. I don't really like the helper methods.
<details><summary>claude's comment</summary>
EventTarget stored every handler with a strong reference. When an object registers one of its own bound methods as a handler on an object it owns (for example a controller registering ``self._on_pointer_down`` on a scene it holds), this forms a reference cycle:

    owner -> child -> _event_handlers -> bound method -> owner

Reference counting can never break a cycle, so dropping the last external reference to the owner frees nothing: the objects, and any GPU resources such as textures they keep alive, are only reclaimed when the *cyclic* garbage collector runs. That collector is scheduled by generational allocation thresholds that count Python objects and are unaware of GPU memory, so VRAM can be exhausted long before it decides to run.

Add an opt-in ``weak=True`` argument to ``add_event_handler``. Weak handlers are stored as ``weakref.WeakMethod`` (for bound methods) or ``weakref.ref`` (for other callables), so the registration no longer keeps the callback - or, for a bound method, the instance it is bound to - alive. With it, the owner above is reclaimed by reference counting alone, without waiting for the cyclic collector. Dead handlers are skipped during dispatch and pruned via a weakref finalizer. The default (``weak=False``) preserves the existing strong-reference behaviour.

Also add ``clear_event_handlers(*types)`` to deterministically detach all handlers (optionally restricted to the given types), and teach ``remove_event_handler`` to match weakly-stored handlers.

<!--
Please see the Contribution Guide:
https://github.com/pygfx/pygfx/blob/main/CONTRIBUTING.md
-->

</details>