### PR TITLE
Use unorm for 16bit textures

### DIFF
--- a/examples/validation/validate_image.py
+++ b/examples/validation/validate_image.py
@@ -27,10 +27,10 @@ scene = gfx.Scene()
 
 data = np.array(
     [
-        [0, 1, 1, 1],
-        [1, 1, 1, 1],
-        [1, 1, 1, 1],
-        [1, 1, 1, 2],
+        [0, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 100],
+        [100, 100, 100, 200],
     ],
     np.uint8,
 )
@@ -39,7 +39,7 @@ data = np.array(
 #
 # float -> r32float, sampler
 # uint8 -> r8unorm, sampler
-# int16 -> r16sint, no sampler | later maybe r16snorm with sampler
+# int16 -> r16snorm, sampler
 # uin32 -> r32uint, no sampler
 
 for dx, dtype in enumerate(["float32", "uint8", "int16", "uint32"]):
@@ -48,7 +48,7 @@ for dx, dtype in enumerate(["float32", "uint8", "int16", "uint32"]):
     for dy, interpolation in enumerate(["nearest", "linear", "cubic"]):
         image = gfx.Image(
             gfx.Geometry(grid=gfx.Texture(typed_data, dim=2)),
-            gfx.ImageBasicMaterial(clim=(0, 2), interpolation=interpolation),
+            gfx.ImageBasicMaterial(clim=(0, 200), interpolation=interpolation),
         )
         image.local.position = dx * 5, dy * 5, 0
         scene.add(image)

--- a/pygfx/renderers/wgpu/engine/shared.py
+++ b/pygfx/renderers/wgpu/engine/shared.py
@@ -35,7 +35,9 @@ def _preconfigure_wgpu_device():
     # (in some way) when it's not available, but this easily results in complex
     # code. I think we can probably get away with requiring only a few features that
     # are available on the main target platforms.
-    wgpu.preconfigure_default_device("pygfx", required_features={"float32-filterable"})
+    wgpu.preconfigure_default_device(
+        "pygfx", required_features={"float32-filterable", "texture-format16bit-norm"}
+    )
 
     if adapter_name := os.environ.get("PYGFX_WGPU_ADAPTER_NAME"):
         # Similar to https://github.com/gfx-rs/wgpu?tab=readme-ov-file#environment-variables

--- a/pygfx/renderers/wgpu/engine/shared.py
+++ b/pygfx/renderers/wgpu/engine/shared.py
@@ -36,7 +36,9 @@ def _preconfigure_wgpu_device():
     # code. I think we can probably get away with requiring only a few features that
     # are available on the main target platforms.
     wgpu.preconfigure_default_device(
-        "pygfx", required_features={"float32-filterable", "texture-format16bit-norm"}
+        "pygfx",
+        required_features={"float32-filterable"},
+        preferred_features={"texture-formats-tier1", "texture-format16bit-norm"},
     )
 
     if adapter_name := os.environ.get("PYGFX_WGPU_ADAPTER_NAME"):
@@ -74,6 +76,13 @@ class Shared(Trackable):
         # Select device
         self._device = wgpu.get_default_device()
         self._adapter = self._device.adapter
+
+        # We could do a graceful fallback, of fail hard. For now we do the latter.
+        if not (
+            "texture-formats-tier1" in self._device.features
+            or "texture-format16bit-norm" in self._device.features
+        ):
+            raise RuntimeError("16bit norm textures not supported on this device.")
 
         self._create_diagnostics()
 

--- a/pygfx/renderers/wgpu/engine/utils.py
+++ b/pygfx/renderers/wgpu/engine/utils.py
@@ -117,9 +117,8 @@ def to_texture_format(format):
         "u1": "8unorm",
         "i2": "16sint",
         "u2": "16uint",
-        # TODO: once wgpu supports 16unorm and 16snorm, probably needs extension
-        # "i2": "16snorm",
-        # "u2": "16unorm",
+        "i2": "16snorm",
+        "u2": "16unorm",
         "i4": "32sint",
         "u4": "32uint",
         "f2": "16float",


### PR DESCRIPTION
Requires https://github.com/pygfx/wgpu-py/pull/805.

Also `texture-format16bit-norm` is a native-only feature, which `wgpu.preconfigure_default_device(` does not allow (need to comment a check in wgpu to be able to use it). The texture features are going to change a bit soon, with two tiers to enable a bunch of features at once. 

So we probably need to wait until wgpu 0.30 and then wgpu-py updating to that. Or we can allow wgpu-py to enable this feature so we can start using it earlier.
