### PR TITLE
View reshape

### DIFF
--- a/pygfx/geometries/_toroidal.py
+++ b/pygfx/geometries/_toroidal.py
@@ -198,15 +198,15 @@ def torus_knot_geometry(
     cy = +tube * np.sin(v)
     # Prepare shapes, so we can do numpy broadcast
     pos = pos1.reshape(-1, 1, 3)
-    cx = np.reshape(cx, (1, -1, 1))
-    cy = np.reshape(cy, (1, -1, 1))
-    vec3 = np.reshape(vec3, (-1, 1, 3))
-    vec4 = np.reshape(vec4, (-1, 1, 3))
+    cx = cx.reshape(1, -1, 1)
+    cy = cy.reshape(1, -1, 1)
+    vec3 = vec3.reshape(-1, 1, 3)
+    vec4 = vec4.reshape(-1, 1, 3)
     # Broadcast!
     positions = pos + cx * vec4 + cy * vec3
     normals = positions - pos
-    positions = np.reshape(positions, (-1, 3))
-    normals = np.reshape(normals, (-1, 3))
+    positions = positions.reshape(-1, 3)
+    normals = normals.reshape(-1, 3)
     normals *= 1 / np.linalg.norm(normals, axis=1).reshape(-1, 1)
 
     # Create texcords

--- a/pygfx/geometries/_toroidal.py
+++ b/pygfx/geometries/_toroidal.py
@@ -198,15 +198,15 @@ def torus_knot_geometry(
     cy = +tube * np.sin(v)
     # Prepare shapes, so we can do numpy broadcast
     pos = pos1.reshape(-1, 1, 3)
-    cx.shape = 1, -1, 1
-    cy.shape = 1, -1, 1
-    vec3.shape = -1, 1, 3
-    vec4.shape = -1, 1, 3
+    cx = np.reshape(cx, (1, -1, 1))
+    cy = np.reshape(cy, (1, -1, 1))
+    vec3 = np.reshape(vec3, (-1, 1, 3))
+    vec4 = np.reshape(vec4, (-1, 1, 3))
     # Broadcast!
     positions = pos + cx * vec4 + cy * vec3
     normals = positions - pos
-    positions.shape = -1, 3
-    normals.shape = -1, 3
+    positions = np.reshape(positions, (-1, 3))
+    normals = np.reshape(normals, (-1, 3))
     normals *= 1 / np.linalg.norm(normals, axis=1).reshape(-1, 1)
 
     # Create texcords

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -90,7 +90,7 @@ class Buffer(Resource):
             # Store data and view, and do some basic checks.
             # The view is a numpy array, but we go via memoryview to ensure data follows the buffer protocol.
             self._data = data
-            self._view = view = np.asarray(memoryview(data))
+            view = np.asarray(memoryview(data))
             if self._force_contiguous:
                 check_data_is_clean_for_performance("buffer", view)
             the_nbytes = view.nbytes
@@ -103,12 +103,12 @@ class Buffer(Resource):
                 the_nitems = view.shape[0]
             else:
                 the_nitems = 1  # A scalar, e.g. a uniform struct
-            reshape_array(view, the_nitems)
+            self._view = reshape_array(view, the_nitems)
             # Establish format
             detected_format = None
-            element_format = get_element_format_from_numpy_array(view)
+            element_format = get_element_format_from_numpy_array(self._view)
             if element_format:
-                elements_per_item = int(np.prod(view.shape[1:], initial=1))
+                elements_per_item = int(np.prod(self._view.shape[1:], initial=1))
                 detected_format = (f"{elements_per_item}x" + element_format).lstrip(
                     "1x"
                 )
@@ -328,7 +328,7 @@ class Buffer(Resource):
         if view.dtype != self._view.dtype:
             raise ValueError("buffer.set_data() format does not match.")
         # Make sure the shape is ok. We only care about the first dimension.
-        reshape_array(view, self.nitems)
+        view = reshape_array(view, self.nitems)
         # Ok
         self._data = data
         self._view = view
@@ -459,4 +459,5 @@ def reshape_array(view, n):
         if n == 0:
             elements_per_item = int(np.prod([max(i, 1) for i in view.shape], initial=1))
         # This can fail if the data is not contiguous and strides don't work out.
-        view.shape = (n, elements_per_item)
+        view = np.reshape(view, (n, elements_per_item), copy=False)
+    return view

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -459,5 +459,5 @@ def reshape_array(view, n):
         if n == 0:
             elements_per_item = int(np.prod([max(i, 1) for i in view.shape], initial=1))
         # This can fail if the data is not contiguous and strides don't work out.
-        view = np.reshape(view, (n, elements_per_item), copy=False)
+        view = view.reshape(n, elements_per_item)
     return view

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -606,5 +606,5 @@ def reshape_array(view, size):
     expected_shape = tuple(reversed(size))
     if expected_shape != view.shape[:3]:
         # This can fail if the data is not contiguous and strides don't work out.
-        view = np.reshape(view, (*expected_shape, -1), copy=False)
+        view = view.reshape(*expected_shape, -1)
     return view

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -135,7 +135,7 @@ class Texture(Resource):
             # Store data and view, and do some basic checks.
             # The view is a numpy array, but we go via memoryview to ensure data follows the buffer protocol.
             self._data = data
-            self._view = view = np.asarray(memoryview(data))
+            view = np.asarray(memoryview(data))
             if self._force_contiguous:
                 check_data_is_clean_for_performance("texture", view)
             the_nbytes = view.nbytes
@@ -144,14 +144,14 @@ class Texture(Resource):
                 the_size = size
             else:
                 the_size = size_from_array(view, dim)
-            reshape_array(view, the_size)
+            self._view = reshape_array(view, the_size)
             # Establish format
-            element_format = get_element_format_from_numpy_array(view)
+            element_format = get_element_format_from_numpy_array(self._view)
             if element_format is None:
                 raise ValueError(
-                    f"Unsupported dtype/format for texture data: {view.dtype}"
+                    f"Unsupported dtype/format for texture data: {self._view.dtype}"
                 )
-            nchannels = int(np.prod(view.shape[3:], initial=1))
+            nchannels = int(np.prod(self._view.shape[3:], initial=1))
             if not (1 <= nchannels <= 4):
                 raise ValueError(
                     f"Expected 1-4 texture color channels, got {nchannels}."
@@ -401,7 +401,7 @@ class Texture(Resource):
         if view.dtype != self._view.dtype:
             raise ValueError("texture.set_data() format does not match.")
         # Make sure the shape is ok.
-        reshape_array(view, self.size)
+        view = reshape_array(view, self.size)
         # Ok
         self._data = data
         self._view = view
@@ -606,4 +606,5 @@ def reshape_array(view, size):
     expected_shape = tuple(reversed(size))
     if expected_shape != view.shape[:3]:
         # This can fail if the data is not contiguous and strides don't work out.
-        view.shape = (*expected_shape, -1)
+        view = np.reshape(view, (*expected_shape, -1), copy=False)
+    return view

--- a/tests/resources/test_chunk_sizes.py
+++ b/tests/resources/test_chunk_sizes.py
@@ -284,9 +284,9 @@ def test_chunk_size_dim3_align():
 def make_mask_3d(mask):
     mask = np.array(mask, bool)
     if mask.ndim == 1:
-        mask = np.reshape(mask, (1, 1, mask.shape[0]))
+        mask = mask.reshape(1, 1, mask.shape[0])
     elif mask.ndim == 2:
-        mask = np.reshape(mask, (1, mask.shape[0], mask.shape[1]))
+        mask = mask.reshape(1, mask.shape[0], mask.shape[1])
     return mask
 
 

--- a/tests/resources/test_chunk_sizes.py
+++ b/tests/resources/test_chunk_sizes.py
@@ -284,9 +284,9 @@ def test_chunk_size_dim3_align():
 def make_mask_3d(mask):
     mask = np.array(mask, bool)
     if mask.ndim == 1:
-        mask.shape = 1, 1, mask.shape[0]
+        mask = np.reshape(mask, (1, 1, mask.shape[0]))
     elif mask.ndim == 2:
-        mask.shape = 1, mask.shape[0], mask.shape[1]
+        mask = np.reshape(mask, (1, mask.shape[0], mask.shape[1]))
     return mask
 
 


### PR DESCRIPTION
The [newest version of numpy](https://github.com/numpy/numpy/releases/tag/v2.5.0) deprecated assignments to [view.shape]. This PR cleans up all of those usages, using `np.reshape` instead.