### PR TITLE
InstancedMesh and InstancedLine now honor instance_buffer.draw_range

### DIFF
--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -314,11 +314,11 @@ class LineShader(BaseShader):
     def get_render_info(self, wobject, shared):
         # Determine how many vertices are needed
         offset, size = self._get_n(wobject.geometry.positions)
-        n_instances = 1
+        inst_offset, inst_size = 0, 1
         if self["instanced"]:
-            n_instances = wobject.instance_buffer.nitems
+            inst_offset, inst_size = wobject.instance_buffer.draw_range
         return {
-            "indices": (size, n_instances, offset, 0),
+            "indices": (size, inst_size, offset, inst_offset),
         }
 
     def get_code(self):

--- a/pygfx/renderers/wgpu/shaders/meshshader.py
+++ b/pygfx/renderers/wgpu/shaders/meshshader.py
@@ -465,12 +465,12 @@ class MeshShader(BaseShader):
         offset, size = geometry.indices.draw_range
         offset, size = mul * offset, mul * size
 
-        n_instances = 1
+        inst_offset, inst_size = 0, 1
         if self["instanced"]:
-            n_instances = wobject.instance_buffer.nitems
+            inst_offset, inst_size = wobject.instance_buffer.draw_range
 
         return {
-            "indices": (size, n_instances, offset, 0),
+            "indices": (size, inst_size, offset, inst_offset),
         }
 
     def _check_texture(self, t, geometry, view_dim):


### PR DESCRIPTION
This makes it possible to allocate room for say 1M instances and then only use a selection.