### PR TITLE
Add copy=False back to reshape calls

### DIFF
--- a/pygfx/geometries/_toroidal.py
+++ b/pygfx/geometries/_toroidal.py
@@ -197,16 +197,16 @@ def torus_knot_geometry(
     cx = -tube * np.cos(v)
     cy = +tube * np.sin(v)
     # Prepare shapes, so we can do numpy broadcast
-    pos = pos1.reshape(-1, 1, 3)
-    cx = cx.reshape(1, -1, 1)
-    cy = cy.reshape(1, -1, 1)
-    vec3 = vec3.reshape(-1, 1, 3)
-    vec4 = vec4.reshape(-1, 1, 3)
+    pos = pos1.reshape(-1, 1, 3, copy=False)
+    cx = cx.reshape(1, -1, 1, copy=False)
+    cy = cy.reshape(1, -1, 1, copy=False)
+    vec3 = vec3.reshape(-1, 1, 3, copy=False)
+    vec4 = vec4.reshape(-1, 1, 3, copy=False)
     # Broadcast!
     positions = pos + cx * vec4 + cy * vec3
     normals = positions - pos
-    positions = positions.reshape(-1, 3)
-    normals = normals.reshape(-1, 3)
+    positions = positions.reshape(-1, 3, copy=False)
+    normals = normals.reshape(-1, 3, copy=False)
     normals *= 1 / np.linalg.norm(normals, axis=1).reshape(-1, 1)
 
     # Create texcords

--- a/pygfx/resources/_buffer.py
+++ b/pygfx/resources/_buffer.py
@@ -459,5 +459,5 @@ def reshape_array(view, n):
         if n == 0:
             elements_per_item = int(np.prod([max(i, 1) for i in view.shape], initial=1))
         # This can fail if the data is not contiguous and strides don't work out.
-        view = view.reshape(n, elements_per_item)
+        view = view.reshape(n, elements_per_item, copy=False)
     return view

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -606,5 +606,5 @@ def reshape_array(view, size):
     expected_shape = tuple(reversed(size))
     if expected_shape != view.shape[:3]:
         # This can fail if the data is not contiguous and strides don't work out.
-        view = view.reshape(*expected_shape, -1)
+        view = view.reshape(*expected_shape, -1, copy=False)
     return view

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "wgpu >= 0.30.1",
     "pylinalg >=0.6.8,<0.7.0",
     # External dependencies
-    "numpy",
+    "numpy>=2.1", # Introduces np.reshape's copy kwarg
     "freetype-py",
     "uharfbuzz",
     "jinja2",

--- a/tests/resources/test_chunk_sizes.py
+++ b/tests/resources/test_chunk_sizes.py
@@ -284,9 +284,9 @@ def test_chunk_size_dim3_align():
 def make_mask_3d(mask):
     mask = np.array(mask, bool)
     if mask.ndim == 1:
-        mask = mask.reshape(1, 1, mask.shape[0])
+        mask = mask.reshape(1, 1, mask.shape[0], copy=False)
     elif mask.ndim == 2:
-        mask = mask.reshape(1, mask.shape[0], mask.shape[1])
+        mask = mask.reshape(1, mask.shape[0], mask.shape[1], copy=False)
     return mask
 
 


### PR DESCRIPTION
Follow-up PR for #1306 - as @hmaarrfk noted (and listed in the [changelog](https://github.com/numpy/numpy/releases?page=4)), I've bumped the minimum bound for numpy to `2.1`. There was no previous minimum bound, so adding *some* minimum bound seems good, but want to draw attention as this version is not quite 2 years old...