### PR TITLE
Update CODE_OF_CONDUCT to clarify that it applies to all repos

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,8 +3,8 @@
 ## Introduction
 
 This code of conduct applies to all spaces managed by the Pygfx project,
-including all public and private mailing lists, issue trackers, wikis, blogs,
-Twitter, and any other communication channel used by our community, including
+including all code repositories under the Pygfx organization, as well as wikis, blogs,
+social media, and any other communication channel used by our community, including
 any in-person events, whether directly organized by Pygfx developers
 or associated people.
 


### PR DESCRIPTION
In some cases (like grants) all repos need a CoC. This change makes it more explicit that this CoC applies to all repos under the pygfx org.

