### PR TITLE
fix: reshape texture and example arrays

### DIFF
--- a/examples/feature_demo/anisotropy_barn_lamp.py
+++ b/examples/feature_demo/anisotropy_barn_lamp.py
@@ -25,7 +25,7 @@ scene.add(directional_light)
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/bloom2.py
+++ b/examples/feature_demo/bloom2.py
@@ -47,7 +47,7 @@ scene = gfx.Scene()
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/clearcoat.py
+++ b/examples/feature_demo/clearcoat.py
@@ -44,7 +44,7 @@ scene = gfx.Scene()
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/clearcoat2.py
+++ b/examples/feature_demo/clearcoat2.py
@@ -42,7 +42,7 @@ scene = gfx.Scene()
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/compute_cloth.py
+++ b/examples/feature_demo/compute_cloth.py
@@ -512,7 +512,7 @@ cloth_buffer_shader.set_resource(3, cloth_normal_buffer)
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/dynamic_env_map.py
+++ b/examples/feature_demo/dynamic_env_map.py
@@ -33,7 +33,7 @@ scene = gfx.Scene()
 
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 env_static = gfx.Texture(
     env_img, dim=2, size=(cube_size, cube_size, 6), generate_mipmaps=True

--- a/examples/feature_demo/env_maps.py
+++ b/examples/feature_demo/env_maps.py
@@ -43,7 +43,7 @@ scene.add(gfx.AmbientLight(1, 0.2), dir_light)
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/gltf_unlit.py
+++ b/examples/feature_demo/gltf_unlit.py
@@ -44,7 +44,7 @@ scene = gfx.Scene()
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/gltf_viewer.py
+++ b/examples/feature_demo/gltf_viewer.py
@@ -77,7 +77,7 @@ favorite_variant = ["glTF-Binary", "glTF-Embedded", "glTF"]
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/iridescence.py
+++ b/examples/feature_demo/iridescence.py
@@ -20,7 +20,7 @@ scene = gfx.Scene()
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/iridescence2.py
+++ b/examples/feature_demo/iridescence2.py
@@ -29,7 +29,7 @@ scene.add(background)
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map, use for IBL.
 env_tex = gfx.Texture(

--- a/examples/feature_demo/pbr.py
+++ b/examples/feature_demo/pbr.py
@@ -43,7 +43,7 @@ scene = gfx.Scene()
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/pbr2.py
+++ b/examples/feature_demo/pbr2.py
@@ -35,7 +35,7 @@ point_light.add(gfx.PointLightHelper(4))
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/pbr_instanced.py
+++ b/examples/feature_demo/pbr_instanced.py
@@ -44,7 +44,7 @@ scene = gfx.Scene()
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/sheen_chair.py
+++ b/examples/feature_demo/sheen_chair.py
@@ -24,7 +24,7 @@ scene.add(directional_light)
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/sheen_glam_velvet_sofa.py
+++ b/examples/feature_demo/sheen_glam_velvet_sofa.py
@@ -24,7 +24,7 @@ scene.add(directional_light)
 # Read cube image and turn it into a 3D image (a 4d array)
 env_img = iio.imread("imageio:meadow_cube.jpg")
 cube_size = env_img.shape[1]
-env_img.shape = 6, cube_size, cube_size, env_img.shape[-1]
+env_img = env_img.reshape((6, cube_size, cube_size, env_img.shape[-1]), copy=False)
 
 # Create environment map
 env_tex = gfx.Texture(

--- a/examples/feature_demo/skybox.py
+++ b/examples/feature_demo/skybox.py
@@ -21,7 +21,7 @@ im = iio.imread("imageio:meadow_cube.jpg")
 
 # Turn it into a 3D image (a 4d nd array)
 width = height = im.shape[1]
-im.shape = -1, width, height, 3
+im = im.reshape((-1, width, height, 3), copy=False)
 
 canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)

--- a/examples/feature_demo/skybox_rotate.py
+++ b/examples/feature_demo/skybox_rotate.py
@@ -20,7 +20,7 @@ im = iio.imread("imageio:meadow_cube.jpg")
 
 # Turn it into a 3D image (a 4d nd array)
 width = height = im.shape[1]
-im.shape = -1, width, height, 3
+im = im.reshape((-1, width, height, 3), copy=False)
 
 canvas = RenderCanvas()
 renderer = gfx.renderers.WgpuRenderer(canvas)

--- a/examples/other/hirez_screenshot.py
+++ b/examples/other/hirez_screenshot.py
@@ -82,7 +82,7 @@ markers = np.tile(markers, ncolors)
 positions = np.zeros((ncolors, nmarkers, 3), np.float32)
 positions[:, :, 0].flat = np.arange(ncolors).repeat(nmarkers) * 2
 positions[:, :, 1] = -np.arange(1, nmarkers + 1) * 2
-positions.shape = -1, 3
+positions = positions.reshape((-1, 3), copy=False)
 
 geometry = gfx.Geometry(
     positions=positions,

--- a/examples/validation/validate_points_markers.py
+++ b/examples/validation/validate_points_markers.py
@@ -72,7 +72,7 @@ markers = np.tile(markers, ncolors)
 positions = np.zeros((ncolors, nmarkers, 3), np.float32)
 positions[:, :, 0].flat = np.arange(ncolors).repeat(nmarkers) * 2
 positions[:, :, 1] = -np.arange(1, nmarkers + 1) * 2
-positions.shape = -1, 3
+positions = positions.reshape((-1, 3), copy=False)
 
 geometry = gfx.Geometry(
     positions=positions,

--- a/examples/validation/validate_srgb.py
+++ b/examples/validation/validate_srgb.py
@@ -21,7 +21,7 @@ import pygfx as gfx
 renderer = gfx.renderers.WgpuRenderer(RenderCanvas(size=(600, 600)))
 
 rgba = np.repeat(np.linspace(0, 255, 6).reshape(1, -1), 2, 0).astype(np.uint8)
-rgba.shape = (*rgba.shape, 1)
+rgba = rgba.reshape((*rgba.shape, 1), copy=False)
 rgba = np.repeat(rgba, 4, 2)
 rgba[:, :, 3] = 255
 rgb = rgba[:, :, :3].copy()

--- a/pygfx/resources/_texture.py
+++ b/pygfx/resources/_texture.py
@@ -371,8 +371,7 @@ class Texture(Resource):
         ):
             raise ValueError("The data with this offset does not fit.")
         # Create chunk
-        data = np.asarray(data).view()
-        data.shape = shape
+        data = np.asarray(data).reshape(shape, copy=False)
         if not data.flags.c_contiguous:
             if self._force_contiguous:
                 raise ValueError(


### PR DESCRIPTION
NumPy 2.5 deprecated direct assignment to `ndarray.shape`. This change uses `reshape(..., copy=False)` for the affected texture and example arrays, which keeps the no-copy behavior and avoids the warning. All tests pass.