### PR TITLE
Texcoord interpolation for lines

### DIFF
--- a/examples/feature_demo/line_map_interpolation.py
+++ b/examples/feature_demo/line_map_interpolation.py
@@ -19,18 +19,18 @@ import cmap
 from rendercanvas.auto import RenderCanvas, loop
 import pygfx as gfx
 
-
-canvas = RenderCanvas(size=(1000, 500))
+canvas = RenderCanvas()
 renderer = gfx.WgpuRenderer(canvas)
 
-# A line whose points carry categorical labels, e.g. cluster ids.
-x = np.linspace(0, 4 * np.pi, 50)
+# A line that represents categorical data, e.g. cluster labels
+x = np.linspace(0, 4 * np.pi, 10)
 y = np.sin(x)
-labels = np.repeat([0, 2, 4, 6, 8], 10)  # five of the ten tab10 colors
+positions = np.column_stack([x, y, np.zeros(10)]).astype(np.float32)
 
-positions = np.array([x * 100, y * 100, np.zeros_like(x)], np.float32).T.copy()
+labels = np.repeat([0, 2, 4, 6, 8], 2).astype(np.float32)
 # Place each label at the center of its texel in the 10-color map.
-texcoords = ((labels + 0.5) / 10).astype(np.float32)
+texcoords = ((labels + 0.5)).astype(np.float32)
+
 geometry = gfx.Geometry(positions=positions, texcoords=texcoords)
 
 tab10 = cmap.Colormap("tab10").to_pygfx()
@@ -38,14 +38,20 @@ tab10 = cmap.Colormap("tab10").to_pygfx()
 line_flat = gfx.Line(
     geometry,
     gfx.LineMaterial(
-        thickness=20, color_mode="vertex_map", map=tab10, map_interpolation="flat"
+        thickness=20,
+        color_mode="vertex_map",
+        map=tab10,
+        map_interpolation="flat",
+        maprange=(0, 10),  # the range of tab10 is [0, 10)
     ),
 )
 line_perspective = gfx.Line(
     geometry,
-    gfx.LineMaterial(thickness=20, color_mode="vertex_map", map=tab10),
+    gfx.LineMaterial(
+        thickness=20, color_mode="vertex_map", map=tab10, maprange=(0, 10)
+    ),
 )
-line_perspective.local.y = -300
+line_perspective.local.y = -2
 
 scene = gfx.Scene()
 scene.add(line_flat, line_perspective)

--- a/examples/feature_demo/line_map_interpolation.py
+++ b/examples/feature_demo/line_map_interpolation.py
@@ -1,0 +1,61 @@
+"""
+Line map interpolation
+=======================
+
+The texture coordinates that index a line's colormap are interpolated across
+the line. This is what you want for a continuous colormap, but for a categorical
+one it makes a segment that spans two categories sample the categories in
+between. Setting ``LineMaterial.map_interpolation = "flat"`` disables the
+interpolation, so each part of the line shows a single color.
+
+The top line uses 'flat' interpolation, the bottom line the default 'perspective'.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'compare'
+
+import numpy as np
+import cmap
+from rendercanvas.auto import RenderCanvas, loop
+import pygfx as gfx
+
+
+canvas = RenderCanvas(size=(1000, 500))
+renderer = gfx.WgpuRenderer(canvas)
+
+# A line whose points carry categorical labels, e.g. cluster ids.
+x = np.linspace(0, 4 * np.pi, 50)
+y = np.sin(x)
+labels = np.repeat([0, 2, 4, 6, 8], 10)  # five of the ten tab10 colors
+
+positions = np.array([x * 100, y * 100, np.zeros_like(x)], np.float32).T.copy()
+# Place each label at the center of its texel in the 10-color map.
+texcoords = ((labels + 0.5) / 10).astype(np.float32)
+geometry = gfx.Geometry(positions=positions, texcoords=texcoords)
+
+tab10 = cmap.Colormap("tab10").to_pygfx()
+
+line_flat = gfx.Line(
+    geometry,
+    gfx.LineMaterial(
+        thickness=20, color_mode="vertex_map", map=tab10, map_interpolation="flat"
+    ),
+)
+line_perspective = gfx.Line(
+    geometry,
+    gfx.LineMaterial(thickness=20, color_mode="vertex_map", map=tab10),
+)
+line_perspective.local.y = -300
+
+scene = gfx.Scene()
+scene.add(line_flat, line_perspective)
+
+camera = gfx.OrthographicCamera()
+camera.show_object(scene)
+controller = gfx.OrbitController(camera, register_events=renderer)
+
+canvas.request_draw(lambda: renderer.render(scene, camera))
+
+if __name__ == "__main__":
+    print(__doc__)
+    loop.run()

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -21,6 +21,8 @@ class LineMaterial(Material):
         The texture map specifying the color for each texture coordinate. Optional.
     maprange : tuple
         The range of the ``geometry.texcoords`` that is projected onto the (color) map. Default (0, 1).
+    map_interpolation : str
+        How the map's texcoords are interpolated across the line, 'perspective' or 'flat'. Default 'perspective'.
     dash_pattern : tuple
         The pattern of the dash, e.g. `[2, 3]`. See `dash_pattern` docs for details. Defaults to an empty tuple, i.e. no dashing.
     dash_offset : float
@@ -50,6 +52,7 @@ class LineMaterial(Material):
         color_mode="auto",
         map=None,
         maprange=None,
+        map_interpolation="perspective",
         dash_pattern=(),
         dash_offset=0,
         loop=False,
@@ -64,6 +67,7 @@ class LineMaterial(Material):
         self.color_mode = color_mode
         self.map = map
         self.maprange = maprange
+        self.map_interpolation = map_interpolation
         self.dash_pattern = dash_pattern
         self.dash_offset = dash_offset
         self.loop = loop
@@ -208,6 +212,24 @@ class LineMaterial(Material):
         # Update uniform data
         self.uniform_buffer.data["maprange"] = maprange
         self.uniform_buffer.update_full()
+
+    @property
+    def map_interpolation(self):
+        """How the map's texcoords are interpolated across the line.
+
+        Either 'perspective' (the default) or 'flat' (no interpolation; each
+        fragment uses a single vertex's texcoord).
+        """
+        return self._store.map_interpolation
+
+    @map_interpolation.setter
+    def map_interpolation(self, value):
+        value = value or "perspective"
+        if value not in ("perspective", "flat"):
+            raise ValueError(
+                f"LineMaterial.map_interpolation must be 'perspective' or 'flat', not {value!r}"
+            )
+        self._store.map_interpolation = value
 
     @property
     def dash_pattern(self):

--- a/pygfx/renderers/wgpu/shader/resolve.py
+++ b/pygfx/renderers/wgpu/shader/resolve.py
@@ -231,10 +231,21 @@ class VaryingResolver:
             used_builtins = used_varyings.intersection(builtin_varyings)
             used_slots = used_varyings.difference(used_builtins)
             used_slots = list(sorted(used_slots))
+            # Varyings tagged with a `// flatvarying <name>` directive are declared
+            # with @interpolate(flat), so they are not interpolated across the primitive.
+            flat_prefix = "// flatvarying "
+            flat_varyings = {
+                line.strip()[len(flat_prefix) :].split("//")[0].strip()
+                for line in lines
+                if line.strip().startswith(flat_prefix)
+            }
             # Build struct
             struct_lines = ["struct Varyings {"]
             for slotnr, name in enumerate(used_slots):
-                struct_lines.append(f"    @location({slotnr}) {name} : {types[name]},")
+                interpolation = "@interpolate(flat) " if name in flat_varyings else ""
+                struct_lines.append(
+                    f"    @location({slotnr}) {interpolation}{name} : {types[name]},"
+                )
             for name in sorted(used_builtins):
                 struct_lines.append(f"    @builtin({name}) {name} : {types[name]},")
             struct_lines.append("};\n")

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -85,6 +85,9 @@ class LineShader(BaseShader):
         else:
             raise RuntimeError(f"Unknown color_mode: '{color_mode}'")
 
+        # How the map's texcoords are interpolated across the primitive
+        self["map_interpolation"] = material.map_interpolation
+
         # Optimization: when the line is opaque, has a uniform color, and no dashing,
         # it can be rendered pretty safely without joins. I *think* this is faster,
         # because a lot of logic related joins becomes simpler. However, the miters

--- a/pygfx/renderers/wgpu/wgsl/line.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/line.wgsl
@@ -731,9 +731,8 @@ fn vs_main(in: VertexInput) -> Varyings {
             varyings.texcoord_vert = vec3<f32>(texcoord_vert);
         $$ endif
         $$ if map_interpolation == 'flat'
-            // Do not interpolate the texcoords across the primitive.
+            // Do not interpolate the node texcoord across the primitive.
             // flatvarying texcoord_node
-            // flatvarying texcoord_vert
         $$ endif
     $$ endif
 
@@ -968,12 +967,18 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
     $$ elif color_mode == 'face'
         let color = varyings.color_vert;
     $$ elif color_mode == 'vertex_map'
+        $$ if map_interpolation == 'flat'
+        // Sample the node's own texcoord. Unlike texcoord_vert it has no screen-space
+        // term, so the color does not drift towards a neighbour node when zooming.
+        let color = sample_colormap(varyings.texcoord_node);
+        $$ else
         var texcoord = varyings.texcoord_vert;
         if (is_join) {
             let texcoord_segment = varyings.texcoord_node - (varyings.texcoord_node - varyings.texcoord_vert) / (1.0 - abs(join_coord_lin));
             texcoord = mix(texcoord_segment, varyings.texcoord_node, abs(join_coord_fan));
         }
         let color = sample_colormap(texcoord);
+        $$ endif
     $$ elif color_mode == 'face_map'
         let color = sample_colormap(varyings.texcoord_vert);
     $$ else

--- a/pygfx/renderers/wgpu/wgsl/line.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/line.wgsl
@@ -730,6 +730,11 @@ fn vs_main(in: VertexInput) -> Varyings {
             varyings.texcoord_node = vec3<f32>(texcoord_node);
             varyings.texcoord_vert = vec3<f32>(texcoord_vert);
         $$ endif
+        $$ if map_interpolation == 'flat'
+            // Do not interpolate the texcoords across the primitive.
+            // flatvarying texcoord_node
+            // flatvarying texcoord_vert
+        $$ endif
     $$ endif
 
     return varyings;


### PR DESCRIPTION
This adds texture coord interpolation options ("flat" and "perspective"). Not sure if `map_interpolation` is the best name for this in the `LineMaterial` and I guess you want an enum for this? 

I think this is only relevant for lines. It's not applicable to `Points` since every displayed fragment is sampled from its own vertex so there's no interpolation. And I don't know much about meshes, but I also think this doesn't really apply to how meshes are used with texture maps?

Almar: Dug into this since you asked a while ago why we're rendering our own colors instead of using texcoords, this is also one reason why :laughing: 

The top line is the desired behavior when using a colormap with categorical/qualitative data and the bottom is what we currently get (perspective interpolation).
<img width="770" height="639" alt="image" src="https://github.com/user-attachments/assets/fee00614-746d-45c9-8e72-d027762681d3" />

Things get a bit weird when you rotate and the plane of the fragment is no longer orthogonal to the view direction, but I think it makes sense since it's basically a tube :thinking: 

https://github.com/user-attachments/assets/c4fcfe07-5d60-402b-8d7e-2c0a88541a83

LLM Disclosure: I did use claude code to help with the shader edits but I babysat it through everything and read everything. 
