### PR TITLE
Fix three CI failures caused by dependency drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,12 +69,13 @@ cube = gfx.Mesh(
 
 rot = la.quat_from_euler((0, 0.01), order="XY")
 
+
 def animate():
     cube.local.rotation = la.quat_mul(rot, cube.local.rotation)
 
+
 if __name__ == "__main__":
     gfx.show(cube, before_render=animate)
-
 ```
 <img src="./docs/_static/guide_rotating_cube.gif" alt="drawing" width="400"/>
 

--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -378,7 +378,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
             return pixel_scale
 
     @pixel_scale.setter
-    def pixel_scale(self, pixel_scale: None | int | float):
+    def pixel_scale(self, pixel_scale: int | float | None):
         self._pixel_scale = None
         self._pixel_ratio = None
         if pixel_scale is not None:
@@ -409,7 +409,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
         return self.pixel_scale * target_pixel_ratio
 
     @pixel_ratio.setter
-    def pixel_ratio(self, pixel_ratio: None | float):
+    def pixel_ratio(self, pixel_ratio: float | None):
         self._pixel_scale = None
         self._pixel_ratio = None
         if pixel_ratio is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,7 +72,7 @@ Repository = "https://github.com/pygfx/pygfx"
 
 # Flit is great solution for simple pure-Python projects.
 [build-system]
-requires = ["flit_core >=3.2,<4"]
+requires = ["flit_core >=3.2,<5"]
 build-backend = "flit_core.buildapi"
 
 # ===== Tooling


### PR DESCRIPTION
Fix some CI problems that popup up in Aug 2026.

<details><summary>claude</summary>

> 🤖 This PR was prepared by **Claude** (Claude Code) acting as @hmaarrfk's agent, in their checkout and at their direction. The commits are authored by them; the diagnosis and the changes are mine. Please read it as machine-generated work — each claim below came from a command that is named, so it is all reproducible.

Three unrelated one-line-ish fixes for CI failures that have nothing to do with any feature work. They are all dependency drift: main's last CI run predates these releases, so main was green when it ran and would be red if it ran today. Split out of #1315, which was carrying them only because it happened to be the branch that noticed.

Each is a separate commit so any one can be dropped.

### 1. `flit_core` 4 broke *Build release*

The job runs `pip install -U flit` and then `python -m build -n`, so the build uses whatever `flit_core` is current. 4.0.2 is now out, and the `<4` cap makes the non-isolated build refuse to start:

```
ERROR Unmet dependencies (checked against .../bin/python):
	flit_core<4,>=3.2
		wanted: <4,>=3.2
		found: 4.0.2
```

Widened to `<5`. Verified against `flit_core` 4.0.2 that `flit_core.buildapi` is still present, that `python -m build -n -s` and `-n -w` both succeed, that `twine check` passes on both artifacts, and that the resulting sdist installs and imports. The same commands fail on main with the error above.

### 2. `ruff` grew RUF036, which fails *Linting*

```
pygfx/renderers/wgpu/engine/renderer.py:381:40: RUF036 `None` not at the end of the type union.
pygfx/renderers/wgpu/engine/renderer.py:412:40: RUF036 `None` not at the end of the type union.
```

`None | int | float` → `int | float | None`, and the same for `None | float`. Annotation order only; no behaviour change.

### 3. `ruff format` now formats Python inside Markdown, which also fails *Linting*

The example block in `README.md` is not in that style, so `ruff format --check .` fails on a file no feature branch touches. This commit is `ruff format README.md` verbatim: two blank lines before the top-level `def` and `if`, and no trailing blank line inside the fence.

---

After this: `ruff check .` and `ruff format --check .` are both clean, `pytest tests` is 346 passed, and *Build release* goes green.

One note on what is **not** here. *Test examples* fails intermittently with five examples off by 2–382 pixels — `validate_image_colormap`, `validate_line_loop`, `validate_outpass`, `validate_points_markers`, `validate_ppaa`. main's own last run fails the same five with identical pixel counts (2, 10, 208, 4, 382) and the same maxdiffs, just on the 3.13 job rather than 3.10, and it passes on re-run. That looks like driver noise that migrates between Python versions, so regenerating those references would chase the noise and likely break whichever version is not currently failing. Left alone deliberately; happy to dig into it separately if you want.

#1315 is stacked on this branch. Since neither branch can be a base in this repo, #1315 shows these three commits too until this merges; it will be rebased to just its own commit afterwards.


</details?>