### PR TITLE
Dashes that split instead of sliding when you zoom

### DIFF
--- a/examples/feature_demo/line_dash_scaling.py
+++ b/examples/feature_demo/line_dash_scaling.py
@@ -1,0 +1,118 @@
+"""
+Dash scaling
+============
+
+How the dash pattern responds to zoom. Scroll to zoom, drag to pan.
+
+All four rows are the same geometry with the same ``dash_pattern``, and differ
+only in ``dash_scale_step``: the factor by which the dash size is allowed to
+jump as the view scale changes.
+
+* ``dash_scale_step=1`` (top) is the old behaviour, and is what
+  ``dash_scaling="continuous"`` does. The size follows the view exactly, so the
+  dashes always have the size asked for -- but their number along the line has
+  to change continuously, so they slide. A dash drifts in proportion to its
+  distance from the start of its line piece, which is why the far end of the
+  long line races while the near end barely moves.
+
+* ``dash_scale_step=2`` (bottom) snaps the size to powers of two. Nothing
+  slides: each time the level changes, every dash splits in two (or pairs
+  merge), and no dash moves. The cost is that the size is only right to within
+  a factor of two.
+
+The two rows between are the same mechanism at 1.25 and 1.6, to show that this
+is one continuous dial rather than two modes. Only a whole-number step gives
+dashes that truly never move, because the dash starts of one level are a subset
+of the next level's only when the levels differ by a whole factor; at 1.25 and
+1.6 the dashes still jump rather than slide, but they land somewhere new when
+they do. The smaller the step, the smaller and more frequent the jumps, until
+at 1 they merge into a continuous slide.
+
+A second parameter, ``dash_max_scale``, chooses where the size range sits: at
+``dash_scale_step`` the dashes are never finer than asked, at 1 never coarser,
+and the default (None) centres it.
+
+Watch the far end of the long line for the sliding, and watch any one dash on
+the bottom row to see it split rather than move.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+import numpy as np
+from rendercanvas.auto import RenderCanvas, loop
+import pygfx as gfx
+
+
+canvas = RenderCanvas(size=(1000, 700))
+renderer = gfx.WgpuRenderer(canvas)
+scene = gfx.Scene()
+scene.add(gfx.Background.from_color("#000"))
+
+
+def circle(n, x=0.0, y=0.0, r=55.0):
+    t = np.linspace(0, 2 * np.pi, n, endpoint=False)
+    return np.stack(
+        [x + r * np.sin(t), y + r * np.cos(t), np.zeros_like(t)], axis=1
+    ).astype(np.float32)
+
+
+nanpoint = np.full((1, 3), np.nan, np.float32)
+
+
+def geometry(y):
+    """A long straight line plus two loops, so drift shows up at both ends."""
+    straight = np.array([[-430, y + 70, 0], [430, y + 70, 0]], np.float32)
+    return gfx.Geometry(
+        positions=np.vstack(
+            [
+                straight,
+                nanpoint,
+                circle(96, -150, y),
+                nanpoint,
+                circle(6, 150, y),
+            ]
+        ).astype(np.float32)
+    )
+
+
+# dash_scale_step, colour, label
+VARIANTS = [
+    (1.0, "#f55", "dash_scale_step=1: the old behaviour, exact size but slides"),
+    (1.25, "#5f5", "dash_scale_step=1.25: small, frequent jumps"),
+    (1.6, "#59f", "dash_scale_step=1.6: larger, rarer jumps"),
+    (2.0, "#fd5", "dash_scale_step=2: dashes split in two, and never move"),
+]
+
+for i, (dash_scale_step, color, label) in enumerate(VARIANTS):
+    y = 240 - i * 170
+    material = gfx.LineMaterial(
+        thickness=8,
+        color=color,
+        loop=True,
+        aa=True,
+        dash_pattern=[2, 2],
+        thickness_space="screen",
+        dash_scaling="quantized",
+    )
+    material.dash_scale_step = dash_scale_step
+    scene.add(gfx.Line(geometry(y), material))
+
+    text = gfx.Text(
+        text=label,
+        font_size=15,
+        screen_space=True,
+        anchor="middle-left",
+        material=gfx.TextMaterial(color=color),
+    )
+    text.local.position = (-430, y + 95, 0)
+    scene.add(text)
+
+camera = gfx.OrthographicCamera(1000, 700)
+controller = gfx.PanZoomController(camera, register_events=renderer)
+
+canvas.request_draw(lambda: renderer.render(scene, camera))
+
+if __name__ == "__main__":
+    print(__doc__)
+    loop.run()

--- a/examples/feature_demo/line_dashing_3d.py
+++ b/examples/feature_demo/line_dashing_3d.py
@@ -1,0 +1,483 @@
+"""
+Dashing in 3D, side by side
+===========================
+
+The dashing controls of ``line_dashing_interactive.py``, but on a perspective
+camera and as a split view: **left is pygfx's current behaviour, right is
+whatever the panel says**. One camera drives both halves, so they are always
+looking at the same thing from the same place and the only difference is the
+material.
+
+The scene is the wireframe-cubes scene from
+``validation/validate_line_thickness_space.py`` -- three cubes of the same
+apparent size, but built at model scales of 1, 1/2 and 1/3.3 inside containers
+scaled to match. That is what makes ``thickness_space`` interesting: in model
+space the three are drawn at three different dash sizes even though they look
+the same size on screen.
+
+Each cube is one ``Line``: two square loops joined by four uprights, as
+nan-separated pieces. ``LineSegmentMaterial`` is deliberately not used, because
+it computes its cumulative distance in the shader rather than in the bake, so
+``dash_scaling`` and ``dash_fit`` do not apply to it.
+
+**What 3D adds.** Everything the 2D example shows still holds. The extra
+question here is what one dash unit is *worth* on screen, which stops being one
+number the moment a line has any extent along the view direction: a segment
+running away from the camera covers far fewer pixels per model unit than one
+across the view.
+
+The dash scale is therefore taken per segment. Press **continuous**
+(``dash_fit=exact``, ``dash_scaling=quantized``, ``dash_scale_step=1``) and the
+two halves agree: exactly at ``fov=0``, and to within a fraction of a dash under
+perspective. Turn a cube edge-on with quantization on and its receding edges keep
+roughly the dash size the pattern asks for, instead of being crammed with the
+same number of dashes as the edges facing you.
+
+What perspective still costs, and it is much smaller: the phase is linear in
+model space, while the projection is not, so within one strongly foreshortened
+segment the dashes bunch slightly toward the far end. At the nodes the two
+halves match to about 1e-6; between them the ink coverage matches to 0.2% and
+the dashes sit a fraction of a period out. Removing that too would need the
+scale chosen per fragment rather than per segment.
+
+The flat square floating above the cubes is a useful reference for the opposite
+reason: it has no extent along the view direction when you face it, so it is the
+one shape for which nothing subtle is happening at all.
+
+Orbit with the left mouse button and zoom with the wheel, in **either** pane;
+one camera drives both, so the halves always show the same view.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+import math
+
+import numpy as np
+import pylinalg as la
+from rendercanvas.auto import RenderCanvas, loop
+import pygfx as gfx
+from wgpu.utils.imgui import ImguiRenderer
+from imgui_bundle import imgui
+
+
+TITLE = "Dashing in 3D, side by side"
+CANVAS_SIZE = 1500, 820
+PANEL_WIDTH = 360
+LABEL_WIDTH = -170
+
+DASH_PATTERNS = [
+    ("2, 2", [2, 2]),
+    ("4, 2", [4, 2]),
+    ("1, 3", [1, 3]),
+    ("6, 2, 2, 2", [6, 2, 2, 2]),
+]
+THICKNESS_SPACES = ["screen", "world", "model"]
+DASH_SCALINGS = ["continuous", "quantized"]
+DASH_FITS = ["exact", "stretch", "spread"]
+PPAA_MODES = ["none", "fxaa", "ddaa"]
+PIXEL_FILTERS = ["nearest", "linear", "tent", "disk", "bspline", "mitchell", "catmull"]
+PIXEL_RATIOS = [1.0, 2.0]
+
+
+def cube_pieces(size=50.0):
+    """A cube as nan-separated pieces: two square loops and four uprights.
+
+    Drawn this way rather than as twelve loose segments so that there are real
+    joins and closed pieces to dash, which is where the pattern's behaviour
+    actually shows.
+    """
+    s = size
+    corners = [(-s, -s), (s, -s), (s, s), (-s, s)]
+    bottom = np.array([[x, y, -s] for x, y in corners], np.float32)
+    top = np.array([[x, y, s] for x, y in corners], np.float32)
+    uprights = [np.array([[x, y, -s], [x, y, s]], np.float32) for x, y in corners]
+    return [bottom, top, *uprights]
+
+
+def joined(parts):
+    nanpoint = np.full((1, 3), np.nan, np.float32)
+    stacked = [parts[0]]
+    for part in parts[1:]:
+        stacked += [nanpoint, part]
+    return np.vstack(stacked).astype(np.float32)
+
+
+CUBE = joined(cube_pieces())
+
+# A flat square, as the control: it has no extent along the view direction when
+# you look straight at it, which is the one case where a single per-object scale
+# factor is exactly right.
+_q = 60.0
+PANEL_SQUARE = np.array(
+    [[-_q, -_q, 0], [_q, -_q, 0], [_q, _q, 0], [-_q, _q, 0]], np.float32
+)
+
+
+def build_side(color):
+    """One scene: three cubes of equal apparent size but different model scale.
+
+    The middle and right cubes are built small and placed in containers scaled
+    back up, so that model space and world space disagree with each other and
+    with screen space. Straight from validate_line_thickness_space.py.
+    """
+    material = gfx.LineMaterial(
+        thickness=8,
+        color=color,
+        loop=True,
+        aa=True,
+        dash_pattern=[2, 2],
+        thickness_space="screen",
+    )
+    scene = gfx.Scene()
+    scene.add(gfx.Background.from_color("#000"))
+    # A row, as in the original scene. The view direction below is mostly
+    # front-on so that the three stay side by side rather than stacking up.
+    for divisor, x in ((1.0, -210.0), (2.0, 0.0), (3.3333, 210.0)):
+        container = gfx.Group()
+        container.add(gfx.Line(gfx.Geometry(positions=CUBE / divisor), material))
+        container.local.scale = divisor
+        # The container's position is in parent space, so it is not scaled by
+        # the container's own scale; it is x, not x / divisor.
+        container.local.position = (x, 0, 0)
+        scene.add(container)
+
+    flat = gfx.Line(gfx.Geometry(positions=PANEL_SQUARE), material)
+    flat.local.position = (0, 175, 0)
+    scene.add(flat)
+    return scene, material
+
+
+canvas = RenderCanvas(size=CANVAS_SIZE, title=TITLE)
+renderer = gfx.WgpuRenderer(canvas)
+
+scene_left, control = build_side("#7af")
+scene_right, live = build_side("#fd5")
+
+# The camera is framed for one half-width viewport, not for the whole canvas,
+# so that show_object fits the scene into the pane it will actually appear in.
+VIEW_ASPECT = (CANVAS_SIZE[0] - PANEL_WIDTH) / 2 / CANVAS_SIZE[1]
+camera = gfx.PerspectiveCamera(35, VIEW_ASPECT)
+camera.show_object(scene_left, view_dir=(-0.3, -0.35, -1.0), scale=1.25)
+
+# One viewport per pane, and the controller is handed whichever one the pointer
+# is over. It measures its gestures against the viewport's rect, so that rect has
+# to be the pane actually under the cursor: registered on the renderer it would
+# scale by the whole canvas width, and registered on one pane the other half
+# would be dead, because `pointer_down` and `wheel` are gated on `is_inside`.
+#
+# That gating is also what keeps the panel usable: events over it fall in neither
+# rect, so dragging a slider does not orbit the camera as well.
+VIEW_W = (CANVAS_SIZE[0] - PANEL_WIDTH) / 2
+view_left = gfx.Viewport(renderer, rect=(0, 0, VIEW_W, CANVAS_SIZE[1]))
+view_right = gfx.Viewport(renderer, rect=(VIEW_W, 0, VIEW_W, CANVAS_SIZE[1]))
+panzoom = gfx.PanZoomController(camera)
+orbit = gfx.OrbitController(camera)
+
+
+def active_controller():
+    return orbit if state["camera_3d"] else panzoom
+
+
+def standoff(fov):
+    """How far back the camera must sit for `fov` to span the current extent.
+
+    Zero for an orthographic camera, whose rays are parallel and which
+    therefore has no such distance. pygfx builds both projections from the same
+    reference size -- the mean of the camera's width and height -- and applies
+    the same aspect correction to each, so that cancels and equating the two
+    extents at distance D gives this. The zoom factor cancels too.
+
+    It is also exactly where `show_object` puts the camera, checked: for this
+    scene it returns 1192.0 against a measured 1192.0.
+    """
+    if fov <= 0:
+        return 0.0
+    return 0.25 * (camera.width + camera.height) / math.tan(math.radians(fov) / 2)
+
+
+def set_fov(fov):
+    """Change the projection while keeping the framing.
+
+    The camera is dollied along its own axis by the change in standoff, so the
+    plane it was looking at still spans the same extent afterwards. Nothing on
+    screen moves; only the perspective does.
+    """
+    if fov == camera.fov:
+        return
+    delta = standoff(fov) - standoff(camera.fov)
+    camera.local.position = camera.local.position + la.vec_transform_quat(
+        (0, 0, delta), camera.local.rotation
+    )
+    camera.fov = fov
+
+
+def route_to_pane(event):
+    """Give the event to the pane the pointer is in."""
+    x = getattr(event, "x", -1)
+    pane = view_right if x >= view_left.rect[2] else view_left
+    active_controller().handle_event(event, pane)
+
+
+renderer.add_event_handler(
+    route_to_pane,
+    "pointer_down",
+    "pointer_move",
+    "pointer_up",
+    "key_down",
+    "key_up",
+    "wheel",
+    "before_render",
+)
+home = camera.get_state()
+
+gui_renderer = ImguiRenderer(renderer.device, canvas)
+
+state = {
+    "dash_fit": DASH_FITS.index("spread"),
+    "dash_scaling": 1,
+    "dash_scale_step": 2.0,
+    "centre_max_scale": True,
+    "dash_scale_hysteresis": 0.1,
+    "dash_max_scale": 1.0,
+    "pattern": 0,
+    "dash_offset": 0.0,
+    "thickness": 8.0,
+    "thickness_space": 0,
+    "loop": True,
+    "aa": True,
+    # Untick for an orthographic camera with pan/zoom; see `set_fov`.
+    "camera_3d": True,
+    "fov": 35.0,
+    "ppaa": PPAA_MODES.index(renderer.ppaa),
+    "pixel_filter": PIXEL_FILTERS.index(renderer.pixel_filter),
+    "pixel_ratio": min(
+        range(len(PIXEL_RATIOS)),
+        key=lambda i: abs(PIXEL_RATIOS[i] - renderer.pixel_ratio),
+    ),
+}
+OPENING_STATE = dict(state)
+# The point of the family where quantization does nothing, i.e. what pygfx does
+# on main. Under a perspective camera this still differs from the left half,
+# which is the thing this example exists to show; set fov to 0 to see them meet.
+CONTINUOUS_STATE = OPENING_STATE | {
+    "dash_fit": DASH_FITS.index("exact"),
+    "dash_scaling": DASH_SCALINGS.index("quantized"),
+    "dash_scale_step": 1.0,
+}
+applied = {}
+
+
+def apply_state():
+    """Push the panel onto the right-hand material, and the shared bits onto both."""
+    if state == applied:
+        return
+    applied.clear()
+    applied.update(state)
+
+    _, pattern = DASH_PATTERNS[state["pattern"]]
+    for material in (live, control):
+        material.dash_pattern = pattern
+        material.dash_offset = state["dash_offset"]
+        material.thickness = state["thickness"]
+        material.thickness_space = THICKNESS_SPACES[state["thickness_space"]]
+        material.loop = state["loop"]
+        material.aa = state["aa"]
+
+    live.dash_fit = DASH_FITS[state["dash_fit"]]
+    live.dash_scaling = DASH_SCALINGS[state["dash_scaling"]]
+    live.dash_scale_step = state["dash_scale_step"]
+    live.dash_max_scale = None if state["centre_max_scale"] else state["dash_max_scale"]
+    live.dash_scale_hysteresis = state["dash_scale_hysteresis"]
+
+    set_fov(state["fov"] if state["camera_3d"] else 0.0)
+    renderer.ppaa = PPAA_MODES[state["ppaa"]]
+    renderer.pixel_filter = PIXEL_FILTERS[state["pixel_filter"]]
+    renderer.pixel_ratio = PIXEL_RATIOS[state["pixel_ratio"]]
+
+
+def draw_overlay():
+    """The two captions and the divider, drawn over the viewports."""
+    view_w = (gui_renderer.backend.io.display_size.x - PANEL_WIDTH) / 2
+    height = gui_renderer.backend.io.display_size.y
+    draw = imgui.get_foreground_draw_list()
+    draw.add_line(
+        imgui.ImVec2(view_w, 0),
+        imgui.ImVec2(view_w, height),
+        imgui.IM_COL32(90, 90, 90, 255),
+    )
+    draw.add_text(
+        imgui.ImVec2(16, 14),
+        imgui.IM_COL32(120, 170, 255, 255),
+        "left: pygfx defaults",
+    )
+    draw.add_text(
+        imgui.ImVec2(view_w + 16, 14),
+        imgui.IM_COL32(255, 221, 85, 255),
+        "right: driven by the panel",
+    )
+
+
+def draw_imgui():
+    display = gui_renderer.backend.io.display_size
+    imgui.set_next_window_size((PANEL_WIDTH, display.y), imgui.Cond_.always)
+    imgui.set_next_window_pos((display.x - PANEL_WIDTH, 0), imgui.Cond_.always)
+    is_expand, _ = imgui.begin(
+        TITLE,
+        None,
+        flags=imgui.WindowFlags_.no_move
+        | imgui.WindowFlags_.no_resize
+        | imgui.WindowFlags_.no_collapse,
+    )
+    if is_expand:
+        imgui.push_item_width(LABEL_WIDTH)
+
+        if imgui.button("reset"):
+            state.update(OPENING_STATE)
+        imgui.set_item_tooltip(
+            "Put every control back to how the example opened.\n"
+            "Does not move the camera; use 'reset view' for that."
+        )
+        imgui.same_line()
+        if imgui.button("continuous"):
+            state.update(CONTINUOUS_STATE)
+        imgui.set_item_tooltip(
+            "dash_fit=exact, dash_scaling=quantized, dash_scale_step=1 --\n"
+            "the point of the family where quantization does nothing.\n\n"
+            "Makes the two halves agree: exactly at fov=0, and to within a\n"
+            "fraction of a dash under perspective. The scale is taken per\n"
+            "segment, so a receding edge keeps the dash size asked for."
+        )
+
+        imgui.separator_text("Fitting (right half only)")
+        _, state["dash_fit"] = imgui.combo(
+            "dash_fit", state["dash_fit"], DASH_FITS, len(DASH_FITS)
+        )
+
+        imgui.separator_text("Quantization (right half only)")
+        _, state["dash_scaling"] = imgui.combo(
+            "dash_scaling", state["dash_scaling"], DASH_SCALINGS, len(DASH_SCALINGS)
+        )
+        quantized = DASH_SCALINGS[state["dash_scaling"]] == "quantized"
+        imgui.begin_disabled(not quantized)
+        _, state["dash_scale_step"] = imgui.slider_float(
+            "dash_scale_step", state["dash_scale_step"], 1.0, 4.0
+        )
+        _, state["centre_max_scale"] = imgui.checkbox(
+            "dash_max_scale = None (centred)", state["centre_max_scale"]
+        )
+        imgui.begin_disabled(state["centre_max_scale"])
+        _, state["dash_max_scale"] = imgui.slider_float(
+            "dash_max_scale",
+            min(max(state["dash_max_scale"], 1.0), state["dash_scale_step"]),
+            1.0,
+            max(state["dash_scale_step"], 1.0001),
+        )
+        imgui.end_disabled()
+        _, state["dash_scale_hysteresis"] = imgui.slider_float(
+            "dash_scale_hysteresis", state["dash_scale_hysteresis"], 0.0, 0.5
+        )
+        imgui.set_item_tooltip(
+            "How far past a step boundary the view must go before the dash\n"
+            "size follows, in fractions of a step. Set it to 0, tick 'animate\n"
+            "zoom' and watch a size sitting near a boundary flicker: that is\n"
+            "what the default 0.1 exists to prevent. The cost is that the\n"
+            "dashes may stray that much further from the size asked for."
+        )
+        imgui.end_disabled()
+        if quantized and THICKNESS_SPACES[state["thickness_space"]] != "screen":
+            imgui.text_wrapped(
+                "Ignored: the pattern is anchored to the object already unless "
+                'thickness_space is "screen".'
+            )
+
+        imgui.separator_text("Pattern (both halves)")
+        _, state["pattern"] = imgui.combo(
+            "dash_pattern",
+            state["pattern"],
+            [name for name, _ in DASH_PATTERNS],
+            len(DASH_PATTERNS),
+        )
+        _, state["dash_offset"] = imgui.slider_float(
+            "dash_offset", state["dash_offset"], 0.0, 4.0
+        )
+        _, state["thickness"] = imgui.slider_float(
+            "thickness", state["thickness"], 1.0, 24.0
+        )
+        _, state["thickness_space"] = imgui.combo(
+            "thickness_space",
+            state["thickness_space"],
+            THICKNESS_SPACES,
+            len(THICKNESS_SPACES),
+        )
+        _, state["loop"] = imgui.checkbox("loop", state["loop"])
+        _, state["aa"] = imgui.checkbox("aa", state["aa"])
+
+        imgui.separator_text("Camera")
+        _, state["camera_3d"] = imgui.checkbox("3D camera", state["camera_3d"])
+        imgui.set_item_tooltip(
+            "Switch between a perspective camera with orbit and an\n"
+            "orthographic one with pan/zoom, in place. The position,\n"
+            "orientation and framing are kept, so nothing changes size or\n"
+            "moves off screen -- but a scene with depth does look different\n"
+            "under a parallel projection, which is rather the point: the\n"
+            "cubes' edges stop converging.\n\n"
+            "The same toggle is in line_dashing_interactive.py, which starts\n"
+            "on the other side of it."
+        )
+        imgui.begin_disabled(not state["camera_3d"])
+        _, state["fov"] = imgui.slider_float("fov", state["fov"], 1.0, 120.0)
+        imgui.set_item_tooltip(
+            "The larger the fov, the more the near and far parts of a cube\n"
+            "disagree about what one dash should measure. The camera is\n"
+            "dollied to keep the framing, so this changes the perspective\n"
+            "without changing how big anything is."
+        )
+        imgui.end_disabled()
+        if imgui.button("reset view"):
+            camera.set_state(home)
+            set_fov(state["fov"] if state["camera_3d"] else 0.0)
+
+        imgui.separator_text("Renderer")
+        _, state["ppaa"] = imgui.combo(
+            "ppaa", state["ppaa"], PPAA_MODES, len(PPAA_MODES)
+        )
+        _, state["pixel_filter"] = imgui.combo(
+            "pixel_filter", state["pixel_filter"], PIXEL_FILTERS, len(PIXEL_FILTERS)
+        )
+        _, state["pixel_ratio"] = imgui.combo(
+            "logical:physical",
+            state["pixel_ratio"],
+            [f"1:{r:g}" for r in PIXEL_RATIOS],
+            len(PIXEL_RATIOS),
+        )
+        pw, ph = renderer.physical_size
+        imgui.text(f"physical: {pw} x {ph}")
+
+        imgui.pop_item_width()
+    imgui.end()
+
+    draw_overlay()
+
+
+gui_renderer.set_gui(draw_imgui)
+
+
+def animate():
+    apply_state()
+    width, height = canvas.get_logical_size()
+    view_w = (width - PANEL_WIDTH) / 2
+    # Keep the controller's idea of the panes in step with the window.
+    view_left.rect = 0, 0, view_w, height
+    view_right.rect = view_w, 0, view_w, height
+    renderer.render(scene_left, camera, flush=False, rect=(0, 0, view_w, height))
+    renderer.render(scene_right, camera, flush=False, rect=(view_w, 0, view_w, height))
+    renderer.flush()
+    gui_renderer.render()
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    print(__doc__)
+    renderer.request_draw(animate)
+    loop.run()

--- a/examples/feature_demo/line_dashing_interactive.py
+++ b/examples/feature_demo/line_dashing_interactive.py
@@ -1,0 +1,581 @@
+"""
+Dashing, interactively
+======================
+
+Live controls for the two dashing questions that only show up once something
+moves or once a line closes: what the dashes do when you zoom (``dash_scaling``,
+``dash_scale_step``, ``dash_max_scale``) and whether the pattern is made to fit
+the line (``dash_fit``).
+
+Split view: **left is pygfx's current behaviour, right is whatever the panel
+says**. One camera drives both halves, so the same shapes sit at the same place
+on screen in both and the only difference is the material. Everything except the
+fit and the quantization is mirrored onto both sides, so you only ever see the
+one difference you are looking at.
+
+The five shapes -- a straight line, a triangle, a square, a pentagon, and a
+99-gon standing in for a circle -- give five piece lengths at once, which is what
+makes a per-piece behaviour legible.
+
+**dash_fit.** By default the pattern keeps exactly the size you asked for and
+simply stops wherever the piece ends. Almost no piece is a whole number of
+periods long, so a closed piece has a seam where the pattern comes back round to
+its start: look at the top of each polygon on the left. Setting
+``dash_fit="stretch"`` scales each piece by the small factor that makes a whole
+number of periods span it, and the seam goes. It is per piece, so the five shapes
+end up with five slightly different dash sizes -- that is the trade being made.
+Open pieces are fitted to whole periods *less the final gap*, so the straight
+line begins and ends with a full stroke rather than trailing off into space.
+
+``dash_fit="spread"`` fits without ever asking for a smaller pattern. Reaching
+the *nearest* whole number of periods means compressing a piece about half the
+time, and ``"stretch"`` does; ``"spread"`` drops to the next count down and
+widens only the gaps, leaving the strokes at exactly the size asked for. The
+pattern is then a floor. Watch one shape while you zoom: the gaps open up, and
+when there is room for another stroke it appears and they snap back.
+
+**dash_scaling.** With ``thickness_space="screen"`` the pattern is measured in
+screen pixels, so the number of dashes along a piece has to change as you zoom,
+and each dash drifts in proportion to its distance from the start of its piece.
+Tick "animate zoom" and watch the left half crawl. With ``"quantized"`` the
+pattern is anchored to the object and only its period follows the view, in steps
+of ``dash_scale_step``, so the dashes hold still and split.
+
+The two combine: under quantization the fitted period count is snapped to a power
+of the step rather than to the nearest whole number, so a level change still
+splits each dash exactly rather than moving it.
+
+**Getting back to today's behaviour.** Press **continuous**. It takes two
+settings, not one: ``dash_fit=exact`` *and* ``dash_scale_step=1``, since a
+stretched pattern differs from main whatever the scaling is set to. A step of 1
+is the point of the family where quantization does nothing -- it is 1 and not 0
+because the parameter is the ratio between successive dash sizes, not an
+increment. Start there, then raise the step to dial quantization in.
+
+**single object vs distinct objects.** The five shapes can be drawn either as one
+``Line`` with nans between the pieces, or as five separate ``Line`` objects
+sharing one material. That these look the same is the property the per-piece dash
+phase exists to give, so the toggle is a check rather than a demonstration: flip
+it and nothing should move.
+
+They are not quite bit-identical, and it is worth knowing why. A later piece's
+cumulative distance is summed straight through the lengths of the pieces before
+it, and only then has its own starting offset subtracted, so it carries a couple
+of float32 ulps that an object starting from zero does not. Measured, the two
+agree to about 2e-7 relative, which is a handful of antialiased pixels at the
+loop seams and nothing anywhere else.
+
+**Renderer settings.** The panel also exposes what sits between the line shader
+and the pixels: the post-processing antialiasing (``ppaa``), the reconstruction
+filter of the downsample (``pixel_filter``), the line's own analytic ``aa``, and
+whether the render is 1:1 or 1:2 against the window. Turn ``ppaa`` off and set
+the ratio to 1:1 and what is left is what the shader actually emitted.
+
+Drag to pan and scroll to zoom in **either** pane; one camera drives both, so
+the halves always show the same view. See ``line_dashing_3d.py`` for the same
+controls under a perspective camera.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+import math
+import time
+
+import numpy as np
+import pylinalg as la
+from rendercanvas.auto import RenderCanvas, loop
+import pygfx as gfx
+from wgpu.utils.imgui import ImguiRenderer
+from imgui_bundle import imgui
+
+
+TITLE = "Dashing, interactively"
+CANVAS_SIZE = 1500, 820
+PANEL_WIDTH = 360
+LABEL_WIDTH = -170
+
+# Half the canvas, less the panel. The camera is sized to match, so that at zoom
+# 1 one model unit is one logical pixel in each pane.
+VIEW_SIZE = (CANVAS_SIZE[0] - PANEL_WIDTH) / 2, CANVAS_SIZE[1]
+
+# Five shapes in a 3 + 2 grid, which fits a half-width pane where a single row
+# would not. The straight line takes the first slot.
+RADIUS = 62.0
+SLOTS = [(-165.0, 165.0), (0.0, 165.0), (165.0, 165.0), (-85.0, -125.0), (85.0, -125.0)]
+POLYGONS = [3, 4, 5, 99]
+
+DASH_PATTERNS = [
+    ("2, 2", [2, 2]),
+    ("4, 2", [4, 2]),
+    ("1, 3", [1, 3]),
+    ("6, 2, 2, 2", [6, 2, 2, 2]),
+]
+THICKNESS_SPACES = ["screen", "world", "model"]
+DASH_SCALINGS = ["continuous", "quantized"]
+DASH_FITS = ["exact", "stretch", "spread"]
+GEOMETRY_MODES = ["single object (nans)", "distinct objects"]
+PPAA_MODES = ["none", "fxaa", "ddaa"]
+PIXEL_FILTERS = ["nearest", "linear", "tent", "disk", "bspline", "mitchell", "catmull"]
+PIXEL_RATIOS = [1.0, 2.0]
+
+AUTO_ZOOM_RANGE = 0.0, 3.0
+AUTO_ZOOM_PERIOD = 16.0  # seconds for a full there-and-back
+
+
+def polygon(n, cx, cy, r=RADIUS):
+    # An even-sided polygon drawn from a vertex at the top reads as standing on
+    # a corner (a square becomes a diamond), so turn it half a side; an odd one
+    # already stands on a side, so leave it pointing up.
+    t = np.linspace(0, 2 * np.pi, n, endpoint=False) + (np.pi / n if n % 2 == 0 else 0)
+    return np.stack(
+        [cx + r * np.sin(t), cy + r * np.cos(t), np.zeros_like(t)], axis=1
+    ).astype(np.float32)
+
+
+def pieces():
+    """The five shapes, each as its own array of nodes."""
+    (lx, ly), *rest = SLOTS
+    straight = np.array([[lx - RADIUS, ly, 0], [lx + RADIUS, ly, 0]], np.float32)
+    return [straight] + [
+        polygon(n, x, y) for n, (x, y) in zip(POLYGONS, rest, strict=True)
+    ]
+
+
+def joined(parts):
+    """The same pieces as one array, nan-separated."""
+    nanpoint = np.full((1, 3), np.nan, np.float32)
+    stacked = [parts[0]]
+    for part in parts[1:]:
+        stacked += [nanpoint, part]
+    return np.vstack(stacked).astype(np.float32)
+
+
+canvas = RenderCanvas(size=CANVAS_SIZE, title=TITLE)
+renderer = gfx.WgpuRenderer(canvas)
+
+
+def build_side(color):
+    """One pane, with the shapes built both ways on top of each other."""
+    material = gfx.LineMaterial(
+        thickness=8,
+        color=color,
+        loop=True,
+        aa=True,
+        dash_pattern=[2, 2],
+        thickness_space="screen",
+    )
+    scene = gfx.Scene()
+    scene.add(gfx.Background.from_color("#000"))
+    parts = pieces()
+    single = gfx.Line(gfx.Geometry(positions=joined(parts)), material)
+    distinct = [gfx.Line(gfx.Geometry(positions=part), material) for part in parts]
+    scene.add(single, *distinct)
+    return scene, material, single, distinct
+
+
+scene_left, control, control_single, control_distinct = build_side("#7af")
+scene_right, live, live_single, live_distinct = build_side("#fd5")
+
+# An orthographic camera in pygfx *is* a perspective one with fov 0 -- they are
+# the same class -- so the 2D and 3D views here are one camera with two values
+# of `fov`, and switching between them keeps the position, orientation and view
+# extent untouched. What changes is the projection and which controller drives
+# it. `width` is the extent at the reference depth, which the projection keeps
+# fixed across a change of fov, so nothing jumps: measured, a box at that depth
+# covers the same 10000 pixels at fov 0, 10, 35 and 70.
+camera = gfx.PerspectiveCamera(0)
+camera.width, camera.height = VIEW_SIZE
+
+# One viewport per pane, and the controller is handed whichever one the pointer
+# is over. It measures pan and zoom against the viewport's rect, so that rect has
+# to be the pane actually under the cursor: registered on the renderer it would
+# scale by the whole canvas width, and registered on one pane the other half
+# would be dead, because `pointer_down` and `wheel` are gated on `is_inside`.
+#
+# That gating is also what keeps the panel usable: events over it fall in neither
+# rect, so dragging a slider does not move the camera as well.
+view_left = gfx.Viewport(renderer, rect=(0, 0, *VIEW_SIZE))
+view_right = gfx.Viewport(renderer, rect=(VIEW_SIZE[0], 0, *VIEW_SIZE))
+panzoom = gfx.PanZoomController(camera)
+orbit = gfx.OrbitController(camera)
+
+
+def active_controller():
+    return orbit if state["camera_3d"] else panzoom
+
+
+def standoff(fov):
+    """How far back the camera must sit for `fov` to span the current height.
+
+    Zero for an orthographic camera, which has no such distance: its rays are
+    parallel, so it can sit in the plane it is looking at -- which is exactly
+    where this one starts, and why switching to a perspective projection
+    without moving it would put the scene at w = 0.
+    """
+    if fov <= 0:
+        return 0.0
+    # pygfx builds both projections from the same reference size, the mean of
+    # the camera's width and height, and applies the same aspect correction to
+    # each -- so that cancels, and equating the two extents at distance D gives
+    # this. The zoom factor cancels as well, so a zoomed view switches cleanly.
+    return 0.25 * (camera.width + camera.height) / math.tan(math.radians(fov) / 2)
+
+
+def set_fov(fov):
+    """Change the projection while keeping the framing.
+
+    The camera is dollied along its own axis by the change in standoff, so the
+    plane it was looking at still spans the same height afterwards. Nothing on
+    screen moves; only the perspective does.
+    """
+    if fov == camera.fov:
+        return
+    delta = standoff(fov) - standoff(camera.fov)
+    camera.local.position = camera.local.position + la.vec_transform_quat(
+        (0, 0, delta), camera.local.rotation
+    )
+    camera.fov = fov
+
+
+def route_to_pane(event):
+    """Give the event to the pane the pointer is in."""
+    x = getattr(event, "x", -1)
+    pane = view_right if x >= view_left.rect[2] else view_left
+    active_controller().handle_event(event, pane)
+
+
+renderer.add_event_handler(
+    route_to_pane,
+    "pointer_down",
+    "pointer_move",
+    "pointer_up",
+    "key_down",
+    "key_up",
+    "wheel",
+    "before_render",
+)
+home = camera.get_state()
+
+gui_renderer = ImguiRenderer(renderer.device, canvas)
+
+state = {
+    "geometry": 0,
+    "dash_fit": DASH_FITS.index("spread"),
+    "dash_scaling": 1,
+    "dash_scale_step": 2.0,
+    "centre_max_scale": True,
+    "dash_scale_hysteresis": 0.1,
+    "dash_max_scale": 1.0,
+    "pattern": 0,
+    "dash_offset": 0.0,
+    "thickness": 8.0,
+    "thickness_space": 0,
+    "loop": True,
+    "aa": True,
+    # Seeded from the renderer's own defaults, so that merely opening the panel
+    # cannot change how anything is drawn.
+    "ppaa": PPAA_MODES.index(renderer.ppaa),
+    "pixel_filter": PIXEL_FILTERS.index(renderer.pixel_filter),
+    "pixel_ratio": min(
+        range(len(PIXEL_RATIOS)),
+        key=lambda i: abs(PIXEL_RATIOS[i] - renderer.pixel_ratio),
+    ),
+    "animate_zoom": False,
+    # The camera is orthographic until this is ticked; see `apply_state`.
+    "camera_3d": False,
+    "fov": 45.0,
+}
+# What "reset" restores, captured before anything can change it.
+OPENING_STATE = dict(state)
+# What "continuous" restores: the point of the parameter family where
+# quantization does nothing, which is pygfx's behaviour on main. Note it takes
+# two of the three -- dash_fit has to be "exact" as well, since a stretched
+# pattern differs from main whatever the scaling is set to.
+CONTINUOUS_STATE = OPENING_STATE | {
+    "dash_fit": DASH_FITS.index("exact"),
+    "dash_scaling": DASH_SCALINGS.index("quantized"),
+    "dash_scale_step": 1.0,
+}
+applied = {}
+
+
+def get_zoom_exp():
+    """The current view scale, as a power of two.
+
+    Read back from the camera rather than stored, so that the GUI and the mouse
+    have one shared handle on the view instead of fighting over two.
+    """
+    return float(np.log2(VIEW_SIZE[0] / camera.width))
+
+
+def set_zoom_exp(exp):
+    factor = 2.0**exp
+    camera.width = VIEW_SIZE[0] / factor
+    camera.height = VIEW_SIZE[1] / factor
+
+
+def apply_state():
+    """Push the panel onto the right pane, and the shared bits onto both.
+
+    The guard matters: the uniform-backed setters re-upload whether or not the
+    value differs, and this runs every frame.
+    """
+    if state == applied:
+        return
+    applied.clear()
+    applied.update(state)
+
+    _, pattern = DASH_PATTERNS[state["pattern"]]
+    for material in (live, control):
+        material.dash_pattern = pattern
+        material.dash_offset = state["dash_offset"]
+        material.thickness = state["thickness"]
+        material.thickness_space = THICKNESS_SPACES[state["thickness_space"]]
+        material.loop = state["loop"]
+        material.aa = state["aa"]
+
+    live.dash_fit = DASH_FITS[state["dash_fit"]]
+    live.dash_scaling = DASH_SCALINGS[state["dash_scaling"]]
+    live.dash_scale_step = state["dash_scale_step"]
+    live.dash_max_scale = None if state["centre_max_scale"] else state["dash_max_scale"]
+    live.dash_scale_hysteresis = state["dash_scale_hysteresis"]
+
+    set_fov(state["fov"] if state["camera_3d"] else 0.0)
+    renderer.ppaa = PPAA_MODES[state["ppaa"]]
+    renderer.pixel_filter = PIXEL_FILTERS[state["pixel_filter"]]
+    renderer.pixel_ratio = PIXEL_RATIOS[state["pixel_ratio"]]
+
+    single = GEOMETRY_MODES[state["geometry"]].startswith("single")
+    for one, many in ((live_single, live_distinct), (control_single, control_distinct)):
+        one.visible = single
+        for line in many:
+            line.visible = not single
+
+
+def draw_overlay():
+    """The two captions and the divider, drawn over the panes."""
+    display = gui_renderer.backend.io.display_size
+    view_w = (display.x - PANEL_WIDTH) / 2
+    draw = imgui.get_foreground_draw_list()
+    draw.add_line(
+        imgui.ImVec2(view_w, 0),
+        imgui.ImVec2(view_w, display.y),
+        imgui.IM_COL32(90, 90, 90, 255),
+    )
+    draw.add_text(
+        imgui.ImVec2(16, 14),
+        imgui.IM_COL32(120, 170, 255, 255),
+        "left: pygfx defaults",
+    )
+    draw.add_text(
+        imgui.ImVec2(view_w + 16, 14),
+        imgui.IM_COL32(255, 221, 85, 255),
+        "right: driven by the panel",
+    )
+
+
+def draw_imgui():
+    display = gui_renderer.backend.io.display_size
+    imgui.set_next_window_size((PANEL_WIDTH, display.y), imgui.Cond_.always)
+    imgui.set_next_window_pos((display.x - PANEL_WIDTH, 0), imgui.Cond_.always)
+    is_expand, _ = imgui.begin(
+        TITLE,
+        None,
+        flags=imgui.WindowFlags_.no_move
+        | imgui.WindowFlags_.no_resize
+        | imgui.WindowFlags_.no_collapse,
+    )
+    if is_expand:
+        imgui.push_item_width(LABEL_WIDTH)
+
+        if imgui.button("reset"):
+            state.update(OPENING_STATE)
+        imgui.set_item_tooltip(
+            "Put every control back to how the example opened:\n"
+            "dash_fit=spread, dash_scaling=quantized, dash_scale_step=2.\n"
+            "Does not move the camera; use 'reset view' for that."
+        )
+        imgui.same_line()
+        if imgui.button("continuous"):
+            state.update(CONTINUOUS_STATE)
+        imgui.set_item_tooltip(
+            "Make the right pane match the left exactly, i.e. what pygfx does\n"
+            "on main: dash_fit=exact, dash_scaling=quantized,\n"
+            "dash_scale_step=1.\n\n"
+            "A step of 1 is the point where quantization does nothing -- the\n"
+            "size follows the view exactly, which is what continuous scaling\n"
+            "means. It is 1 and not 0 because the parameter is the ratio\n"
+            "between successive dash sizes, not an increment.\n\n"
+            "Start here and raise dash_scale_step to dial quantization in."
+        )
+
+        imgui.separator_text("Fitting (right pane only)")
+        _, state["dash_fit"] = imgui.combo(
+            "dash_fit", state["dash_fit"], DASH_FITS, len(DASH_FITS)
+        )
+
+        imgui.separator_text("Quantization (right pane only)")
+        _, state["dash_scaling"] = imgui.combo(
+            "dash_scaling", state["dash_scaling"], DASH_SCALINGS, len(DASH_SCALINGS)
+        )
+        quantized = DASH_SCALINGS[state["dash_scaling"]] == "quantized"
+        imgui.begin_disabled(not quantized)
+        _, state["dash_scale_step"] = imgui.slider_float(
+            "dash_scale_step", state["dash_scale_step"], 1.0, 4.0
+        )
+        _, state["centre_max_scale"] = imgui.checkbox(
+            "dash_max_scale = None (centred)", state["centre_max_scale"]
+        )
+        imgui.begin_disabled(state["centre_max_scale"])
+        # The property clamps to [1, step]; clamp the slider to match, so that
+        # it shows the value that is actually in effect.
+        _, state["dash_max_scale"] = imgui.slider_float(
+            "dash_max_scale",
+            min(max(state["dash_max_scale"], 1.0), state["dash_scale_step"]),
+            1.0,
+            max(state["dash_scale_step"], 1.0001),
+        )
+        imgui.end_disabled()
+        _, state["dash_scale_hysteresis"] = imgui.slider_float(
+            "dash_scale_hysteresis", state["dash_scale_hysteresis"], 0.0, 0.5
+        )
+        imgui.set_item_tooltip(
+            "How far past a step boundary the view must go before the dash\n"
+            "size follows, in fractions of a step. Set it to 0, tick 'animate\n"
+            "zoom' and watch a size sitting near a boundary flicker: that is\n"
+            "what the default 0.1 exists to prevent. The cost is that the\n"
+            "dashes may stray that much further from the size asked for."
+        )
+        imgui.end_disabled()
+
+        if quantized and THICKNESS_SPACES[state["thickness_space"]] != "screen":
+            imgui.text_wrapped(
+                "Ignored: the pattern is anchored to the object already unless "
+                'thickness_space is "screen".'
+            )
+
+        imgui.separator_text("Pattern (both panes)")
+        _, state["pattern"] = imgui.combo(
+            "dash_pattern",
+            state["pattern"],
+            [name for name, _ in DASH_PATTERNS],
+            len(DASH_PATTERNS),
+        )
+        _, state["dash_offset"] = imgui.slider_float(
+            "dash_offset", state["dash_offset"], 0.0, 4.0
+        )
+        if state["dash_offset"] % 1.0:
+            if quantized:
+                imgui.text_wrapped(
+                    "A fractional offset is a fraction of a period here, so it "
+                    "slides the pattern at every level change."
+                )
+            if DASH_FITS[state["dash_fit"]] == "stretch":
+                imgui.text_wrapped(
+                    "A fractional offset moves the open piece off its stroke "
+                    "ends; closed pieces still join up."
+                )
+        _, state["thickness"] = imgui.slider_float(
+            "thickness", state["thickness"], 1.0, 24.0
+        )
+        _, state["thickness_space"] = imgui.combo(
+            "thickness_space",
+            state["thickness_space"],
+            THICKNESS_SPACES,
+            len(THICKNESS_SPACES),
+        )
+        _, state["loop"] = imgui.checkbox("loop", state["loop"])
+        _, state["aa"] = imgui.checkbox("aa (the line's own analytic AA)", state["aa"])
+
+        imgui.separator_text("Geometry (both panes)")
+        _, state["geometry"] = imgui.combo(
+            "drawn as", state["geometry"], GEOMETRY_MODES, len(GEOMETRY_MODES)
+        )
+        imgui.text_wrapped(
+            "Nothing should move; they agree to ~2e-7, a few pixels at the seams."
+        )
+
+        imgui.separator_text("Renderer")
+        _, state["ppaa"] = imgui.combo(
+            "ppaa", state["ppaa"], PPAA_MODES, len(PPAA_MODES)
+        )
+        _, state["pixel_filter"] = imgui.combo(
+            "pixel_filter", state["pixel_filter"], PIXEL_FILTERS, len(PIXEL_FILTERS)
+        )
+        _, state["pixel_ratio"] = imgui.combo(
+            "logical:physical",
+            state["pixel_ratio"],
+            [f"1:{r:g}" for r in PIXEL_RATIOS],
+            len(PIXEL_RATIOS),
+        )
+        pw, ph = renderer.physical_size
+        imgui.text(f"physical: {pw} x {ph}")
+
+        imgui.separator_text("View")
+
+        _, state["camera_3d"] = imgui.checkbox("3D camera", state["camera_3d"])
+        imgui.set_item_tooltip(
+            "Switch between an orthographic camera with pan/zoom and a\n"
+            "perspective one with orbit, in place: the position, orientation\n"
+            "and view extent are kept, so the picture does not jump. On a flat\n"
+            "scene like this one nothing visibly moves at the moment you tick\n"
+            "it -- what changes is that dragging now rotates instead of\n"
+            "panning, and that the dash scale starts to vary with depth once\n"
+            "you tilt the view."
+        )
+        imgui.begin_disabled(not state["camera_3d"])
+        _, state["fov"] = imgui.slider_float("fov", state["fov"], 1.0, 120.0)
+        imgui.end_disabled()
+
+        _, state["animate_zoom"] = imgui.checkbox("animate zoom", state["animate_zoom"])
+        imgui.begin_disabled(state["animate_zoom"])
+        changed, exp = imgui.slider_float("zoom (2**x)", get_zoom_exp(), -1.0, 5.0)
+        if changed:
+            set_zoom_exp(exp)
+        imgui.end_disabled()
+        if imgui.button("reset view"):
+            camera.set_state(home)
+            # `home` was captured while orthographic, so re-apply the standoff
+            # for whatever the toggle currently says rather than leaving fov 0.
+            set_fov(state["fov"] if state["camera_3d"] else 0.0)
+        imgui.text(f"view scale: {2 ** get_zoom_exp():.2f} px per model unit")
+        _, pattern = DASH_PATTERNS[state["pattern"]]
+        imgui.text(f"dash size asked for: {state['thickness'] * pattern[0]:.1f} px")
+
+        imgui.pop_item_width()
+    imgui.end()
+
+    draw_overlay()
+
+
+gui_renderer.set_gui(draw_imgui)
+
+start_time = time.perf_counter()
+
+
+def animate():
+    if state["animate_zoom"]:
+        low, high = AUTO_ZOOM_RANGE
+        phase = (time.perf_counter() - start_time) / AUTO_ZOOM_PERIOD
+        # A cosine rather than a sawtooth, so the sweep slows to a stop at each
+        # end instead of snapping back and hiding what just happened.
+        set_zoom_exp(low + (high - low) * 0.5 * (1 - np.cos(2 * np.pi * phase)))
+
+    apply_state()
+    width, height = canvas.get_logical_size()
+    view_w = (width - PANEL_WIDTH) / 2
+    # Keep the controller's idea of the panes in step with the window.
+    view_left.rect = 0, 0, view_w, height
+    view_right.rect = view_w, 0, view_w, height
+    renderer.render(scene_left, camera, flush=False, rect=(0, 0, view_w, height))
+    renderer.render(scene_right, camera, flush=False, rect=(view_w, 0, view_w, height))
+    renderer.flush()
+    gui_renderer.render()
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    print(__doc__)
+    renderer.request_draw(animate)
+    loop.run()

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -1,7 +1,7 @@
 from ._base import Material
 from ..resources import Texture, TextureMap
 from ..utils import unpack_bitfield, Color, assert_type
-from ..utils.enums import ColorMode, CoordSpace
+from ..utils.enums import ColorMode, CoordSpace, DashFit, DashScaling
 
 
 class LineMaterial(Material):
@@ -25,6 +25,16 @@ class LineMaterial(Material):
         The pattern of the dash, e.g. `[2, 3]`. See `dash_pattern` docs for details. Defaults to an empty tuple, i.e. no dashing.
     dash_offset : float
         The offset into the dash phase. Default 0.0.
+    dash_scaling : str | DashScaling
+        How the dash pattern behaves when the view scale changes ('continuous', 'quantized'). Default 'continuous'.
+    dash_scale_step : float
+        For 'quantized' scaling, the factor between successive dash sizes. 1 reproduces continuous scaling, 2 makes each dash split in two. Default 2.
+    dash_max_scale : float | None
+        For 'quantized' scaling, the largest the dashes may grow, relative to the requested size, before they split. Default None, i.e. centred on the requested size.
+    dash_scale_hysteresis : float
+        For 'quantized' scaling, how far past a step boundary the view must go before the dash size follows, as a fraction of one step. Default 0.1.
+    dash_fit : str | DashFit
+        Whether and how the pattern is fitted so that a whole number of periods spans each line piece ('exact', 'stretch', 'spread'). Default 'exact'.
     loop : bool
         Whether the line's end should be connected. Default False.
     aa : bool
@@ -52,6 +62,11 @@ class LineMaterial(Material):
         maprange=None,
         dash_pattern=(),
         dash_offset=0,
+        dash_scaling="continuous",
+        dash_scale_step=2.0,
+        dash_max_scale=None,
+        dash_scale_hysteresis=0.1,
+        dash_fit="exact",
         loop=False,
         aa=False,
         **kwargs,
@@ -66,6 +81,11 @@ class LineMaterial(Material):
         self.maprange = maprange
         self.dash_pattern = dash_pattern
         self.dash_offset = dash_offset
+        self.dash_scaling = dash_scaling
+        self.dash_scale_step = dash_scale_step
+        self.dash_max_scale = dash_max_scale
+        self.dash_scale_hysteresis = dash_scale_hysteresis
+        self.dash_fit = dash_fit
         self.loop = loop
         self.aa = aa
 
@@ -245,6 +265,206 @@ class LineMaterial(Material):
     def dash_offset(self, value):
         self.uniform_buffer.data["dash_offset"] = float(value)
         self.uniform_buffer.update_full()
+
+    @property
+    def dash_scaling(self):
+        """How the dash pattern responds to a change in view scale.
+
+        See :obj:`pygfx.utils.enums.DashScaling`.
+
+        With the default 'continuous', the dash pattern has exactly the size
+        that `dash_pattern` and `thickness_space` ask for. The catch, when
+        `thickness_space` is 'screen', is that the number of dashes along the
+        line then changes continuously as you zoom, so the dashes slide along
+        the line. A dash drifts by an amount proportional to its distance from
+        the start of its line piece, which makes the far end of a long line
+        appear to race while the near end sits still.
+
+        With 'quantized', the pattern is instead anchored to the object, and
+        only its period is allowed to follow the view scale, snapped to a power
+        of two. Dashes therefore never move: each time the view scale doubles,
+        every dash splits into two, and each time it halves, pairs of dashes
+        merge. The price is that the on-screen dash size is only approximately
+        the requested one, staying within about a factor of 1.5 of it, and
+        that it changes in steps rather than smoothly. The step is snapped with
+        hysteresis, so a view parked near a boundary does not flicker between
+        two levels.
+
+        Note that with 'quantized' the `dash_offset` is expressed in periods
+        rather than in units of the pattern, because only a whole number of
+        periods keeps the dashes from moving when the period changes.
+        """
+        return self._store.dash_scaling
+
+    @dash_scaling.setter
+    def dash_scaling(self, value):
+        value = "continuous" if value is None else str(value)
+        if value not in DashScaling:
+            raise ValueError(
+                f"LineMaterial.dash_scaling must be a string in {DashScaling}, not {value!r}"
+            )
+        self._store.dash_scaling = value
+
+    @property
+    def dash_scale_step(self):
+        """The factor between successive dash sizes, when `dash_scaling` is
+        'quantized'.
+
+        As the view scale changes, the dash size does not follow it smoothly;
+        it is held, and then jumps by this factor. The parameter is a
+        continuous dial between the two behaviours:
+
+        * 1.0 -- the size follows the view exactly, i.e. this reproduces
+          `dash_scaling='continuous'`. The dashes keep the size asked for, and
+          slide along the line as you zoom.
+        * 2.0 (the default) -- the size snaps to powers of two. Nothing slides:
+          each step splits every dash into two.
+        * 3.0 -- as above, but each step splits every dash into three, over a
+          three-fold range of sizes.
+
+        Only a whole number gives dashes that truly never move, because the
+        dash starts of one level are a subset of the next level's only when the
+        levels differ by a whole factor. In between, the dashes still jump
+        rather than slide, but they land somewhere new when they do; the
+        smaller the step, the smaller and more frequent those jumps, until at
+        1.0 they merge into the continuous slide.
+
+        The size varies over a range of exactly this factor, so a larger step
+        buys stiller dashes at the cost of a less accurate size.
+        """
+        return self._store.dash_scale_step
+
+    @dash_scale_step.setter
+    def dash_scale_step(self, value):
+        value = float(value)
+        if value < 1.0:
+            raise ValueError(
+                f"LineMaterial.dash_scale_step must be at least 1, not {value!r}"
+            )
+        self._store.dash_scale_step = value
+
+    @property
+    def dash_max_scale(self):
+        """How large the dashes may grow before they split, when `dash_scaling`
+        is 'quantized'.
+
+        Expressed as a ratio to the size that `dash_pattern` asks for. The
+        dashes range over exactly `dash_scale_step`, from
+        `dash_max_scale / dash_scale_step` up to `dash_max_scale` times the
+        requested size; this property only chooses where that range sits.
+        It is clamped to lie between 1 and `dash_scale_step`.
+
+        The default, None, centres the range on the requested size, i.e.
+        ``sqrt(dash_scale_step)``, so that the dashes are never off by more
+        than that factor in either direction. Setting it to
+        `dash_scale_step` means the dashes are never finer than requested, and
+        setting it to 1 means they are never coarser.
+
+        Note that the hysteresis on the snap (see the `dash_scaling` docs) lets
+        the dashes overshoot the range slightly, so that a view parked on a
+        boundary does not flicker between two levels.
+        """
+        return self._store.dash_max_scale
+
+    @dash_max_scale.setter
+    def dash_max_scale(self, value):
+        if value is not None:
+            value = float(value)
+            if value < 1.0:
+                raise ValueError(
+                    f"LineMaterial.dash_max_scale must be at least 1, not {value!r}"
+                )
+        self._store.dash_max_scale = value
+
+    @property
+    def dash_scale_hysteresis(self):
+        """How far past a step boundary the view must go before the dash size
+        follows, when `dash_scaling` is 'quantized'.
+
+        In fractions of one `dash_scale_step`. The snap is a Schmitt trigger:
+        a segment keeps the size it has until the size it would ideally take is
+        this much beyond the boundary, which is what stops it flickering between
+        two sizes when the view sits near one. Measured at a boundary over 200
+        frames, with the default 0.1 against 0 (a plain threshold):
+
+        =============  =================  ===================
+        camera jitter  size changes at 0  size changes at 0.1
+        =============  =================  ===================
+        0.5%           108                0
+        5.0%           108                0
+        =============  =================  ===================
+
+        A monotonic zoom still changes size exactly once per step, just slightly
+        later than the nominal point. The price is that the dashes may stray
+        that much further from the size asked for: the range widens by
+        ``dash_scale_step ** dash_scale_hysteresis`` at each end, so at the
+        default step of 2 the bound goes from a factor of 1.41 to 1.52.
+
+        Set to 0 for a plain threshold, which is worth doing only to see the
+        flicker it exists to prevent.
+        """
+        return self._store.dash_scale_hysteresis
+
+    @dash_scale_hysteresis.setter
+    def dash_scale_hysteresis(self, value):
+        value = float(value)
+        if value < 0:
+            raise ValueError(
+                f"LineMaterial.dash_scale_hysteresis cannot be negative, got {value!r}"
+            )
+        self._store.dash_scale_hysteresis = value
+
+    @property
+    def dash_fit(self):
+        """Whether the dash pattern is stretched to fit the line pieces.
+
+        See :obj:`pygfx.utils.enums.DashFit`.
+
+        With the default 'exact', the dashes have exactly the size that
+        `dash_pattern` asks for, and the pattern simply stops wherever the line
+        piece happens to end. A closed piece therefore has a seam: the pattern
+        arrives back at its starting point mid-period, so the last stroke
+        before the join is the wrong length, or lands on top of the first one.
+
+        With 'stretch', each line piece is scaled by the small factor that
+        makes a whole number of periods span it, which removes the seam. A
+        closed piece joins up as though the pattern had been drawn for it; an
+        open one begins and ends with a full stroke.
+
+        Each nan-separated piece is fitted on its own, so pieces of different
+        lengths end up with slightly different dash sizes. That is the price:
+        the dash size is no longer the one `dash_pattern` asked for, but the
+        nearest one that divides the piece. The error is at most half a period
+        spread over the whole piece, so it is largest on short pieces -- a
+        piece shorter than one period is stretched to exactly one.
+
+        With 'spread', only the gaps give. The strokes keep exactly the size
+        `dash_pattern` asks for and the space between them is widened until the
+        piece is a whole number of periods long. The pattern is then a *floor*:
+        nothing is ever drawn smaller, or closer together, than asked for. Where
+        'stretch' would have compressed a piece to reach the nearest whole
+        number of periods, 'spread' drops to the next one down and widens the
+        gaps instead; when a piece has grown enough to take another stroke it
+        gets one, and the gaps snap back to their minimum.
+
+        A piece shorter than a single period cannot be fitted without drawing
+        something smaller than asked, so it is left alone and the pattern simply
+        runs off the end of it.
+
+        Note that the fit is to the pattern's *period*. With a `dash_offset`
+        that is not a whole number of periods, a closed piece still joins up,
+        but an open one no longer starts and ends on a stroke boundary.
+        """
+        return self._store.dash_fit
+
+    @dash_fit.setter
+    def dash_fit(self, value):
+        value = "exact" if value is None else str(value)
+        if value not in DashFit:
+            raise ValueError(
+                f"LineMaterial.dash_fit must be a string in {DashFit}, not {value!r}"
+            )
+        self._store.dash_fit = value
 
     @property
     def loop(self) -> bool:

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -43,7 +43,10 @@ class LineShader(BaseShader):
 
         self["line_type"] = "line"
         self["dashing"] = False
+        self["dash_fit"] = "exact"
         self["thickness_space"] = material.thickness_space
+        self["dash_scaling"] = "continuous"
+        self["cumdist_space"] = material.thickness_space
         self["aa"] = material._gfx_effective_aa
         self["loop"] = False
         self["debug"] = False
@@ -120,14 +123,36 @@ class LineShader(BaseShader):
             if not isinstance(material, LineSegmentMaterial):
                 self.needs_bake_function = True
                 self._cumdist_hash = None
+                self._dash_levels = None
+                self._dash_units = None
+                self._closing_dash_units = None
                 # Like the loop buffer, this buffer is one larger when looping, so
                 # that the node that closes a loop can store the cumulative distance
                 # of the full loop (see _bake_line_distance).
-                self.line_distance_buffer = Buffer(
-                    np.zeros(
-                        (geometry.positions.nitems + int(self["loop"]),), np.float32
-                    )
-                )
+                n_cumdist = geometry.positions.nitems + int(self["loop"])
+                self.line_distance_buffer = Buffer(np.zeros((n_cumdist,), np.float32))
+                # How much each piece's gaps are widened to make the pattern fit
+                # it, for `dash_fit="spread"`. One per node, constant within a
+                # piece. It is always present and always 1.0 unless spreading,
+                # rather than templated, so that changing `dash_fit` does not
+                # recompile the shader.
+                self.line_gap_scale_buffer = Buffer(np.ones((n_cumdist,), np.float32))
+                # A quantized dash pattern is baked in model space, so that it is
+                # anchored to the object and cannot slide; only its period follows
+                # the view scale, in powers of two. This only has an effect when
+                # the pattern is sized in screen space, because in the other
+                # thickness spaces the pattern is anchored to the object already.
+                if (
+                    material.dash_scaling == "quantized"
+                    and material.thickness_space == "screen"
+                ):
+                    self["dash_scaling"] = "quantized"
+                    self["cumdist_space"] = "model"
+
+                # Only "spread" needs the gap widening in the shader. Keeping it
+                # out of the other modes means their WGSL is byte-for-byte what
+                # it was, so their rendered output is too.
+                self["dash_fit"] = material.dash_fit
 
     def bake_function(self, wobject, camera, logical_size):
         if hasattr(self, "line_loop_buffer"):
@@ -198,6 +223,264 @@ class LineShader(BaseShader):
 
         loop_buffer.update_range(r_offset, r_size + 1)
 
+    def _get_model_units_per_pixel(self, wobject, camera, logical_size, positions):
+        """How many model units one logical pixel spans, at the middle of the line.
+
+        This is the same trick the shader uses for `thickness_ratio` (see
+        line.wgsl): take a reference point, shift it by one logical pixel on
+        screen, transform it back, and measure how far it moved in model space.
+        Under a perspective camera the answer varies along the line, which is
+        why the dash scale is taken per segment rather than once for the object.
+        """
+        finites = positions[np.isfinite(positions).all(axis=1)]
+        if len(finites) == 0:
+            return None
+        reference = 0.5 * (finites.min(axis=0) + finites.max(axis=0))
+
+        matrix = camera.camera_matrix @ wobject.world.matrix
+        try:
+            matrix_inv = np.linalg.inv(matrix)
+        except np.linalg.LinAlgError:
+            return None
+
+        # One logical pixel, in ndc. The bake maps ndc to logical pixels with
+        # `0.5 * logical_size`, so a pixel is `2 / logical_size` of ndc.
+        ndc = la.vec_transform(reference, matrix)
+        pixel_ndc = 2.0 / np.maximum(1.0, np.asarray(logical_size, float))
+
+        offset_x = np.array([pixel_ndc[0], 0.0, 0.0])
+        offset_y = np.array([0.0, pixel_ndc[1], 0.0])
+        origin = la.vec_transform(ndc, matrix_inv)
+        shifted_x = la.vec_transform(ndc + offset_x, matrix_inv)
+        shifted_y = la.vec_transform(ndc + offset_y, matrix_inv)
+        # Average the two, so that anisotropic scaling lands in the middle
+        units_per_pixel = 0.5 * (
+            np.linalg.norm(shifted_x - origin) + np.linalg.norm(shifted_y - origin)
+        )
+
+        if not np.isfinite(units_per_pixel) or units_per_pixel <= 0:
+            return None
+        return float(units_per_pixel)
+
+    def _get_screen_positions(self, wobject, camera, logical_size):
+        """The nodes of the drawn range, in logical pixels.
+
+        The same transform the continuous path bakes its cumdist from. The
+        quantized path needs it too, but only to measure how many pixels each
+        segment covers, which is what sets that segment's dash scale.
+        """
+        positions_buffer = wobject.geometry.positions
+        r_offset, r_size = positions_buffer.draw_range
+        positions = positions_buffer.data[r_offset : r_offset + r_size]
+        xyz = la.vec_transform(positions, camera.camera_matrix @ wobject.world.matrix)
+        return xyz[:, :2] * (0.5 * np.array(logical_size))
+
+    def _get_dash_units(self, material, model_distances, screen_distances):
+        """The length of one dash unit, in model units, for each segment.
+
+        The pattern wants one dash unit to cover `material.thickness` logical
+        pixels. How many model units that is differs from segment to segment
+        the moment the line has any extent along the view direction: a segment
+        running away from the camera covers fewer pixels per model unit than
+        one across the view. Taking one factor for the whole object -- which is
+        what this did at first -- gives the foreshortened segments the wrong
+        number of dashes, badly wrong once an object is turned edge-on.
+
+        Snapping that to a power of `material.dash_scale_step`, per segment, is
+        what makes the dashes hold still: for a whole-number step the dash
+        starts of one level are a subset of the next level's, so a change of
+        level splits each dash rather than moving it. Under a zoom every
+        segment's scale changes by the same factor, so the levels step together
+        and nothing slides; under a rotation they change by different factors,
+        which is exactly when the dashes *should* be redistributed.
+
+        The step is a continuous dial between the two behaviours. At 1 there is
+        no snapping at all and each segment's size follows the view exactly,
+        which reproduces `dash_scaling='continuous'` for *any* geometry rather
+        than only for geometry at a constant depth from the camera.
+
+        The snap has hysteresis, i.e. it is a Schmitt trigger: a level is kept
+        until the ideal level is clearly past the boundary. Without it a segment
+        sitting near a boundary would flip between two levels from frame to
+        frame and its dashes would stutter between splitting and merging. The
+        state is per segment, so it is dropped when the segment count changes.
+        """
+        thickness = material.thickness
+        with np.errstate(divide="ignore", invalid="ignore"):
+            # Model units per logical pixel, along each segment.
+            units_per_pixel = model_distances / screen_distances
+        # A segment of zero screen length (edge-on, or degenerate) has no
+        # defined scale; it also has no dashes to get wrong.
+        bad = ~np.isfinite(units_per_pixel) | (units_per_pixel <= 0)
+        units_per_pixel = np.where(bad, 1.0, units_per_pixel)
+        nominal = max(thickness, 1e-9) * units_per_pixel
+
+        step = material.dash_scale_step
+        if step <= 1.0:
+            # The limit of the snapping below, and the behaviour of
+            # dash_scaling='continuous': each size follows the view exactly.
+            self._dash_levels = None
+            return nominal
+
+        # Where in the step the size range sits. The ratio of the snapped size
+        # to the nominal one is step**(level - ideal), and level is the floor of
+        # (ideal + bias), so the ratio spans [step**(bias-1), step**bias]: the
+        # bias is the log of the largest scale allowed. None means centred.
+        max_scale = material.dash_max_scale
+        if max_scale is None:
+            bias = 0.5
+        else:
+            bias = np.log(min(max(max_scale, 1.0), step)) / np.log(step)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            biased = np.log(nominal) / np.log(step) + bias
+        biased = np.where(np.isfinite(biased), biased, 0.0)
+
+        previous = self._dash_levels
+        if previous is None or len(previous) != len(biased):
+            levels = np.floor(biased)
+        else:
+            hysteresis = material.dash_scale_hysteresis
+            keep = (previous - hysteresis <= biased) & (
+                biased < previous + 1.0 + hysteresis
+            )
+            levels = np.where(keep, previous, np.floor(biased))
+
+        self._dash_levels = levels
+        return step**levels
+
+    def _fit_dash_periods(
+        self, wobject, positions_buffer, r_offset, r_size, piece_starts, phase_per_unit
+    ):
+        """Scale each line piece so that a whole number of dash periods spans it.
+
+        Without this the pattern simply stops wherever the piece ends, which
+        leaves a closed piece with a visible seam: the pattern comes back round
+        to its start mid-period, so the stroke that closes the loop is the wrong
+        length or lands on top of the first one. Scaling the phase of a piece by
+        the small factor that makes it a whole number of periods removes that,
+        at the cost of a dash size that is no longer exactly the one asked for.
+
+        Open and closed pieces are fitted to different targets. A closed piece
+        wants a whole number of periods, so that the end of the pattern meets
+        its beginning. An open piece wants a whole number of periods *less its
+        final gap*, so that it both begins and ends with a full stroke rather
+        than trailing off into empty space.
+
+        The count is snapped differently under the two scalings, and for the
+        same reason the level is snapped in `_get_dash_unit`. Under 'continuous'
+        the nearest whole number is what is wanted. Under 'quantized' the count
+        is snapped to a power of `dash_scale_step` instead, because the whole
+        point of that mode is that a level change splits each dash rather than
+        moving it: a count on the power ladder is divisible by the step, so it
+        keeps that property, whereas the nearest whole number does not (7
+        periods cannot split into 14 and then back into 7 via a rounded halving).
+        """
+        material = wobject.material
+        pattern = material.dash_pattern
+        period = sum(pattern)
+        if period <= 0:
+            return
+        last_gap = pattern[-1]
+
+        data = self.line_distance_buffer.data
+        piece_bounds = np.append(np.flatnonzero(piece_starts), r_size)
+        starts, stops = piece_bounds[:-1], piece_bounds[1:]
+
+        # The phase span of a piece sits at its last node. Nodes across a nan
+        # carry the previous cumdist forward (their distances are zeroed), so
+        # for an open piece that is the last node before the next piece starts.
+        # A loop instead ends at its connector, which holds the length of the
+        # *closed* loop, and which is the first nan node after the loop.
+        span_index = stops - 1
+        is_closed = np.zeros(len(starts), bool)
+        if self["loop"]:
+            for i_first, _i_last, i_connector in self._get_loop_ranges(
+                positions_buffer
+            ):
+                (piece,) = np.nonzero(starts == i_first - r_offset)
+                span_index[piece] = i_connector - r_offset
+                is_closed[piece] = True
+
+        span = data[r_offset + span_index] * phase_per_unit
+
+        # How many periods the piece would like to hold, given its target.
+        with np.errstate(divide="ignore", invalid="ignore"):
+            wanted = np.where(is_closed, span, span + last_gap) / period
+        if self["dash_scaling"] == "quantized" and self._dash_levels is not None:
+            step = material.dash_scale_step
+            with np.errstate(divide="ignore", invalid="ignore"):
+                count = step ** np.round(np.log(wanted) / np.log(step))
+        else:
+            count = np.round(wanted)
+        count = np.maximum(np.nan_to_num(count, nan=1.0), 1.0)
+
+        if material.dash_fit == "spread":
+            return self._spread_dash_gaps(
+                material, data, r_offset, r_size, starts, stops, span, is_closed
+            )
+
+        target = count * period - np.where(is_closed, 0.0, last_gap)
+        # A pattern whose period is all gap (e.g. [0, 4]) has nothing to end on,
+        # so there is no sensible open-piece target; fall back to whole periods.
+        target = np.where(target > 0, target, count * period)
+
+        # A zero-length piece has no phase to scale, and nothing to show either.
+        scale = np.where(span > 0, target / np.where(span > 0, span, 1.0), 1.0)
+        data[r_offset : r_offset + r_size] *= np.repeat(scale, stops - starts)
+
+    def _spread_dash_gaps(
+        self, material, data, r_offset, r_size, starts, stops, span, is_closed
+    ):
+        """Fit by widening the gaps, leaving the strokes exactly as asked.
+
+        `stretch` scales the whole pattern, so reaching the *nearest* whole
+        number of periods often means compressing a piece: its strokes come out
+        shorter and closer together than `dash_pattern` asked for. Here the
+        pattern is a floor instead. The count is rounded *down*, so the piece
+        always holds at least as much room as the pattern wants, and the slack
+        left over is put into the gaps, which is the only part that may grow.
+
+        Solving for the gap factor k, with T the stroke total, G the gap total
+        and gl the final gap of one period:
+
+            closed piece:  span = n * (T + k * G)          -> k = (span/n - T) / G
+            open piece:    span = n * (T + k * G) - k * gl -> k = (span - n*T) / (n*G - gl)
+
+        and k >= 1 exactly when n <= (span + gl) / period, hence the floor. The
+        cumdist is left alone; k travels to the fragment shader in its own
+        buffer and widens `gap_sizes` there.
+        """
+        pattern = material.dash_pattern
+        strokes, gaps = pattern[::2], pattern[1::2]
+        stroke_total, gap_total = sum(strokes), sum(gaps)
+        last_gap = gaps[-1]
+
+        gap_scale = self.line_gap_scale_buffer.data
+        if gap_total <= 0:
+            # Nothing to widen: a pattern with no gaps cannot be spread.
+            gap_scale[r_offset : r_offset + r_size] = 1.0
+            self.line_gap_scale_buffer.update_range(r_offset, r_size)
+            return
+
+        period = stroke_total + gap_total
+        with np.errstate(divide="ignore", invalid="ignore"):
+            count = np.floor((span + np.where(is_closed, 0.0, last_gap)) / period)
+        count = np.maximum(np.nan_to_num(count, nan=1.0), 1.0)
+
+        denominator = np.where(
+            is_closed, count * gap_total, count * gap_total - last_gap
+        )
+        with np.errstate(divide="ignore", invalid="ignore"):
+            k = (span - count * stroke_total) / denominator
+        # A piece too short for even one period would need k < 1, i.e. drawing
+        # something smaller than asked. Leave those alone; the pattern runs off
+        # the end, which is what "exact" does everywhere.
+        k = np.where(np.isfinite(k), k, 1.0)
+        k = np.maximum(k, 1.0)
+
+        gap_scale[r_offset : r_offset + r_size] = np.repeat(k, stops - starts)
+        self.line_gap_scale_buffer.update_range(r_offset, r_size)
+
     def _bake_line_distance(self, wobject, camera, logical_size):
         # Prepare
         positions_buffer = wobject.geometry.positions
@@ -210,11 +493,35 @@ class LineShader(BaseShader):
         finites = np.isfinite(positions_array).all(axis=1)
         has_non_finites = not finites.all()
 
+        # A quantized pattern is measured in model space, and then divided by the
+        # length of one dash unit, so that the buffer holds the phase directly.
+        # That length follows the view scale, but only in powers of two, so it
+        # changes rarely: the whole bake can be skipped while the level holds.
+        quantized = self["dash_scaling"] == "quantized"
+
         # Get vertices in the appropriate coordinate frame
-        if wobject.material.thickness_space == "model":
-            # Skip this step if the position data has not changed
-            cumdist_hash = (id(positions_buffer), positions_buffer.rev)
-            if cumdist_hash == self._cumdist_hash:
+        if self["cumdist_space"] == "model":
+            # Skip this step if neither the positions nor the level have changed
+            fit = wobject.material.dash_fit
+            cumdist_hash = (
+                id(positions_buffer),
+                positions_buffer.rev,
+                # Fitting depends on the pattern and the thickness, which the
+                # plain model-space cumdist does not; without these, changing
+                # either would be silently skipped by the early-out below. They
+                # are left out when not fitting, so that the default path still
+                # re-bakes only when the positions move.
+                fit,
+                *(
+                    (wobject.material.dash_pattern, wobject.material.thickness)
+                    if fit == "stretch"
+                    else ()
+                ),
+            )
+            if cumdist_hash == self._cumdist_hash and not quantized:
+                # A quantized bake depends on the camera as well, through the
+                # per-segment scale, so it cannot take this shortcut. Its own
+                # early-out is below, once the levels are known.
                 return
             self._cumdist_hash = cumdist_hash
             vertex_array = positions_array
@@ -225,7 +532,7 @@ class LineShader(BaseShader):
             else:
                 positions_array_sub = positions_array
             # Transform
-            if wobject.material.thickness_space == "world":
+            if self["cumdist_space"] == "world":
                 vertex_array_sub = la.vec_transform(
                     positions_array_sub, wobject.world.matrix
                 )
@@ -250,6 +557,56 @@ class LineShader(BaseShader):
         distances = np.linalg.norm(vertex_array[1:] - vertex_array[:-1], axis=1)
         distances[~np.isfinite(distances)] = 0.0
 
+        # Convert model units to dash units, per segment. One dash unit spans
+        # `thickness` logical pixels, which is a different number of model units
+        # for a segment running away from the camera than for one across the
+        # view, so the conversion cannot be a single factor for the object. It
+        # is snapped to a power of `dash_scale_step`, which is what keeps the
+        # dashes from sliding: a change of level splits each dash in place.
+        if quantized:
+            screen = self._get_screen_positions(wobject, camera, logical_size)
+            screen_distances = np.linalg.norm(screen[1:] - screen[:-1], axis=1)
+            screen_distances[~np.isfinite(screen_distances)] = 0.0
+
+            # The segment that closes a loop is not one of the pairs above, and
+            # is foreshortened independently of them, so it needs a scale of its
+            # own. Appending them here rather than treating them separately
+            # keeps one array of levels, and so one consistent hysteresis state.
+            loop_ranges = (
+                self._get_loop_ranges(positions_buffer) if self["loop"] else []
+            )
+            closing_model = np.array(
+                [
+                    np.linalg.norm(
+                        vertex_array[i_last - r_offset]
+                        - vertex_array[i_first - r_offset]
+                    )
+                    for i_first, i_last, _ in loop_ranges
+                ],
+                np.float64,
+            ).reshape(-1)
+            closing_screen = np.array(
+                [
+                    np.linalg.norm(
+                        screen[i_last - r_offset] - screen[i_first - r_offset]
+                    )
+                    for i_first, i_last, _ in loop_ranges
+                ],
+                np.float64,
+            ).reshape(-1)
+            closing_model[~np.isfinite(closing_model)] = 0.0
+            closing_screen[~np.isfinite(closing_screen)] = 0.0
+
+            n_open = len(distances)
+            units = self._get_dash_units(
+                wobject.material,
+                np.concatenate([distances, closing_model]),
+                np.concatenate([screen_distances, closing_screen]),
+            )
+            self._dash_units = units[:n_open]
+            self._closing_dash_units = units[n_open:]
+            distances = distances / self._dash_units
+
         # Store cumulatives
         distance_array[0] = 0.0
         np.cumsum(distances, out=distance_array[1:])
@@ -260,10 +617,10 @@ class LineShader(BaseShader):
         # the total length of all preceding pieces, which makes the dashes of the
         # later pieces race ahead as soon as anything (e.g. the zoom level) changes
         # that length. This matches how SVG restarts its dashes at each subpath.
+        # A node starts a piece if it is finite and the node before it is not.
+        piece_starts = np.zeros(len(distance_array), bool)
+        piece_starts[0] = True
         if has_non_finites:
-            # A node starts a piece if it is finite and the node before it is not.
-            piece_starts = np.empty(len(distance_array), bool)
-            piece_starts[0] = True
             np.logical_and(finites[1:], ~finites[:-1], out=piece_starts[1:])
             # The cumdist is non-decreasing, so a running maximum of the cumdist at
             # the piece starts (and zero elsewhere) gives, for each node, the cumdist
@@ -279,16 +636,42 @@ class LineShader(BaseShader):
         # the whole loop, making its dashes much denser. See gh-1103.
         if self["loop"]:
             full_distance_array = self.line_distance_buffer.data
-            for i_first, i_last, i_connector in self._get_loop_ranges(positions_buffer):
+            for i_loop, (i_first, i_last, i_connector) in enumerate(
+                self._get_loop_ranges(positions_buffer)
+            ):
                 closing_distance = np.linalg.norm(
                     vertex_array[i_last - r_offset] - vertex_array[i_first - r_offset]
                 )
                 if not np.isfinite(closing_distance):
                     closing_distance = 0.0
+                if quantized:
+                    closing_distance /= self._closing_dash_units[i_loop]
                 full_distance_array[i_connector] = (
                     full_distance_array[i_last] + closing_distance
                 )
             r_size += 1  # the connector of the last loop can sit just past the range
+
+        # Stretch each piece a little, so that a whole number of dash periods
+        # spans it and the pattern has no seam. The cumdist is a phase, so this
+        # is just a per-piece factor on the values already computed; the shader
+        # is not involved. One dash unit is `thickness` of whatever the cumdist
+        # is measured in, except under quantization, where the division above
+        # has already put the buffer in dash units.
+        if wobject.material.dash_fit != "spread":
+            gap_scale = self.line_gap_scale_buffer.data
+            if np.any(gap_scale[r_offset : r_offset + r_size] != 1.0):
+                gap_scale[r_offset : r_offset + r_size] = 1.0
+                self.line_gap_scale_buffer.update_range(r_offset, r_size)
+
+        if wobject.material.dash_fit in ("stretch", "spread"):
+            self._fit_dash_periods(
+                wobject,
+                positions_buffer,
+                r_offset,
+                r_size,
+                piece_starts,
+                1.0 if quantized else 1.0 / wobject.material.thickness,
+            )
 
         # Mark that the data has changed
         self.line_distance_buffer.update_range(r_offset, r_size)
@@ -348,6 +731,9 @@ class LineShader(BaseShader):
         if hasattr(self, "line_distance_buffer"):
             bindings.append(
                 Binding("s_cumdist", rbuffer, self.line_distance_buffer, "VERTEX")
+            )
+            bindings.append(
+                Binding("s_gapscale", rbuffer, self.line_gap_scale_buffer, "VERTEX")
             )
 
         bindings = {i: b for i, b in enumerate(bindings)}

--- a/pygfx/renderers/wgpu/wgsl/line.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/line.wgsl
@@ -366,11 +366,11 @@ fn vs_main(in: VertexInput) -> Varyings {
             var cumdist_other = 0.0;
         $$ else
             let cumdist_before = 0.0;
-            $$ if thickness_space == 'screen'
+            $$ if cumdist_space == 'screen'
             let cumdist_after = length(pos_s_node.xy - select(pos_s_prev.xy, pos_s_next.xy, node_index_is_even));
-            $$ elif thickness_space == 'world'
+            $$ elif cumdist_space == 'world'
             let cumdist_after = length(pos_w_node.xyz - select(pos_w_prev.xyz, pos_w_next.xyz, node_index_is_even));
-            $$ elif thickness_space == 'model'
+            $$ elif cumdist_space == 'model'
             let cumdist_after = length(pos_m_node.xyz - select(pos_m_prev.xyz, pos_m_next.xyz, node_index_is_even));
             $$ endif
             let cumdist_node = select(cumdist_before, cumdist_after, !node_index_is_even);
@@ -702,9 +702,12 @@ fn vs_main(in: VertexInput) -> Varyings {
     $$ if dashing
         // Set two varyings, so that we can correctly interpolate the cumdist in the joins.
         // If the thickness is in screen space, we need to correct for perspective division
-        varyings.cumdist_node = f32(cumdist_node)  {{ '* w' if thickness_space == 'screen' else '' }};
-        varyings.cumdist_vertex = f32(cumdist_vertex)  {{ '* w' if thickness_space == 'screen' else '' }};
-        varyings.cumdist_per_pixel = f32( abs(cumdist_node - cumdist_other) / length(pos_s_node - pos_s_other) / l2p )  {{ '' if thickness_space == 'screen' else '* (pos_n_node.w / pos_n_other.w) / w' }};
+        $$ if dash_fit == 'spread'
+        varyings.gap_scale = f32(load_s_gapscale(cumdist_index));
+        $$ endif
+        varyings.cumdist_node = f32(cumdist_node)  {{ '* w' if cumdist_space == 'screen' else '' }};
+        varyings.cumdist_vertex = f32(cumdist_vertex)  {{ '* w' if cumdist_space == 'screen' else '' }};
+        varyings.cumdist_per_pixel = f32( abs(cumdist_node - cumdist_other) / length(pos_s_node - pos_s_other) / l2p )  {{ '' if cumdist_space == 'screen' else '* (pos_n_node.w / pos_n_other.w) / w' }};
     $$ endif
 
     // Picking
@@ -837,7 +840,7 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
             // In a segment everything is straight.
             cumdist_continuous = varyings.cumdist_vertex;
         }
-        $$ if thickness_space == 'screen'
+        $$ if cumdist_space == 'screen'
             cumdist_continuous = cumdist_continuous / varyings.w;
             cumdist_per_pixel = varyings.cumdist_per_pixel;
         $$ else
@@ -850,7 +853,11 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
         var gap_sizes = array<f32,dash_count>{{dash_pattern[1::2]}};
         for (var i=0; i<dash_count; i+=1) {
             stroke_sizes[i] = stroke_sizes[i];
-            gap_sizes[i] = gap_sizes[i];
+            $$ if dash_fit == 'spread'
+            // Widening only the gaps is what lets a pattern be fitted to a
+            // piece without the strokes changing size.
+            gap_sizes[i] = gap_sizes[i] * varyings.gap_scale;
+            $$ endif
         }
 
         // Calculate the total dash size, and the size of the last gap. The dash_count is a const
@@ -864,7 +871,14 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
 
         // Calculate dash_progress, a number 0..dash_size, indicating the fase of the dash.
         // Except that we shift it, so that half of the final gap gets in front (as a negative number).
-        let cumdist_corrected = cumdist_continuous / u_material.thickness + u_material.dash_offset % dash_size;
+        $$ if dash_scaling == 'quantized'
+            // The baked cumdist is already in dash units. The offset is in whole
+            // periods, because only a whole number of periods leaves the dashes
+            // in place when the period changes.
+            let cumdist_corrected = cumdist_continuous + (u_material.dash_offset % 1.0) * dash_size;
+        $$ else
+            let cumdist_corrected = cumdist_continuous / u_material.thickness + u_material.dash_offset % dash_size;
+        $$ endif
         let dash_progress = (cumdist_corrected + 0.5 * last_gap) % dash_size - 0.5 * last_gap;
 
         // Its looks a bit like this. Now we select the nearest stroke, and calculate the
@@ -900,7 +914,11 @@ fn fs_main(varyings: Varyings, @builtin(front_facing) is_front: bool) -> Fragmen
         let dist_to_dash = max(0.0, max(dist_to_begin, dist_to_end));
 
         // Convert to (physical) pixel units
-        let dashdist_to_physical = u_material.thickness / cumdist_per_pixel;
+        $$ if dash_scaling == 'quantized'
+            let dashdist_to_physical = 1.0 / cumdist_per_pixel;
+        $$ else
+            let dashdist_to_physical = u_material.thickness / cumdist_per_pixel;
+        $$ endif
         let dist_to_begin_p = dist_to_begin * dashdist_to_physical;
         let dist_to_end_p = dist_to_end * dashdist_to_physical;
         let dist_to_dash_p = dist_to_dash * dashdist_to_physical;

--- a/pygfx/utils/enums.py
+++ b/pygfx/utils/enums.py
@@ -10,6 +10,8 @@ The enums used in pygfx. The enums are all available from the root ``pygfx`` nam
     BindMode
     ColorMode
     CoordSpace
+    DashFit
+    DashScaling
     EdgeMode
     ElementFormat
     InterpolationFilter
@@ -32,6 +34,8 @@ __all__ = [
     "BindMode",
     "ColorMode",
     "CoordSpace",
+    "DashFit",
+    "DashScaling",
     "EdgeMode",
     "ElementFormat",
     "InterpolationFilter",
@@ -129,6 +133,21 @@ class CoordSpace(Enum):
     model = None  #: The space relative to the object. When the object (or a parent) is e.g. scaled with ``wobject.local.scale = 2`` the thing becomes bigger.
     world = None  #: The space of the scene (the root object). Scaling or rotating of objects does not affect the thing's size or orientation.
     screen = None  #: The screen space (in logical pixels). The thing's size is not affected by zooming or scaling.
+
+
+class DashFit(Enum):
+    """The DashFit enum specifies whether a line's dash pattern is adjusted to fit its line pieces."""
+
+    exact = None  #: The dashes have exactly the size that ``dash_pattern`` asks for. Where a line piece is not a whole number of periods long -- which is almost always -- the pattern is cut off mid-period at the end, and on a closed piece the two ends of the pattern do not meet.
+    stretch = None  #: The pattern is scaled, per line piece, by the small factor that makes a whole number of periods span the piece. A closed piece then joins up seamlessly, and an open one begins and ends with a full stroke. The dash size is no longer exactly the one asked for, and differs between pieces of different lengths.
+    spread = None  #: As 'stretch', but only the gaps give: the strokes keep exactly the size ``dash_pattern`` asks for, and the space between them is widened until a whole number of periods spans the piece. The pattern is therefore a floor -- nothing is ever drawn smaller or closer together than asked -- and a piece that has grown enough to take another stroke gets one, which returns the gaps to their minimum.
+
+
+class DashScaling(Enum):
+    """The DashScaling enum specifies how a line's dash pattern behaves when the view scale changes."""
+
+    continuous = None  #: The dash pattern keeps the size given by ``dash_pattern`` and ``thickness_space``. When ``thickness_space`` is 'screen', the on-screen dash size is constant, but the dashes slide along the line as you zoom, increasingly so with the distance from the start of the line.
+    quantized = None  #: The dash pattern is anchored to the object, and its period is snapped to a power of two so that its on-screen size stays close to the size that ``dash_pattern`` asks for. The dashes do not move when you zoom: each time the view scale doubles, every dash splits in two.
 
 
 class MarkerShape(Enum):

--- a/tests/renderers/test_line_dashing.py
+++ b/tests/renderers/test_line_dashing.py
@@ -6,6 +6,7 @@ values have exact expected answers, which makes the assertions sharp.
 """
 
 import numpy as np
+import pytest
 import pygfx as gfx
 from pygfx.renderers.wgpu.shaders.lineshader import LineShader
 
@@ -131,6 +132,746 @@ def test_cumdist_with_nonfinites_in_other_thickness_spaces():
         assert np.all(np.isfinite(cumdist))
         assert cumdist[0] == 0
         assert cumdist[4] > cumdist[3] > 0
+
+
+# ----- quantized dash scaling
+
+
+def bake_quantized(positions, view_width, thickness=10.0, logical_size=(1000, 1000)):
+    """Bake with dash_scaling='quantized' at a given ortho camera width."""
+    line = gfx.Line(
+        gfx.Geometry(positions=positions),
+        gfx.LineMaterial(
+            thickness=thickness,
+            dash_pattern=[2, 2],
+            thickness_space="screen",
+            dash_scaling="quantized",
+        ),
+    )
+    camera = gfx.OrthographicCamera(view_width, view_width)
+    shader = LineShader(line)
+    shader.bake_function(line, camera, logical_size)
+    return shader.line_distance_buffer.data.copy(), shader._dash_levels[0]
+
+
+def test_dash_scaling_only_applies_to_screen_space():
+    """In model/world space the pattern is anchored to the object already."""
+    positions = np.array([[0, 0, 0], [10, 0, 0]], np.float32)
+    for thickness_space in ["model", "world"]:
+        line = gfx.Line(
+            gfx.Geometry(positions=positions),
+            gfx.LineMaterial(
+                thickness=1,
+                dash_pattern=[2, 2],
+                thickness_space=thickness_space,
+                dash_scaling="quantized",
+            ),
+        )
+        shader = LineShader(line)
+        assert shader["dash_scaling"] == "continuous"
+        assert shader["cumdist_space"] == thickness_space
+
+
+def test_quantized_period_is_a_power_of_two_of_model_units():
+    """One dash unit spans 2**level model units, whatever the zoom."""
+    positions = np.array([[0, 0, 0], [100, 0, 0]], np.float32)
+    for view_width, expected_level in [(400, 2), (200, 1), (100, 0), (50, -1)]:
+        cumdist, level = bake_quantized(positions, view_width)
+        assert level == expected_level
+        # cumdist is in dash units, so the far node sits at length / 2**level
+        assert np.allclose(cumdist[1], 100.0 / 2.0**level)
+
+
+def test_quantized_dashes_split_rather_than_slide():
+    """Every dash edge of a coarser level survives at the next finer level.
+
+    This is the property that makes the dashes appear to split in two rather
+    than travel along the line when the view scale changes.
+    """
+    positions = np.array([[0, 0, 0], [100, 0, 0]], np.float32)
+    dash_size = 4.0
+
+    def edges(view_width):
+        cumdist, _ = bake_quantized(positions, view_width)
+        # phase is linear in x along this straight line
+        model_per_period = dash_size * 100.0 / cumdist[1]
+        return np.arange(0, 100.0 + 1e-9, model_per_period)
+
+    previous = None
+    for view_width in np.linspace(320, 160, 17):  # a smooth 2x zoom in
+        current = edges(view_width)
+        if previous is not None:
+            # every old edge must still be an edge, to within float error
+            distance = np.abs(previous[:, None] - current[None, :]).min(axis=1)
+            assert distance.max() < 1e-3, f"a dash edge moved by {distance.max()}"
+        previous = current
+
+
+def test_quantized_on_screen_size_stays_near_the_requested_one():
+    """Rounding the log2 keeps the dash unit within sqrt(2) of `thickness`."""
+    positions = np.array([[0, 0, 0], [100, 0, 0]], np.float32)
+    thickness, logical = 10.0, 1000
+    for view_width in np.geomspace(40, 400, 25):
+        _, level = bake_quantized(positions, view_width, thickness=thickness)
+        model_units_per_pixel = view_width / logical
+        on_screen = 2.0**level / model_units_per_pixel
+        assert (
+            thickness / np.sqrt(2) - 1e-6 <= on_screen <= thickness * np.sqrt(2) + 1e-6
+        )
+
+
+def test_quantized_level_does_not_flicker_at_a_boundary():
+    """The level snap has hysteresis, so a view parked on a boundary is stable.
+
+    Without it, jitter of a fraction of a percent flips the level on more than
+    half of all frames, and the dashes stutter between splitting and merging.
+    """
+    positions = np.array([[0, 0, 0], [100, 0, 0]], np.float32)
+    line = gfx.Line(
+        gfx.Geometry(positions=positions),
+        gfx.LineMaterial(
+            thickness=10,
+            dash_pattern=[2, 2],
+            thickness_space="screen",
+            dash_scaling="quantized",
+        ),
+    )
+    shader = LineShader(line)
+    # thickness * view_width / logical_size == 2 ** (level + 0.5) at a boundary
+    boundary = 100 * 2**0.5
+    rng = np.random.default_rng(0)
+
+    levels = []
+    for _ in range(200):
+        view_width = boundary * (1 + rng.uniform(-0.05, 0.05))
+        shader.bake_function(
+            line, gfx.OrthographicCamera(view_width, view_width), (1000, 1000)
+        )
+        levels.append(shader._dash_levels[0])
+    assert len(set(levels)) == 1, f"level flickered between {sorted(set(levels))}"
+
+
+def test_dash_scale_hysteresis_is_a_material_property():
+    """Turning it off must bring the flicker back, and up must damp harder.
+
+    The default exists to stop a segment sitting near a step boundary from
+    flipping between two sizes frame to frame. Setting it to zero makes the snap
+    a plain threshold, which is the behaviour it was added to replace.
+    """
+    positions = np.array([[0, 0, 0], [100, 0, 0]], np.float32)
+
+    def level_changes(hysteresis):
+        material = gfx.LineMaterial(
+            thickness=10,
+            dash_pattern=[2, 2],
+            thickness_space="screen",
+            dash_scaling="quantized",
+            dash_scale_hysteresis=hysteresis,
+        )
+        line = gfx.Line(gfx.Geometry(positions=positions), material)
+        shader = LineShader(line)
+
+        # Park the view exactly on a boundary and jitter it.
+        boundary = 100 * 2**0.5
+        rng = np.random.default_rng(0)
+        levels = []
+        for _ in range(200):
+            width = boundary * (1 + 0.01 * rng.uniform(-1, 1))
+            camera = gfx.OrthographicCamera(width, width)
+            camera.set_view_size(1000, 1000)
+            shader.bake_function(line, camera, (1000, 1000))
+            levels.append(float(shader._dash_levels[0]))
+        return int(np.count_nonzero(np.diff(levels)))
+
+    assert gfx.LineMaterial().dash_scale_hysteresis == 0.1
+    assert level_changes(0.1) == 0, "the default must hold the size steady"
+    assert level_changes(0.0) > 10, "without it, a plain threshold must flicker"
+
+
+def test_quantized_level_still_follows_a_real_zoom():
+    """Hysteresis must delay a level change, not prevent it."""
+    positions = np.array([[0, 0, 0], [100, 0, 0]], np.float32)
+    line = gfx.Line(
+        gfx.Geometry(positions=positions),
+        gfx.LineMaterial(
+            thickness=10,
+            dash_pattern=[2, 2],
+            thickness_space="screen",
+            dash_scaling="quantized",
+        ),
+    )
+    shader = LineShader(line)
+    levels = []
+    for view_width in np.geomspace(400, 50, 60):  # a 3-octave zoom in
+        shader.bake_function(
+            line, gfx.OrthographicCamera(view_width, view_width), (1000, 1000)
+        )
+        levels.append(shader._dash_levels[0])
+    # Monotonically decreasing, one step at a time, spanning three octaves
+    steps = np.diff(levels)
+    assert set(np.unique(steps)) <= {0, -1}
+    assert levels[0] - levels[-1] == 3
+
+
+def test_dash_max_scale_places_the_size_range():
+    """`dash_max_scale` chooses where the factor-of-two band sits.
+
+    The band is always exactly one octave wide -- that is what makes a level
+    change split each dash rather than move it -- so the only freedom is where
+    it sits relative to the size that `dash_pattern` asks for.
+    """
+    positions = np.array([[0, 0, 0], [100, 0, 0]], np.float32)
+    thickness, logical = 10.0, 1000
+    overshoot = (
+        2 ** gfx.LineMaterial().dash_scale_hysteresis
+    )  # hysteresis lets it stray this much
+
+    for dash_max_scale in [1.0, 2**0.5, 2.0]:
+        line = gfx.Line(
+            gfx.Geometry(positions=positions),
+            gfx.LineMaterial(
+                thickness=thickness,
+                dash_pattern=[2, 2],
+                thickness_space="screen",
+                dash_scaling="quantized",
+                dash_max_scale=dash_max_scale,
+            ),
+        )
+        shader = LineShader(line)
+        ratios, levels = [], []
+        for view_width in np.geomspace(400, 25, 400):  # four octaves of zoom
+            shader.bake_function(
+                line, gfx.OrthographicCamera(view_width, view_width), (logical, logical)
+            )
+            ratios.append(
+                2.0 ** shader._dash_levels[0] / (view_width / logical) / thickness
+            )
+            levels.append(shader._dash_levels[0])
+
+        # the level only ever steps down, one at a time
+        assert set(np.diff(levels)) <= {0, -1}
+        # and the size stays inside the octave, give or take the hysteresis
+        assert min(ratios) >= dash_max_scale / 2 / overshoot - 1e-6
+        assert max(ratios) <= dash_max_scale * overshoot + 1e-6
+        # the band really is a factor of two wide, not something narrower
+        assert max(ratios) / min(ratios) > 1.5
+
+
+def test_dash_max_scale_default_matches_round():
+    """The default sqrt(2) is exactly the `round(log2(...))` behaviour."""
+    positions = np.array([[0, 0, 0], [100, 0, 0]], np.float32)
+    for view_width, expected_level in [(400, 2), (200, 1), (100, 0), (50, -1)]:
+        _, level = bake_quantized(positions, view_width)
+        assert level == expected_level
+
+
+def test_dash_scaling_parameters_are_validated():
+    material = gfx.LineMaterial(dash_pattern=[2, 2])
+    assert material.dash_scale_step == 2.0
+    assert material.dash_max_scale is None  # i.e. centred on the requested size
+    with pytest.raises(ValueError):
+        material.dash_scale_step = 0.9
+    with pytest.raises(ValueError):
+        material.dash_max_scale = 0.9
+
+
+def test_dash_scale_step_one_reproduces_continuous():
+    """The old behaviour is a value of the new parameter, not a separate mode.
+
+    Exact at the nodes for any camera and any geometry, since the scale is
+    taken per segment. See test_dash_scale_step_one_reproduces_continuous_in_3d
+    for the case that used to be about 50% out.
+    """
+    positions = np.array([[0, 0, 0], [100, 0, 0]], np.float32)
+    thickness = 10.0
+
+    def far_node(dash_scaling, view_width, step=1.0):
+        material = gfx.LineMaterial(
+            thickness=thickness,
+            dash_pattern=[2, 2],
+            thickness_space="screen",
+            dash_scaling=dash_scaling,
+        )
+        if dash_scaling == "quantized":
+            material.dash_scale_step = step
+        line = gfx.Line(gfx.Geometry(positions=positions), material)
+        shader = LineShader(line)
+        shader.bake_function(
+            line, gfx.OrthographicCamera(view_width, view_width), (1000, 1000)
+        )
+        value = shader.line_distance_buffer.data[1]
+        # continuous keeps screen pixels and divides by thickness in the
+        # shader; quantized bakes dash units directly
+        return value / thickness if dash_scaling == "continuous" else value
+
+    for view_width in np.geomspace(400, 40, 40):
+        reference = far_node("continuous", view_width)
+        assert np.isclose(far_node("quantized", view_width, 1.0), reference, rtol=1e-5)
+
+
+def test_dash_scale_step_dials_smoothly_away_from_continuous():
+    """A larger step departs further from the requested size, monotonically."""
+    positions = np.array([[0, 0, 0], [100, 0, 0]], np.float32)
+    thickness, logical = 10.0, 1000
+
+    def worst_deviation(step):
+        material = gfx.LineMaterial(
+            thickness=thickness,
+            dash_pattern=[2, 2],
+            thickness_space="screen",
+            dash_scaling="quantized",
+        )
+        material.dash_scale_step = step
+        line = gfx.Line(gfx.Geometry(positions=positions), material)
+        shader = LineShader(line)
+        worst = 0.0
+        for view_width in np.geomspace(400, 40, 60):
+            shader.bake_function(
+                line, gfx.OrthographicCamera(view_width, view_width), (logical, logical)
+            )
+            ratio = shader._dash_units[0] / (thickness * view_width / logical)
+            worst = max(worst, abs(ratio - 1))
+        return worst
+
+    deviations = [worst_deviation(step) for step in [1.0, 1.1, 1.5, 2.0]]
+    assert deviations[0] < 1e-6  # step 1 is exactly the requested size
+    assert deviations == sorted(deviations)  # and it grows with the step
+
+
+def test_dash_scale_step_sets_the_width_of_the_size_range():
+    """The dash size ranges over exactly one step, whatever the step is."""
+    positions = np.array([[0, 0, 0], [100, 0, 0]], np.float32)
+    thickness, logical = 10.0, 1000
+    overshoot = 2 ** gfx.LineMaterial().dash_scale_hysteresis
+
+    for step in [1.5, 2.0, 3.0]:
+        material = gfx.LineMaterial(
+            thickness=thickness,
+            dash_pattern=[2, 2],
+            thickness_space="screen",
+            dash_scaling="quantized",
+        )
+        material.dash_scale_step = step
+        line = gfx.Line(gfx.Geometry(positions=positions), material)
+        shader = LineShader(line)
+        ratios = []
+        for view_width in np.geomspace(400, 400 / step**4, 400):
+            shader.bake_function(
+                line, gfx.OrthographicCamera(view_width, view_width), (logical, logical)
+            )
+            ratios.append(shader._dash_units[0] / (thickness * view_width / logical))
+        observed = max(ratios) / min(ratios)
+        assert step / overshoot < observed <= step * overshoot
+
+
+def test_quantized_levels_change_rarely_even_though_the_bake_runs():
+    """The bake runs every frame; what has to be stable is the level.
+
+    The scale is per segment, so it depends on where the camera is and the bake
+    cannot be skipped the way it could when one factor served the whole object.
+    What makes the dashes hold still is not the bake being skipped but the level
+    being snapped: a small zoom must leave it alone, a large one must move it.
+    """
+    positions = np.array([[0, 0, 0], [100, 0, 0]], np.float32)
+    line = gfx.Line(
+        gfx.Geometry(positions=positions),
+        gfx.LineMaterial(
+            thickness=10,
+            dash_pattern=[2, 2],
+            thickness_space="screen",
+            dash_scaling="quantized",
+        ),
+    )
+    shader = LineShader(line)
+
+    def level(view_width):
+        camera = gfx.OrthographicCamera(view_width, view_width)
+        camera.set_view_size(1000, 1000)
+        shader.bake_function(line, camera, (1000, 1000))
+        return float(shader._dash_levels[0])
+
+    first = level(200)
+    assert level(190) == first, "a small zoom should not change the level"
+    assert level(100) != first, "a 2x zoom should change the level"
+
+
+def test_quantized_scale_is_per_segment_not_per_object():
+    """A foreshortened segment must get its own dash size, not the object's.
+
+    Two segments of equal *model* length, one across the view and one running
+    away from the camera, cover very different numbers of pixels. A single
+    factor for the whole object gives the receding one far too many dashes,
+    which is what an edge-on cube used to look like.
+    """
+    # One piece per segment, so that each is measured on its own.
+    positions = np.vstack(
+        [
+            np.array([[-80, 0, 0], [80, 0, 0]], np.float32),  # across the view
+            NAN,
+            np.array([[0, 0, 60], [0, 0, -100]], np.float32),  # running away
+        ]
+    ).astype(np.float32)
+
+    camera = gfx.PerspectiveCamera(50, 1.0)
+    camera.local.position = (0, 120, 260)
+    camera.look_at((0, 0, 0))
+    camera.set_view_size(600, 600)
+
+    def bake_with(**kwargs):
+        material = gfx.LineMaterial(
+            thickness=10, dash_pattern=[2, 2], thickness_space="screen", **kwargs
+        )
+        line = gfx.Line(gfx.Geometry(positions=positions), material)
+        shader = LineShader(line)
+        shader.bake_function(line, camera, (600, 600))
+        data = shader.line_distance_buffer.data
+        # phase spanned by each of the two pieces
+        return float(data[1]), float(data[4])
+
+    across_c, away_c = bake_with()
+    across_q, away_q = bake_with(dash_scaling="quantized", dash_scale_step=1.0)
+
+    # Continuous bakes screen pixels; the shader divides by thickness. At step 1
+    # the quantized path must land on exactly the same phase for both segments.
+    assert across_q == pytest.approx(across_c / 10.0, rel=1e-4)
+    assert away_q == pytest.approx(away_c / 10.0, rel=1e-4)
+
+    # And the receding segment must hold far fewer periods than the other,
+    # because it covers far fewer pixels despite being longer in model space.
+    assert away_q < across_q
+
+
+def test_dash_scale_step_one_reproduces_continuous_in_3d():
+    """The equivalence must hold for an object with depth, from any angle.
+
+    This is what the per-segment scale buys. With one factor per object it was
+    about 50% out on a cube even under an orthographic camera, because a cube
+    spans depth from every angle and one factor cannot serve its near and far
+    edges at once.
+    """
+    corners = [(-50, -50), (50, -50), (50, 50), (-50, 50)]
+    pieces = [
+        np.array([[x, y, -50] for x, y in corners], np.float32),
+        np.array([[x, y, 50] for x, y in corners], np.float32),
+        *[np.array([[x, y, -50], [x, y, 50]], np.float32) for x, y in corners],
+    ]
+    stacked = [pieces[0]]
+    for piece in pieces[1:]:
+        stacked += [NAN, piece]
+    cube = np.vstack(stacked).astype(np.float32)
+
+    def phase(camera, **kwargs):
+        material = gfx.LineMaterial(
+            thickness=8,
+            dash_pattern=[2, 2],
+            thickness_space="screen",
+            loop=True,
+            **kwargs,
+        )
+        line = gfx.Line(gfx.Geometry(positions=cube), material)
+        shader = LineShader(line)
+        shader.bake_function(line, camera, (600, 600))
+        data = shader.line_distance_buffer.data.copy()
+        return data if kwargs.get("dash_scaling") == "quantized" else data / 8.0
+
+    for position in [(120, 90, 200), (260, 0, 20), (30, 240, 60), (0, 0, 300)]:
+        camera = gfx.PerspectiveCamera(50, 1.0)
+        camera.local.position = position
+        camera.look_at((0, 0, 0))
+        camera.set_view_size(600, 600)
+
+        reference = phase(camera)
+        quantized = phase(camera, dash_scaling="quantized", dash_scale_step=1.0)
+        usable = np.isfinite(reference) & np.isfinite(quantized) & (reference > 1e-6)
+        deviation = np.max(
+            np.abs(quantized[usable] - reference[usable]) / reference[usable]
+        )
+        assert deviation < 1e-4, f"from {position}: {deviation:.4%}"
+
+
+# The period of the [2, 2] pattern that `bake` uses, and its final gap.
+PERIOD = 4.0
+LAST_GAP = 2.0
+
+
+def test_dash_fit_stretches_a_loop_to_whole_periods():
+    """A fitted loop holds an exact whole number of periods, so it has no seam.
+
+    Unfitted, the pattern arrives back at its starting point part-way through a
+    period, and the stroke that closes the loop is the wrong length.
+    """
+    positions = regular_polygon(99, r=3.3)
+    perimeter = 99 * polygon_side_length(99, 3.3)
+
+    exact = bake(positions, loop=True)
+    assert np.allclose(exact[-1], perimeter)
+    assert not np.isclose(exact[-1] / PERIOD, round(exact[-1] / PERIOD), atol=1e-3), (
+        "this geometry is meant to be an awkward fit, so that the test can bite"
+    )
+
+    fitted = bake(positions, loop=True, dash_fit="stretch")
+    assert np.isclose(fitted[-1] / PERIOD, round(fitted[-1] / PERIOD))
+    # The stretch is only the small factor needed to reach the nearest fit.
+    assert 0.9 < fitted[-1] / perimeter < 1.1
+
+
+def test_dash_fit_ends_an_open_piece_on_a_stroke():
+    """An open piece is fitted to a whole number of periods less the final gap.
+
+    Fitting it to whole periods instead would leave it ending in empty space,
+    since the piece starts at the beginning of a stroke.
+    """
+    positions = np.array([[0, 0, 0], [10.3, 0, 0]], np.float32)
+    fitted = bake(positions, dash_fit="stretch")
+    assert np.allclose(fitted[-1], 10.0)  # 3 periods less the final gap
+    assert np.isclose((fitted[-1] + LAST_GAP) / PERIOD, 3.0)
+
+
+def test_dash_fit_is_per_piece():
+    """Each nan-separated piece is fitted on its own.
+
+    This is the whole point of fitting: pieces have different lengths, so a
+    single global factor could not make all of them come out whole.
+    """
+    positions = np.vstack(
+        [
+            np.array([[0, 0, 0], [10.3, 0, 0]], np.float32),  # open
+            NAN,
+            regular_polygon(3, r=1.0),  # closed, ~5.196 long
+            NAN,
+            regular_polygon(4, r=1.7),  # closed, ~9.617 long
+            NAN,
+            regular_polygon(99, r=3.3),  # closed, ~20.73 long
+        ]
+    ).astype(np.float32)
+    fitted = bake(positions, loop=True, dash_fit="stretch")
+
+    # The span of a piece sits at its last node: the connector for a loop, and
+    # the final node for the open piece.
+    assert np.allclose(fitted[1], 3 * PERIOD - LAST_GAP)  # open
+    assert np.allclose(fitted[6], 1 * PERIOD)  # triangle
+    assert np.allclose(fitted[11], 2 * PERIOD)  # square
+    assert np.allclose(fitted[-1], 5 * PERIOD)  # 99-gon
+
+
+def test_dash_fit_stretches_a_short_piece_to_one_period():
+    """A piece shorter than one period still gets a whole period, not zero."""
+    positions = regular_polygon(3, r=0.05)  # perimeter ~0.26, well under a period
+    fitted = bake(positions, loop=True, dash_fit="stretch")
+    assert np.allclose(fitted[-1], PERIOD)
+
+
+def test_dash_fit_exact_leaves_the_cumdist_alone():
+    """The default must be the plain arc length, i.e. bit-identical to no fitting."""
+    positions = np.vstack(
+        [
+            np.array([[0, 0, 0], [10.3, 0, 0]], np.float32),
+            NAN,
+            regular_polygon(4, r=1.7),
+        ]
+    ).astype(np.float32)
+    assert np.array_equal(
+        bake(positions, loop=True), bake(positions, loop=True, dash_fit="exact")
+    )
+    assert np.allclose(bake(positions, loop=True)[1], 10.3)
+
+
+def test_dash_fit_handles_a_pattern_that_is_all_gap():
+    """A pattern with no stroke has no stroke end to finish on.
+
+    `dash_pattern=[0, 4]` is a legal (if odd) pattern. The open-piece target of
+    `n * period - last_gap` is zero for it, which would scale the whole piece to
+    nothing; whole periods are used instead.
+    """
+    positions = np.array([[0, 0, 0], [10.3, 0, 0]], np.float32)
+    line = gfx.Line(
+        gfx.Geometry(positions=positions),
+        gfx.LineMaterial(
+            thickness=1,
+            dash_pattern=[0, 4],
+            thickness_space="model",
+            dash_fit="stretch",
+        ),
+    )
+    shader = LineShader(line)
+    shader.bake_function(line, gfx.OrthographicCamera(100, 100), (100, 100))
+    fitted = shader.line_distance_buffer.data
+
+    assert fitted[-1] > 0
+    assert np.isclose(fitted[-1] / 4.0, round(fitted[-1] / 4.0))
+
+
+def test_dash_fit_counts_ride_the_step_ladder_under_quantization():
+    """Under quantization the period count is snapped to a power of the step.
+
+    The nearest whole number would break the property that quantization exists
+    for: a level change must split each dash rather than move it, and a count of
+    7 cannot halve to a count of 3.5. A count on the power ladder always can, so
+    the dash edges of one level stay a strict subset of the next level's.
+    """
+    positions = regular_polygon(99, r=3.3)
+    line = gfx.Line(
+        gfx.Geometry(positions=positions),
+        gfx.LineMaterial(
+            thickness=8,
+            dash_pattern=[2, 2],
+            thickness_space="screen",
+            loop=True,
+            dash_scaling="quantized",
+            dash_fit="stretch",
+        ),
+    )
+    shader = LineShader(line)
+
+    counts = []
+    for exp in np.linspace(0, 4, 33):  # a smooth 16x zoom
+        width = 100 / 2**exp
+        shader.bake_function(line, gfx.OrthographicCamera(width, width), (1000, 1000))
+        counts.append(shader.line_distance_buffer.data[-1] / PERIOD)
+    counts = np.array(counts)
+
+    assert np.allclose(counts, np.round(counts)), "every count must be whole"
+    assert np.allclose(np.log2(counts), np.round(np.log2(counts))), (
+        "and must sit on the power-of-two ladder"
+    )
+    # Frame to frame the count either holds or doubles, never lands elsewhere.
+    ratios = counts[1:] / counts[:-1]
+    assert np.all(np.isclose(ratios, 1.0) | np.isclose(ratios, 2.0))
+    assert counts.max() > counts.min(), "the sweep must actually cross a level"
+
+    # Dash edges sit at multiples of 1/count around the loop, so a coarser
+    # level's edges are exactly a subset of a finer level's.
+    coarse, fine = int(counts.min()), int(counts.max())
+    assert set(np.arange(coarse) / coarse) <= set(np.arange(fine) / fine)
+
+
+def test_dash_fit_rebakes_when_the_pattern_or_thickness_changes():
+    """The fit depends on inputs the unfitted model-space cumdist does not.
+
+    In model space the bake short-circuits on the positions alone. The fit also
+    depends on the pattern and the thickness, so those have to join the hash or
+    a change to either is silently ignored.
+    """
+    positions = regular_polygon(99, r=3.3)
+    line = gfx.Line(
+        gfx.Geometry(positions=positions),
+        gfx.LineMaterial(
+            thickness=1,
+            dash_pattern=[2, 2],
+            thickness_space="model",
+            loop=True,
+            dash_fit="stretch",
+        ),
+    )
+    shader = LineShader(line)
+    camera = gfx.OrthographicCamera(100, 100)
+
+    def bake_span():
+        shader.bake_function(line, camera, (1000, 1000))
+        return shader.line_distance_buffer.data[-1]
+
+    first = bake_span()
+    line.material.thickness = 2
+    assert bake_span() != first, "a thickness change must re-fit"
+    line.material.thickness = 1
+    assert bake_span() == first
+    line.material.dash_pattern = [6, 2]
+    assert bake_span() != first, "a pattern change must re-fit"
+
+
+def spread(positions, **material_kwargs):
+    """Bake with dash_fit='spread' and return (cumdist, per-node gap scale)."""
+    material_kwargs.setdefault("thickness_space", "model")
+    line = gfx.Line(
+        gfx.Geometry(positions=positions),
+        gfx.LineMaterial(
+            thickness=1, dash_pattern=[2, 2], dash_fit="spread", **material_kwargs
+        ),
+    )
+    shader = LineShader(line)
+    shader.bake_function(line, gfx.OrthographicCamera(100, 100), (100, 100))
+    return (
+        shader.line_distance_buffer.data.copy(),
+        shader.line_gap_scale_buffer.data.copy(),
+    )
+
+
+def test_dash_fit_spread_leaves_the_strokes_alone():
+    """Only the gaps give, so the cumdist must be the plain arc length.
+
+    `stretch` reaches its fit by scaling the phase, which changes the strokes
+    with everything else. `spread` must not touch it: the strokes keep exactly
+    the size the pattern asks for, and the whole adjustment is carried by the
+    gap scale instead.
+    """
+    positions = np.array([[0, 0, 0], [25.3, 0, 0]], np.float32)
+    cumdist, gap_scale = spread(positions)
+
+    assert np.allclose(cumdist, bake(positions)), "the phase must be untouched"
+    assert np.allclose(gap_scale, gap_scale[0]), "one scale for the whole piece"
+    assert gap_scale[0] > 1.0, "this piece needs its gaps widened to fit"
+
+
+@pytest.mark.parametrize("length", [9.0, 12.5, 16.0, 19.9, 20.0, 25.3, 41.7, 100.0])
+def test_dash_fit_spread_never_asks_for_a_smaller_pattern(length):
+    """The pattern is a floor: the gaps may only ever grow.
+
+    This is what separates it from `stretch`, which reaches the *nearest* whole
+    number of periods and so compresses a piece about half the time.
+    """
+    positions = np.array([[0, 0, 0], [length, 0, 0]], np.float32)
+    _, gap_scale = spread(positions)
+    assert gap_scale.min() >= 1.0, f"gaps were narrowed to {gap_scale.min()}"
+
+
+def test_dash_fit_spread_fits_a_whole_number_of_periods():
+    """With the widened gaps, the piece must hold a whole number of periods.
+
+    The strokes total 2 and the gaps 2 per period, so a piece of phase span S
+    holds n periods of `2 + 2 * gap_scale` less the final widened gap.
+    """
+    for length in (12.5, 19.9, 25.3, 41.7, 100.0):
+        positions = np.array([[0, 0, 0], [length, 0, 0]], np.float32)
+        cumdist, gap_scale = spread(positions)
+        span, k = float(cumdist[-1]), float(gap_scale[0])
+        period = 2 + 2 * k
+        # Open piece: it ends on a stroke end, so the last gap is not included.
+        count = (span + 2 * k) / period
+        assert count == pytest.approx(round(count)), (
+            f"length {length}: {count} periods, not a whole number"
+        )
+        assert round(count) >= 1
+
+
+def test_dash_fit_spread_adds_a_stroke_instead_of_squeezing():
+    """As a piece grows the gaps widen, then a stroke appears and they snap back.
+
+    The count comes from a floor rather than a round, which is exactly what
+    makes the pattern a floor too.
+    """
+    counts, scales = [], []
+    for length in np.arange(20.0, 44.0, 1.0):
+        positions = np.array([[0, 0, 0], [length, 0, 0]], np.float32)
+        cumdist, gap_scale = spread(positions)
+        k = float(gap_scale[0])
+        scales.append(k)
+        counts.append(round((float(cumdist[-1]) + 2 * k) / (2 + 2 * k)))
+
+    assert max(counts) > min(counts), "the sweep must cross a stroke being added"
+    for i in range(1, len(counts)):
+        if counts[i] > counts[i - 1]:
+            assert scales[i] < scales[i - 1], "adding a stroke must narrow the gaps"
+        else:
+            assert scales[i] >= scales[i - 1] - 1e-6, "otherwise they only widen"
+
+
+def test_dash_fit_is_validated():
+    material = gfx.LineMaterial()
+    assert material.dash_fit == "exact"
+    material.dash_fit = "stretch"
+    assert material.dash_fit == "stretch"
+    with pytest.raises(ValueError):
+        material.dash_fit = "squash"
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I would like to consider an update to the dashing algorithm to help make things "more natural" presently the consistent "changing" of the path is dizzying.

#1315 and #1316 are in, so this is now rebased onto plain `main` and ready to look at.


Video recording has audio

https://github.com/user-attachments/assets/ee593927-af6e-4e4f-a2dd-f9e313cbd853



<details>
<summary>claude</summary>

> 🤖 This description was written by **Claude** (Claude Code) acting as @hmaarrfk's agent, in their checkout and at their direction. The commits are authored by them; the design, code and measurements are mine. Read it as machine-generated work and check it — every number below came from a command that is named, so it is reproducible.

**Draft, for evaluation.** The mechanism works and is measured; the API shape is the part that wants a maintainer's opinion.

## Where this sits

#1316 (CI fixes) and #1315 (the dashed-loop fixes — closes #1103, follows on from #1047) have both landed. History is now squashed to two commits — **the feature** and **the examples** — on top of one:

| | |
|---|---|
| #1324 | bake functions get the viewport size, not the canvas size |
| **this** | dashes that split instead of sliding, and dashes that fit the piece |

#1324 is included here because the split-view examples need it: without it the two panes disagree by thousands of pixels on settings that should be identical. It stands on its own and can merge first, after which this rebases down to its own two commits.

This is a genuine follow-on rather than a separate topic. #1315 established that a dash's phase error is proportional to its distance from the anchor, and fixed the part of that which showed up *between* nan-separated pieces. This addresses the part that shows up *within* one piece, which no amount of re-anchoring can reach.

## The problem

With `thickness_space="screen"` the cumulative distance is measured in screen pixels, so for view scale `s`:

```
dash_progress(L) = s * L / thickness   (mod D)
d(phase)/ds      = L / thickness
```

A dash drifts in proportion to its distance from the start of its line piece. Zooming makes the far end of a long line race while the near end sits still, and a dashed circle's pattern rotates as you scroll. Restarting the phase per piece (#1315) removed the drift *between* pieces; by construction it cannot touch the drift *within* one.

![dash_scale_step sweep](https://raw.githubusercontent.com/hmaarrfk/pygfx/pr-dash-scaling-media/dash_scale_step_sweep.png)

## The approach

Anchor the pattern in model space and let only its period follow the view, snapped:

```
one dash unit = step ** floor(log_step(thickness * model_units_per_pixel) + bias)
```

Dash edges then sit at multiples of `dash_size * step**level` in model space. When the step is a whole number, the edges of one level are a strict subset of the next level's, so **no edge ever moves**: each dash splits into `step` pieces, and new dashes appear in the gaps.

Measured on a straight line over a smooth 2x zoom in 17 steps:

| | edges surviving frame to frame | worst shift of a surviving edge |
|---|---|---|
| continuous | 14.2% | 0.84 model units |
| quantized | **100%** | **0.000** |

At a level change the edge count went 7 → 13 with all 7 originals intact.

## Two parameters, with the old behaviour as a point in the family

The first draft had only a "quantized or not" switch, which is the wrong shape: it made the existing behaviour a separate mode rather than a value. The base of the quantization fixes that, because `step ** floor(log_step(x) + bias)` tends to `x` as `step -> 1`.

**`dash_scale_step`** (>= 1, default 2) — the factor the size jumps by:

| step | worst \|quantized / continuous - 1\| over a zoom sweep |
|---|---|
| **1.0** | **0.00000012** — float32 noise, i.e. exactly continuous |
| 1.01 | 0.00496 |
| 1.1 | 0.0486 |
| 1.5 | 0.2218 |
| 2.0 | 0.4076 |

**`dash_max_scale`** (default `None` = centred) — where the size range sits. The range is always exactly one step wide, from `dash_max_scale / step` to `dash_max_scale`, and only its placement is free. Over four octaves of zoom (the observed overshoot is the hysteresis factor, 2^0.1 = 1.072):

| `dash_max_scale` | ideal | observed | meaning |
|---|---|---|---|
| `step` | [1.000, 2.000] | [1.000, 2.140] | never finer than asked |
| `sqrt(step)` (default) | [0.707, 1.414] | [0.759, 1.515] | closest to asked |
| 1 | [0.500, 1.000] | [0.500, 1.070] | never coarser than asked |

![the four steps](https://raw.githubusercontent.com/hmaarrfk/pygfx/pr-dash-scaling-media/dash_scaling_demo.png)

## Hysteresis (`dash_scale_hysteresis`)

The level snap is a Schmitt trigger. A plain threshold flickers badly when the view parks near a boundary — measured at a boundary over 200 frames:

| jitter | level changes without hysteresis | with |
|---|---|---|
| 0.5% | 108 | 0 |
| 5.0% | 108 | 0 |

How far past a boundary it holds is **`dash_scale_hysteresis`**, in fractions of a step, default 0.1 — a material property, alongside the rest of the pattern's appearance. Being able to set it to 0 is the only way to see the flicker it prevents, which is what the test does: 0 size changes at the default against more than 10 at zero. The price is that the dashes may stray that much further from the size asked for — the range widens by `step ** hysteresis` at each end, so at the default step of 2 the bound goes from 1.41 to 1.52.

A monotonic zoom still steps exactly once per level, about 7% later than the nominal point.

## What this does not do, and the things to argue with

* **Only a whole-number step gives dashes that truly never move.** The nesting needs levels to differ by a whole factor. At 1.25 or 1.6 the dashes still jump rather than slide, but they land somewhere new when they do. The dial is continuous; the "never moves" property is not.
* **Within one strongly foreshortened segment the dashes still bunch toward the far end.** The phase is linear in model space and the projection is not. At the nodes quantized and continuous agree to about 1e-6; between them ink coverage matches to 0.2% and the dashes sit a fraction of a period out. Removing that needs the scale chosen per fragment rather than per segment, using the `cumdist_per_pixel` varying the shader already carries.
* **The quantized bake no longer short-circuits.** An earlier version skipped it while one object-wide level held; a per-segment scale depends on the camera, so it runs every frame, at about the cost of the continuous path. Correctness was worth more than the saving.
* **There is a visible pop at each level change**, since the dash size changes by the step. The pop-free version morphs dash lengths across the change instead. I costed it and did not build it: the blocker is that a zero-length stroke does not vanish but renders as a dot, because round caps are added around it (measured: `dash_pattern=[0, 4]` gives 0.206 ink coverage, not 0). Making an inserted dash fade in would mean letting stroke length go negative by the cap radius, which varies per fragment — that is a rework of the dash/cap SDF, not a tweak.
* **A true "pinch in the middle" split does not work.** At level *k* strokes occupy `[0,2], [4,6], …`; at *k-1* they occupy `[0,1], [2,3], [4,5], …`. So `[0,2]` must become `[0,1]` with a *new* stroke at `[2,3]`. Pinching `[0,2]` in the middle converges to `[0,1]` and `[1,2]` — the wrong pattern, half a period out of phase, which would then have to slide to correct.
* **Screen thickness space only.** In model and world space the pattern is anchored to the object already, and quantizing would only make its size wrong; the shader falls back to continuous, and a test asserts it.
* **`LineMaterial` only, not `LineSegmentMaterial`**, which computes its cumdist in the shader rather than in the bake.
* **`dash_offset` is in whole periods** under this mode. A fractional offset shifts the pattern by half a period at each level change — reintroducing exactly the sliding this removes.

## A second knob: `dash_fit`

Added after the above, on the same theme of "the pattern should belong to the line rather than to the frame". A dash pattern has a period and a line piece has a length, and the two are almost never a whole multiple of each other, so the pattern stops wherever the piece ends. On a closed piece that is a **seam**: the pattern comes back round to its own start mid-period, and the stroke that closes the loop is cut short or lands on top of the first one. Every dashed circle in pygfx has one today.

`dash_fit="stretch"` scales each piece by the small factor that makes a whole number of periods span it. It is entirely in the bake -- the cumdist buffer *is* the dash phase, so this is a per-piece multiply, with no WGSL change and no pipeline rebuild.

Open and closed pieces get different targets. A closed piece is fitted to `n` whole periods so the pattern meets itself. An open piece is fitted to `n` periods *less the final gap*, so it begins and ends with a full stroke instead of trailing off into empty space -- which is what "fit the dashes to the path" means everywhere else it exists (Illustrator's *Aligns dashes to corners and path ends*).

The two features compose rather than fight, but only because the count is snapped differently under each scaling. Under `continuous` it is the nearest whole number. Under `quantized` that would break the whole point, since a level change must *split* each dash, which needs the count to be divisible by the step -- and 7 cannot halve to 3.5. So the count is snapped to a power of the step:

```
count = step ** round(log_step(wanted))
```

which is level-independent by construction, since `wanted` is proportional to `step**-level`. Measured over a smooth 16x zoom on a 99-gon:

| | count around the loop |
|---|---|
| `exact` | 5.183 … 82.924 — never whole, so the seam is always there |
| `stretch` | **4, 8, 16, 32, 64** — always whole, always exactly doubling |

So the loop closes at every zoom *and* nothing slides. The cost is one more factor of `sqrt(step)` of slack in the on-screen dash size, on top of quantization's own, and that pieces of different lengths end up with different dash sizes — which is inherent to fitting, not a limitation.

**This could reasonably be split into its own PR.** It is a separate user-facing knob and touches no shader code. It is here because the quantized interaction above is the interesting part of it, and that only exists in the context of this branch.

## Prior art

Worth knowing that nobody does this. Every library surveyed sits at one of two poles — pattern in object space (SVG, Skia, Cairo, Three.js: anchored, unbounded density) or in screen space (Cesium, OpenLayers, matplotlib: constant density, slides). matplotlib has this exact bug. The nearest thing is Mapbox GL JS, whose `line-dasharray` *is* a power-of-two LOD cross-fade — and which is also the one people file issues about, because it quantizes the bake but still stretches the pattern continuously in between.

The in-house precedent is `Ruler` (`pygfx/objects/_ruler.py:508-536`), which picks a step from a 1-2-2.5-5 ladder each frame and places ticks at absolute world multiples, so ticks appear and vanish but never translate. Powers of two rather than 1-2-5 here: the ladder breaks nesting at 5→2, and the payoff of 1-2-5 is round *labels*, which dashes do not have.

## Verification

* `tests/renderers/test_line_dashing.py` — 28 tests, asserting on the baked buffer rather than on pixels, since the expected values are exact. `dash_fit="exact"` is asserted bit-identical to the unfitted cumdist.
* Full suite: 374 passed. `ruff check .` and `ruff format --check .` clean.
* All 51 `compare` examples render **byte-identical** to #1315, on both this machine and in a lavapipe container, so nothing changes unless `dash_scaling` is set.
* `examples/feature_demo/line_dash_scaling.py` steps 1 → 1.25 → 1.6 → 2 on identical geometry.
* `examples/feature_demo/line_dashing_interactive.py` — every parameter on an imgui control, as a split view with pygfx's defaults on the left, since what these parameters change is *motion* and the shape of a closed path. Each pane holds a line, triangle, square, pentagon and 99-gon, so five piece lengths are on screen at once; the seam is visible on the left without moving anything. A **continuous** preset button returns the right pane to today's behaviour — verified pixel-identical to a genuine `dash_scaling="continuous"` material, 0–2 differing pixels out of ~12k across four zooms. Driven offscreen through 1536 control combinations.
* `examples/feature_demo/line_dashing_3d.py` — the same controls on a perspective camera, on the wireframe-cubes scene from `validate_line_thickness_space.py`, with an `fov` slider (0 is orthographic) and a flat square as the on-screen control for the depth-extent rule above. 2304 combinations.
* `examples/feature_demo/line_dash_scaling_interactive.py` puts every parameter on an imgui control, against a line pinned to `dash_scaling="continuous"` as a control, and animates the zoom — because what these parameters change is *motion*, which a static row of screenshots cannot show. Driven offscreen through every combination of the controls (5760 renders, each over a zoom sweep crossing several levels) with the GUI callback exercised on both branches of every widget.

The example also carries a toggle between drawing the five shapes as one nan-separated `Line` and as five separate `Line` objects sharing a material. That is a check rather than a demo — flipping it should not move anything — and it turned up one thing worth recording: the two differ by about 2e-7 relative, roughly 190 antialiased pixels out of 630,000, all at the loop seams. The cause is float32, not logic: a later piece's cumdist is summed straight through the lengths of the pieces before it and only then has its own offset subtracted, so it carries a couple of ulps that an object starting from zero does not. Pre-existing, harmless, and `dash_fit="stretch"` normalises exactly that quantity away (the seam phase comes out at 0.000000 both ways).

## The scale is per segment

`model_units_per_pixel` is not one number. The moment a line has any extent along the view direction, a segment running away from the camera covers far fewer pixels per model unit than one across the view. The first version of this took one factor per object, which is wrong in a way you can see: turn a cube edge-on and its receding edges fill with dashes the near edges do not have. Two segments of equal model length, one across the view and one receding, with a pattern asking for a 32 px period:

| | continuous | per-object | per-segment |
|---|---|---|---|
| face-on | 32.0 px | 35.9 px | **32.0 px** |
| foreshortened | 32.0 px | **14.1 px** | **28.2 px** |

Each segment gets its own level and its own hysteresis. The dashes still hold still, because a zoom changes every segment's scale by the same factor so the levels step together; a rotation changes them by different factors, which is exactly when the dashes *should* be redistributed. The segment closing a loop is foreshortened independently and gets its own scale too.

This also removes the limitation the first version had. `step=1` now reproduces continuous for *any* geometry from *any* camera:

| step=1 vs continuous, max deviation | per-object | per-segment |
|---|---|---|
| flat square, face-on | 0.00% | 0.000098% |
| cube, four camera angles | **49.87%** | **0.000235%** |

<sub>The images are hosted on the `pr-dash-scaling-media` branch of hmaarrfk/pygfx, which holds nothing but those two PNGs and can be deleted when this PR closes.</sub>

</details>





