### PR TITLE
Characterise the seam a line draws across a broken join

### DIFF
--- a/examples/validation/validate_line_join_seam.py
+++ b/examples/validation/validate_line_join_seam.py
@@ -1,0 +1,94 @@
+"""
+Line join seam
+==============
+
+* A row of increasingly sharp corners, dashed on top and solid below.
+* The dash phase is chosen so that a dash straddles each corner.
+* The lines are translucent, which is what makes the defect plain.
+
+**This example currently renders incorrectly**, on purpose: it is the picture of
+an open bug. Every pixel of a uniformly translucent line over a flat background
+must composite to the same value, and on the dashed row the inside of each
+corner from 70 degrees down is crossed by a darker hairline.
+
+A line overlaps itself wherever a join is "broken" -- a corner too sharp to be
+mitred, which the shader covers with the two segments' own caps instead. Those
+faces are coplanar and disagree about coverage where they overlap, so the depth
+test arbitrates, and the fragment that wins may be the one carrying a partial
+antialiasing alpha. That is the seam.
+
+Dashing is what makes these corners broken joins at all: the shader mitres up to
+`max_vec_mag`, which is 100 when solid but drops to 1.5 (about 90 degrees) when
+dashing. Hence the solid row below is clean at the same angles -- it is the
+control, not a second example of the bug.
+
+The corners are drawn separately rather than as one polygon so that each gets
+the same dash phase, which is what makes the row comparable.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+import numpy as np
+from rendercanvas.auto import RenderCanvas, loop
+import pygfx as gfx
+
+
+canvas = RenderCanvas(size=(1000, 500))
+renderer = gfx.WgpuRenderer(canvas)
+renderer.ppaa = "none"  # the seam is the shader's own, not the AA pass's
+
+scene = gfx.Scene()
+scene.add(gfx.Background.from_color("#000"))
+
+THICKNESS = 14.0
+# The dash phase at the corner is leg_length / THICKNESS, in dash units, so this
+# puts the corner one unit into a two-unit stroke: a dash sits astride it.
+LEG_LENGTH = 70.0
+ANGLES = [90, 70, 60, 45, 30]
+
+
+def corner(angle_deg, cx, cy):
+    """Two legs meeting at `angle_deg`, opening upwards from (cx, cy)."""
+    half = np.radians(angle_deg / 2)
+    dx, dy = LEG_LENGTH * np.sin(half), LEG_LENGTH * np.cos(half)
+    return np.array(
+        [[cx - dx, cy + dy, 0], [cx, cy, 0], [cx + dx, cy + dy, 0]], np.float32
+    )
+
+
+for i, angle in enumerate(ANGLES):
+    x = -380 + i * 190
+    for dashed, y, color in (
+        (True, 40, (1.0, 0.85, 0.33, 0.4)),
+        (False, -190, (0.47, 0.68, 1.0, 0.4)),
+    ):
+        scene.add(
+            gfx.Line(
+                gfx.Geometry(positions=corner(angle, x, y)),
+                gfx.LineMaterial(
+                    thickness=THICKNESS,
+                    color=color,
+                    aa=True,
+                    dash_pattern=[2, 2] if dashed else (),
+                ),
+            )
+        )
+    label = gfx.Text(
+        text=f"{angle}",
+        font_size=18,
+        screen_space=True,
+        anchor="middle-center",
+        material=gfx.TextMaterial(color="#888"),
+    )
+    label.local.position = (x, -60, 0)
+    scene.add(label)
+
+camera = gfx.OrthographicCamera(1000, 500)
+controller = gfx.PanZoomController(camera, register_events=renderer)
+
+canvas.request_draw(lambda: renderer.render(scene, camera))
+
+if __name__ == "__main__":
+    print(__doc__)
+    loop.run()

--- a/tests/renderers/test_line_join_seam.py
+++ b/tests/renderers/test_line_join_seam.py
@@ -1,0 +1,185 @@
+"""
+Characterise the seam a line draws across a broken join.
+
+A line overlaps itself wherever a join is "broken" -- a corner too sharp to be
+mitred, which the shader covers with the two segments' own caps instead. The
+two faces are coplanar and disagree about coverage in the overlap, and the
+depth test arbitrates between them. Under the default ``depth_compare="<"``
+only the first fragment survives, so where it sits on an antialiased edge that
+its sibling covers solidly, the pixel keeps a partial alpha: a dark hairline is
+drawn across the inside of the corner.
+
+These tests describe the defect rather than fix it. The requirement below is
+marked xfail, strictly, so that whoever does fix it is told by a failing
+XPASS rather than having to notice this file.
+
+The measurement uses a *translucent* line, which is much the better probe:
+
+* it is exact. Every inked pixel of a uniformly translucent line over a flat
+  background must be one value, so any departure is a defect and its direction
+  says which one -- darker means a fragment was dropped, brighter means one was
+  composited twice.
+* it is stable. The opaque seam depends on the pixel ratio (invisible at 1,
+  224/255 at 2, 241/255 at 4), so an opaque test can silently pass. The
+  translucent one shows the defect at every pixel ratio.
+
+Note that dashing is what makes a 60 degree corner a broken join at all: the
+shader mitres up to ``max_vec_mag``, which is 100 when solid but drops to 1.5
+(about 90 degrees) when dashing. A *solid* 60 degree corner is properly mitred
+and is clean.
+"""
+
+import numpy as np
+import pytest
+import wgpu
+
+import pygfx as gfx
+
+from ..testutils import can_use_wgpu_lib
+
+
+if not can_use_wgpu_lib:
+    pytest.skip("Skipping tests that need the wgpu lib", allow_module_level=True)
+
+
+SIZE = 200
+THICKNESS = 14.0
+ALPHA = 0.4
+# The criterion is uniformity, not a particular value: a line of one colour and
+# one alpha over a flat background must composite to one value everywhere, and
+# what that value is does not matter. (It is not 255*ALPHA, incidentally --
+# compositing happens in linear space, so 0.4 comes out at 170, not 102.)
+# Antialiasing makes the *edge* pixels legitimately different, so the interior
+# is eroded before measuring, and a few levels of slack are allowed.
+TOLERANCE = 4
+# The dash phase at the corner is leg_length / THICKNESS in dash units, so this
+# puts the corner one unit into a two-unit stroke: a dash sits astride it.
+LEG_LENGTH = 70.0
+
+
+def erode(mask, iterations=2):
+    """Shrink a boolean mask by `iterations` pixels, in all 8 directions."""
+    for _ in range(iterations):
+        m = mask
+        mask = np.pad(
+            m[1:-1, 1:-1]
+            & m[:-2, 1:-1]
+            & m[2:, 1:-1]
+            & m[1:-1, :-2]
+            & m[1:-1, 2:]
+            & m[:-2, :-2]
+            & m[:-2, 2:]
+            & m[2:, :-2]
+            & m[2:, 2:],
+            1,
+        )
+    return mask
+
+
+def render_corner(angle_deg, *, dashed=True, alpha=ALPHA, pixel_ratio=None, **kwargs):
+    """A translucent white corner on black, rendered offscreen.
+
+    The corner sits at the origin with both legs running upwards, so that the
+    inside of it -- the interesting part -- is in view.
+    """
+    half = np.radians(angle_deg / 2)
+    dx, dy = LEG_LENGTH * np.sin(half), LEG_LENGTH * np.cos(half)
+    positions = np.array([[-dx, dy, 0], [0, 0, 0], [dx, dy, 0]], np.float32)
+
+    target = gfx.Texture(
+        dim=2, size=(SIZE, SIZE, 1), format=wgpu.TextureFormat.rgba8unorm
+    )
+    renderer = gfx.WgpuRenderer(target)
+    # The seam is the line shader's own. Post-processing AA would only blur the
+    # evidence and make the numbers adapter-dependent.
+    renderer.ppaa = "none"
+    if pixel_ratio is not None:
+        renderer.pixel_ratio = pixel_ratio
+
+    scene = gfx.Scene()
+    scene.add(gfx.Background.from_color("#000"))
+    scene.add(
+        gfx.Line(
+            gfx.Geometry(positions=positions),
+            gfx.LineMaterial(
+                thickness=THICKNESS,
+                color=(1, 1, 1, alpha),
+                aa=True,
+                dash_pattern=[2, 2] if dashed else (),
+                **kwargs,
+            ),
+        )
+    )
+
+    camera = gfx.OrthographicCamera(SIZE, SIZE)
+    camera.local.position = (0, 45, 0)
+    renderer.render(scene, camera)
+    return renderer.snapshot()[..., 0].astype(int)
+
+
+def interior_range(image):
+    """The (min, max) of the pixels strictly inside the ink."""
+    interior = erode(image > 40)
+    assert interior.any(), "nothing was drawn, so the measurement proves nothing"
+    return int(image[interior].min()), int(image[interior].max())
+
+
+@pytest.mark.xfail(strict=True, reason="the broken-join seam is not fixed yet")
+@pytest.mark.parametrize("angle", [70, 60, 45, 30])
+def test_no_seam_across_a_broken_join(angle):
+    """A uniformly translucent line must render to one uniform value.
+
+    This is the requirement. It currently fails with the interior spanning
+    roughly 70..170 instead of a single value: a one-pixel dark line drawn
+    across the inside of the corner.
+    """
+    low, high = interior_range(render_corner(angle))
+    assert high - low <= TOLERANCE, (
+        f"the inside of a {angle} degree corner is not uniform: {low}..{high}"
+    )
+
+
+@pytest.mark.parametrize("angle", [90, 70, 60, 45])
+def test_a_mitred_join_is_clean(angle):
+    """A solid line mitres these corners, and mitred joins do not seam.
+
+    This is the control. It shows the defect belongs to the broken join and not
+    to sharp corners as such, and it guards the measurement: if this ever fails,
+    the harness is wrong rather than the shader.
+    Thirty degrees and sharper is excluded: a solid corner that sharp has a
+    small defect of its own (a spread of about 18), which `depth_compare` does
+    not affect either way and which is not understood.
+    """
+    low, high = interior_range(render_corner(angle, dashed=False))
+    assert high - low <= TOLERANCE, f"{angle} degrees: {low}..{high}"
+
+
+def test_depth_compare_le_is_not_the_fix():
+    """`depth_compare="<="` moves the error rather than removing it.
+
+    It is the obvious one-line candidate, and it does remove the *dark* seam,
+    because both coplanar fragments now survive instead of one being dropped.
+    But surviving means both composite, so the overlap is painted twice and the
+    seam comes back as a bright patch. On an opaque line that is invisible,
+    which is exactly why the opaque metric must not be trusted here.
+
+    Kept as a passing test so the candidate is not re-proposed.
+    """
+    plain_low, plain_high = interior_range(render_corner(60))
+    low, high = interior_range(render_corner(60, depth_compare="<="))
+    assert low > plain_low + 3 * TOLERANCE, "the dark seam should be gone"
+    assert high > plain_high + 3 * TOLERANCE, (
+        f"expected a bright patch from double compositing, got {low}..{high}"
+    )
+
+
+@pytest.mark.parametrize("pixel_ratio", [1, 2, 4])
+def test_the_defect_is_visible_at_every_pixel_ratio(pixel_ratio):
+    """Why this file measures a translucent line and not an opaque one.
+
+    The opaque seam is a resampling coincidence: it is invisible at pixel ratio
+    1 and only reaches 224/255 at 2. The translucent one is there at all of
+    them, so a test built on it cannot pass by accident.
+    """
+    low, high = interior_range(render_corner(60, pixel_ratio=pixel_ratio))
+    assert high - low > 3 * TOLERANCE, f"pixel ratio {pixel_ratio}: {low}..{high}"


### PR DESCRIPTION
Dashed lines draw a thin dark line straight across the inside of a sharp corner. It has always been there; it is easiest to notice on a dashed polygon, where a dash landing on a vertex puts the overlap in the middle of the ink rather than at the end of it.

Found while looking at something else in #1317, but entirely independent of it — it reproduces on plain `main` with a default `LineMaterial`.

**This PR does not fix it.** It pins the defect down with a measurement and an example, and records why the obvious one-line fix is wrong. Left as a draft for that reason.

## The defect, and why `depth_compare="<="` is not the fix

A row of corners from 90° down to 30°, translucent, rendered offscreen with `ppaa` off at 1:1 so every pixel is a real fragment, cropped to the corner and blown up 8×.

**Top row — `depth_compare="<"`, i.e. today.** A dark hairline across the inside of each corner from 70° down.
**Bottom row — `depth_compare="<="`, the obvious candidate.** The dark seam is gone and a *bright* lens has taken its place.

![translucent comparison](https://raw.githubusercontent.com/hmaarrfk/pygfx/pr-line-seam-media/seam_translucent.png)

Every inked pixel of a uniformly translucent line over a flat background must composite to the same value. At a 60° corner:

| `depth_compare` | interior min | interior max | |
|---|---|---|---|
| `"<"` (today) | **70** | 170 | dark seam |
| `"<="` (candidate) | 170 | **210** | bright patch |

`<=` moves the error rather than removing it. Both fragments now survive instead of one being dropped — and surviving means both composite, so the overlap is painted twice. On an *opaque* line that bright patch is invisible, which is exactly why an opaque metric must not be trusted here. A passing test asserts this, so the candidate does not get re-proposed.

## Cause

A line overlaps itself wherever a join is *broken* — a corner too sharp to be mitred, which the shader covers with the two segments' own caps instead. Those faces are coplanar and disagree about coverage where they overlap, so the depth test arbitrates, and the fragment that wins may be the one carrying a partial antialiasing alpha.

Dashing is what makes these corners broken joins at all: the shader mitres up to `max_vec_mag`, which is 100 when solid but drops to 1.5 (~90°) when dashing. So a *solid* 60° corner is properly mitred and is clean — that is the control in the test file, not a second symptom.

## Measuring it

The tests assert **uniformity** rather than a reference value, which keeps them adapter-independent: any spread across the eroded interior is a defect, and its direction says which one — darker means a fragment was dropped, brighter means one was composited twice.

This matters, because the opaque seam is a resampling coincidence: invisible at pixel ratio 1, `224/255` at 2, `241/255` at 4. A test built on it can pass by accident. The translucent one shows at every pixel ratio, and a test asserts that.

The requirement is marked `xfail(strict=True)`, so whoever fixes this is told by a failing XPASS rather than having to find the file.

## Where a real fix has to go

Any fix that leaves both faces drawing will hit the double-composite, so this is not reachable by patching the SDF each face evaluates. It points at not emitting overlapping geometry at a broken join at all — clipping the two contributions at the angle bisector so they tile rather than overlap.

An attempt at the union-of-capsules approach (pass the turn angle as a varying, have each cap take the `min` of the two capsule SDFs) was made and abandoned: it cleans up the opaque metric but still reads 70 on the translucent one, and it bleeds ink into gaps when the corner lands mid-gap, because the union ignores the neighbour's dash state.

One useful finding for whoever picks this up: `load_s_positions(index)` is a free indexed loader, so the vertex shader can already read nodes i−2 and i+2. A face knowing both of its bounding nodes' turn angles is reachable without new buffers.

## Known gap

A *solid* corner at ~30° or sharper has a small defect of its own (a spread of about 18), unaffected by `depth_compare` either way. Different mechanism, not understood, deliberately excluded rather than folded in.

## Verification

Suite 360 passed, 4 xfailed. Examples 125 passed, 71 skipped. `ruff check .` and `ruff format --check .` clean. No rendering code is changed, so the `compare` screenshots are untouched by construction.

`examples/validation/validate_line_join_seam.py` draws the row for eyeballing. It is marked `run` rather than `compare` deliberately: it currently renders *incorrectly* on purpose, and pinning that as a reference screenshot would be pinning the bug.

<sub>Images are on the `pr-line-seam-media` branch of hmaarrfk/pygfx, which holds nothing else and can be deleted when this PR closes.</sub>

---

🤖 This description was written by **Claude** (Claude Code) acting as @hmaarrfk's agent, in their checkout and at their direction. The commit is authored by them; the diagnosis, code and measurements are mine. Every number above came from a command that is named, so it is reproducible.

https://claude.ai/code/session_01PrzhWvnA9xhCauwXfx3WXc
