### PR TITLE
Give bake functions the viewport size, not the canvas size

### DIFF
--- a/pygfx/renderers/wgpu/engine/renderer.py
+++ b/pygfx/renderers/wgpu/engine/renderer.py
@@ -742,7 +742,7 @@ class WgpuRenderer(RootEventHandler, Renderer):
         flat.collect_pipelines_container_groups(renderstate)
 
         # Enable pipelines to update data on the CPU.
-        flat.call_bake_functions(camera, logical_size)
+        flat.call_bake_functions(camera, scene_lsize)
 
         # Update *all* buffers and textures that have changed
         for resource in resource_update_registry.get_syncable_resources(flush=True):

--- a/tests/renderers/test_viewport_bake_size.py
+++ b/tests/renderers/test_viewport_bake_size.py
@@ -1,0 +1,106 @@
+"""
+Test that bake functions are given the size of the viewport, not of the canvas.
+
+``renderer.render(..., rect=...)`` draws into part of the canvas, and already
+computes the logical size of that part in order to set the camera's view size.
+Bake functions were handed the size of the whole canvas instead. The only bake
+function in pygfx is the line shader's, which uses the size to convert ndc to
+logical pixels, so a dashed line drawn into a sub-viewport came out with its
+dashes scaled by the ratio between the canvas and the viewport -- about 2.6x too
+fine in a typical side-by-side layout.
+
+The test measures a property that does not depend on the adapter or on where the
+line happens to land: the on-screen dash period of a line drawn into a viewport
+must be the same as when the same line is drawn into the whole canvas.
+"""
+
+import numpy as np
+import pytest
+import wgpu
+
+import pygfx as gfx
+
+from ..testutils import can_use_wgpu_lib
+
+
+if not can_use_wgpu_lib:
+    pytest.skip("Skipping tests that need the wgpu lib", allow_module_level=True)
+
+
+WIDTH, HEIGHT = 900, 400
+# A viewport whose aspect differs strongly from the canvas, so that a wrong
+# size is unmistakable rather than a rounding difference.
+VIEW_WIDTH = 300
+THICKNESS = 8.0
+PATTERN = [2, 2]
+# The pattern is measured in units of the thickness, so this is the period the
+# dashes should have on screen, whatever they are drawn into.
+EXPECTED_PERIOD = THICKNESS * sum(PATTERN)
+
+
+def render_dashed_line(view_width=None, **material_kwargs):
+    """A horizontal dashed line, drawn either full-canvas or into a viewport.
+
+    The camera is always sized to the area being drawn into, so one model unit
+    is one logical pixel either way and the dash period can be read straight off
+    the image.
+    """
+    target = gfx.Texture(
+        dim=2, size=(WIDTH, HEIGHT, 1), format=wgpu.TextureFormat.rgba8unorm
+    )
+    renderer = gfx.WgpuRenderer(target)
+    renderer.ppaa = "none"
+    renderer.pixel_ratio = 1
+
+    positions = np.array([[-140, 0, 0], [140, 0, 0]], np.float32)
+    scene = gfx.Scene()
+    scene.add(gfx.Background.from_color("#000"))
+    scene.add(
+        gfx.Line(
+            gfx.Geometry(positions=positions),
+            gfx.LineMaterial(
+                thickness=THICKNESS,
+                color="#fff",
+                aa=False,
+                dash_pattern=PATTERN,
+                thickness_space="screen",
+                **material_kwargs,
+            ),
+        )
+    )
+
+    width = view_width if view_width else WIDTH
+    camera = gfx.OrthographicCamera(width, HEIGHT)
+    if view_width:
+        renderer.render(scene, camera, flush=False, rect=(0, 0, view_width, HEIGHT))
+        renderer.flush()
+    else:
+        renderer.render(scene, camera)
+    image = renderer.snapshot()[..., 0].astype(int)
+    return image[:, :width]
+
+
+def dash_period(image):
+    """The mean on-screen dash period, along the line's own row."""
+    ink = image > 128
+    assert ink.any(), "nothing was drawn"
+    row = ink[int(ink.sum(axis=1).argmax())]
+    starts = int((np.diff(row.astype(int)) == 1).sum())
+    assert starts >= 3, f"expected several dashes, found {starts}"
+    lit = np.flatnonzero(row)
+    return (lit.max() - lit.min()) / starts
+
+
+def test_dash_period_is_the_same_in_a_viewport_as_full_canvas():
+    """The dashes must not care which part of the canvas they are drawn into."""
+    full = dash_period(render_dashed_line())
+    viewport = dash_period(render_dashed_line(VIEW_WIDTH))
+
+    assert full == pytest.approx(EXPECTED_PERIOD, rel=0.15), (
+        f"the full-canvas reference is itself wrong: {full}"
+    )
+    assert viewport == pytest.approx(full, rel=0.1), (
+        f"dashes differ between viewport ({viewport:.1f} px) and "
+        f"full canvas ({full:.1f} px); the ratio of the two areas is "
+        f"{WIDTH / VIEW_WIDTH:.2f}"
+    )


### PR DESCRIPTION
Basically the bake functions don't take into account the viewport size, so it seems natural to do so.

This helps with "dashed lines" and whatnot

I was working on #1317 and doing some before and after side by sides.

You can see on the x axis, the dashing doesn't look quite "isotropic" since we are only rendering to "half the screen", and so the dashes look compressed on the x axis, and the y axis they look more normal,

On the left, is on main (with the rest of the window hidden), on the right is the application demo as #1317 (rebased onto this branch so that I can have the fix implemented)

<img width="2055" height="1294" alt="image" src="https://github.com/user-attachments/assets/8b409ba9-8b5f-4b3c-a9e4-b1da101c8e3c" />


<details><summary>claude</summary>

`renderer.render(..., rect=...)` already computes the logical size of the region it is drawing into — `scene_lsize` — and uses it to set the camera's view size. Bake functions were handed `logical_size`, the size of the whole canvas, instead.

```diff
-        flat.call_bake_functions(camera, logical_size)
+        flat.call_bake_functions(camera, scene_lsize)
```

The only bake function in pygfx is the line shader's, and it uses that size to convert ndc to logical pixels for the cumulative distance a dash pattern is measured along. So a dashed line with `thickness_space="screen"` drawn into a sub-viewport comes out with its dashes scaled by the ratio between the canvas and the viewport.

Measured on a 900 px canvas with a 300 px viewport, on a line whose pattern asks for a 32 px period:

| | on-screen dash period |
|---|---|
| full canvas | 31.4 px — correct |
| into a `rect` | **12.0 px** — 2.6× too fine, i.e. the width ratio |

## Why it matters beyond cosmetics

Any side-by-side or subplot layout silently draws its dashes at the wrong size, and two panes of *different* widths disagree with each other. `examples/feature_demo/scene_subplots1.py` is the shape of layout affected.

It also breaks an invariant that ought to hold: two materials that should be equivalent stop agreeing, because they read the size through different code paths. Building a split-screen comparison of dash settings, the two panes differed by ~4000 pixels where they should have been identical; with this change they come out at 0–2 px.

## Verification

`tests/renderers/test_viewport_bake_size.py` renders the same line full-canvas and into a viewport and asserts the on-screen dash period matches. It asserts a property rather than exact pixels, so it holds on any adapter, and it separately checks the full-canvas reference against the period the pattern actually asks for — so it cannot pass by both being wrong together.

**It bites**: reverting the one-word change fails it, reporting 12.0 px against 31.4 px.

All **52 `compare` examples render byte-identical** with and without the change (Metal, `PYGFX_DEFAULT_PPAA=none`, the same conditions the screenshot comparison uses). That is expected rather than lucky: none of them render into a `rect`, so `scene_lsize` and `logical_size` are the same thing for every one of them.

Suite 353 passed; examples 124 passed, 71 skipped. `ruff check .` and `ruff format --check .` clean.

---

🤖 This description was written by **Claude** (Claude Code) acting as @hmaarrfk's agent, in their checkout and at their direction. The commit is authored by them; the diagnosis, code and measurements are mine. Every number above came from a command that is named, so it is reproducible.

https://claude.ai/code/session_01PrzhWvnA9xhCauwXfx3WXc

</details>