### PR TITLE
Allow loop=int for lines

### DIFF
--- a/examples/feature_demo/line_loop_interactive.py
+++ b/examples/feature_demo/line_loop_interactive.py
@@ -1,0 +1,477 @@
+"""
+Closed shapes with material.loop = n
+====================================
+
+A field of random convex polygons, all of them corners of one buffer, drawn as
+closed shapes by ``material.loop = n``: every ``n``'th node closes back to the
+first node of its group. No nan-separators, no repeated end-points -- an
+``(m, n, 3)`` array of corners is reshaped to ``(m * n, 3)`` and handed over as
+it is.
+
+**What to look at.** Turn the opacity down and zoom in on a corner. The shapes
+are closed but nothing is drawn twice, so the seam where a shape meets itself
+is exactly as dark as the rest of it. That is the whole point of ``loop``: with
+a repeated end-point the first node would be painted over itself and show up as
+a brighter spot. See https://github.com/pygfx/pygfx/issues/1047.
+
+**nan loop** switches to the other way of writing the same picture: a buffer
+with a nan-position after every shape and ``material.loop = True``. It should
+look identical -- what differs is the cost. The nan buffer carries an extra node
+per shape, and closing the shapes that way means finding the nans, which is a
+scan of the positions on the CPU. Tick **positions change each frame** and watch
+the bake time at the bottom of the panel: with ``loop = n`` it stays at zero,
+because the shader needs no baked buffer at all.
+
+**loop length** is both the number of corners each shape is generated with and
+the value of ``material.loop``. It is the one control that rebuilds the position
+buffer.
+
+**objects** does not touch the geometry at all: the positions for the maximum
+number of shapes are uploaded once, and the slider only moves
+``geometry.positions.draw_range``. Ranges snap outward to whole shapes.
+
+**dash_pattern** puts the shapes on a dashed line. Each shape restarts its
+pattern from zero and its closing segment measures its own length, so the dashes
+run round a shape and meet themselves rather than arriving mid-period.
+
+Zoom with the wheel and pan by dragging. Tick **3D camera** for a perspective
+view with orbit; the shapes are scattered through a slab of depth and lean at
+random angles, so there is something for the perspective to do.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+import math
+import time
+
+import numpy as np
+import pylinalg as la
+from rendercanvas.auto import RenderCanvas, loop
+import pygfx as gfx
+from pygfx.renderers.wgpu.shaders.lineshader import LineShader
+from wgpu.utils.imgui import ImguiRenderer
+from imgui_bundle import imgui
+
+
+# Instrumentation, for this example only -- pygfx itself carries no timing code.
+# The renderer collects `shader.bake_function` from every shader that asks for
+# one, so wrapping it on the class measures exactly the per-frame CPU work that
+# a line's own dashing and loop buffers cost. It is a bound method that is
+# looked up when a pipeline is built, so this has to be in place before the
+# first render, which it is.
+BAKE_WINDOW = 60  # frames the timing is averaged over
+BAKE_SETTLE = 10  # frames before it is worth reporting at all
+_bake_ms = [0.0]  # accumulated within the current frame
+_bake_history = []
+_original_bake_function = LineShader.bake_function
+
+
+def _timed_bake_function(self, *args):
+    t0 = time.perf_counter()
+    _original_bake_function(self, *args)
+    _bake_ms[0] += (time.perf_counter() - t0) * 1e3
+
+
+LineShader.bake_function = _timed_bake_function
+
+
+TITLE = "Closed shapes with material.loop = n"
+CANVAS_SIZE = 1300, 820
+PANEL_WIDTH = 340
+LABEL_WIDTH = -150
+
+SEED = 7
+MAX_OBJECTS = 4000
+MIN_CORNERS, MAX_CORNERS = 3, 16
+FIELD = 1000.0  # half-width of the field of shapes
+DEPTH = 700.0  # half-depth of the slab they are scattered through
+MAX_TILT = 55.0  # degrees a shape's plane may lean away from the 2D view
+
+DASH_PATTERNS = [
+    ("none", []),
+    ("2, 2", [2, 2]),
+    ("4, 2", [4, 2]),
+    ("1, 3", [1, 3]),
+    ("6, 2, 2, 2", [6, 2, 2, 2]),
+]
+
+
+def make_positions(corners):
+    """The corners of MAX_OBJECTS random convex polygons, as (MAX_OBJECTS * n, 3).
+
+    Convex by construction: the corners of each shape sit on a circle at
+    increasing angles, which is always a convex cyclic polygon, and the scale,
+    tilt and translation applied afterwards are affine, so they keep it convex.
+
+    The per-object draws come first and in a fixed order, so changing `corners`
+    re-rolls the shapes but leaves every centre, size and tilt where it was.
+    """
+
+    def normalized(v):
+        return v / np.linalg.norm(v, axis=-1, keepdims=True)
+
+    rng = np.random.default_rng(SEED)
+    centers = rng.uniform(-1, 1, (MAX_OBJECTS, 1, 3)) * (FIELD, FIELD, DEPTH)
+    # Two half-axes, unequal so the shapes are not all near-circular
+    rx = rng.uniform(12.0, 55.0, (MAX_OBJECTS, 1, 1))
+    ry = rx * rng.uniform(0.35, 1.0, (MAX_OBJECTS, 1, 1))
+    # A random plane per shape, so that the 3D view has something to show. Its
+    # normal is drawn from a cone about the 2D view direction rather than from
+    # the whole sphere, so that face-on the shapes still read as shapes instead
+    # of collapsing to slivers; orbiting is what turns them edge-on.
+    lean = np.arccos(
+        rng.uniform(math.cos(math.radians(MAX_TILT)), 1.0, (MAX_OBJECTS, 1))
+    )
+    around = rng.uniform(0, 2 * np.pi, (MAX_OBJECTS, 1))
+    normal = np.stack(
+        [np.sin(lean) * np.cos(around), np.sin(lean) * np.sin(around), np.cos(lean)],
+        axis=-1,
+    )  # (m, 1, 3)
+    # Any two perpendicular axes within that plane; the in-plane orientation is
+    # random because the vector crossed in is.
+    u = normalized(np.cross(normal, rng.normal(size=(MAX_OBJECTS, 1, 3))))
+    v = np.cross(normal, u)
+
+    # Evenly spaced angles with a bounded jitter: varied shapes, but no two
+    # corners so close together that the join degenerates.
+    steps = np.arange(corners) + rng.uniform(-0.3, 0.3, (MAX_OBJECTS, corners))
+    angles = (steps * (2 * np.pi / corners))[..., np.newaxis]  # (m, n, 1)
+
+    positions = centers + rx * np.cos(angles) * u + ry * np.sin(angles) * v
+    return positions.reshape(-1, 3).astype(np.float32)
+
+
+def with_nans(positions, corners):
+    """The same shapes, written the classic way: a nan-position after each one.
+
+    That is what `material.loop = True` needs in order to tell the shapes apart,
+    and it is what `material.loop = n` exists to avoid: an extra node per shape,
+    and a copy of the whole array to put it there.
+    """
+    shapes = positions.reshape(-1, corners, 3)
+    out = np.full((len(shapes), corners + 1, 3), np.nan, np.float32)
+    out[:, :corners] = shapes
+    return out.reshape(-1, 3)
+
+
+_geometries = {}
+
+
+def get_geometry(corners, nan):
+    """The geometry for this corner count, in either layout, built once.
+
+    Only the current corner count is kept; both layouts of it are built together
+    so that toggling `nan loop` does not rebuild anything.
+    """
+    if (corners, nan) not in _geometries:
+        _geometries.clear()
+        positions = make_positions(corners)
+        _geometries[corners, False] = gfx.Geometry(positions=positions)
+        _geometries[corners, True] = gfx.Geometry(
+            positions=with_nans(positions, corners)
+        )
+    return _geometries[corners, nan]
+
+
+canvas = RenderCanvas(size=CANVAS_SIZE, title=TITLE)
+renderer = gfx.WgpuRenderer(canvas)
+
+scene = gfx.Scene()
+scene.add(gfx.Background.from_color("#000"))
+
+material = gfx.LineMaterial(
+    thickness=6,
+    color="#4cf",
+    alpha_mode="blend",
+    opacity=0.45,
+    loop=4,
+    aa=True,
+    thickness_space="screen",
+)
+line = gfx.Line(get_geometry(4, False), material)
+scene.add(line)
+
+# An orthographic camera in pygfx *is* a perspective one with fov 0 -- they are
+# the same class -- so the 2D and 3D views here are one camera with two values
+# of `fov`, and switching between them keeps the position, orientation and view
+# extent untouched. What changes is the projection, and which controller drives
+# it.
+VIEW_SIZE = CANVAS_SIZE[0] - PANEL_WIDTH, CANVAS_SIZE[1]
+camera = gfx.PerspectiveCamera(0)
+camera.width = 2.4 * FIELD
+camera.height = camera.width * VIEW_SIZE[1] / VIEW_SIZE[0]
+
+# The controller measures pan, zoom and rotate against a viewport's rect, so it
+# is given a viewport covering the render area rather than the whole canvas.
+# That is also what keeps the panel usable: `pointer_down` and `wheel` are gated
+# on `Viewport.is_inside`, so events over the panel fall outside and dragging a
+# slider does not move the camera as well.
+view = gfx.Viewport(renderer, rect=(0, 0, *VIEW_SIZE))
+panzoom = gfx.PanZoomController(camera)
+orbit = gfx.OrbitController(camera)
+
+
+def active_controller():
+    return orbit if state["camera_3d"] else panzoom
+
+
+def standoff(fov):
+    """How far back the camera must sit for `fov` to span the current extent.
+
+    Zero for an orthographic camera, which has no such distance: its rays are
+    parallel, so it can sit in the plane it is looking at -- which is where this
+    one starts, and why switching to a perspective projection without moving it
+    would put the scene at w = 0.
+
+    pygfx builds both projections from the same reference size, the mean of the
+    camera's width and height, and applies the same aspect correction to each,
+    so that cancels and equating the two extents at distance D gives this. The
+    zoom factor cancels as well, so a zoomed view switches just as cleanly.
+    """
+    if fov <= 0:
+        return 0.0
+    return 0.25 * (camera.width + camera.height) / math.tan(math.radians(fov) / 2)
+
+
+def set_fov(fov):
+    """Change the projection while keeping the framing.
+
+    The camera is dollied along its own axis by the change in standoff, so the
+    plane it was looking at still spans the same extent afterwards. Nothing on
+    screen moves; only the perspective does.
+    """
+    if fov == camera.fov:
+        return
+    delta = standoff(fov) - standoff(camera.fov)
+    camera.local.position = camera.local.position + la.vec_transform_quat(
+        (0, 0, delta), camera.local.rotation
+    )
+    camera.fov = fov
+
+
+renderer.add_event_handler(
+    lambda event: active_controller().handle_event(event, view),
+    "pointer_down",
+    "pointer_move",
+    "pointer_up",
+    "key_down",
+    "key_up",
+    "wheel",
+    "before_render",
+)
+home = camera.get_state()
+
+gui_renderer = ImguiRenderer(renderer.device, canvas)
+
+state = {
+    "opacity": 0.45,
+    "thickness": 6.0,
+    "loop_length": 4,
+    "n_objects": 400,
+    "nan_loop": False,
+    "stream": False,
+    "dash_pattern": 0,
+    "dash_offset": 0.0,
+    # Tick for a perspective camera with orbit; see `set_fov`.
+    "camera_3d": False,
+    "fov": 45.0,
+}
+OPENING_STATE = dict(state)
+applied = {}
+
+
+def apply_state():
+    if state == applied:
+        return
+    corners = state["loop_length"]
+    nan = state["nan_loop"]
+    applied.clear()
+    applied.update(state)
+    # The timing below is a rolling mean, so it has to start over whenever a
+    # control moves; otherwise it reports the previous setting for a second.
+    _bake_history.clear()
+
+    # The two layouts of the same shapes. Swapping between them is free; a new
+    # corner count is the one thing that rebuilds a buffer.
+    geometry = get_geometry(corners, nan)
+    if line.geometry is not geometry:
+        line.geometry = geometry
+
+    # The object count is only a draw range: the positions for MAX_OBJECTS are
+    # already on the GPU, and nothing is copied, re-baked or re-uploaded.
+    stride = corners + 1 if nan else corners
+    line.geometry.positions.draw_range = 0, state["n_objects"] * stride
+
+    material.opacity = state["opacity"]
+    material.thickness = state["thickness"]
+    material.loop = True if nan else corners
+    material.dash_pattern = DASH_PATTERNS[state["dash_pattern"]][1]
+    material.dash_offset = state["dash_offset"]
+
+    set_fov(state["fov"] if state["camera_3d"] else 0.0)
+
+
+def draw_imgui():
+    display = gui_renderer.backend.io.display_size
+    imgui.set_next_window_size((PANEL_WIDTH, display.y), imgui.Cond_.always)
+    imgui.set_next_window_pos((display.x - PANEL_WIDTH, 0), imgui.Cond_.always)
+    is_expand, _ = imgui.begin(
+        TITLE,
+        None,
+        flags=imgui.WindowFlags_.no_move
+        | imgui.WindowFlags_.no_resize
+        | imgui.WindowFlags_.no_collapse,
+    )
+    if is_expand:
+        imgui.push_item_width(LABEL_WIDTH)
+
+        if imgui.button("reset"):
+            state.update(OPENING_STATE)
+        imgui.same_line()
+        if imgui.button("reset view"):
+            camera.set_state(home)
+            set_fov(state["fov"] if state["camera_3d"] else 0.0)
+
+        imgui.separator_text("The shapes")
+        _, state["n_objects"] = imgui.slider_int(
+            "objects", state["n_objects"], 1, MAX_OBJECTS
+        )
+        imgui.set_item_tooltip(
+            "Only moves geometry.positions.draw_range. The corners of all\n"
+            f"{MAX_OBJECTS} shapes are uploaded once and never touched again,\n"
+            "so this costs nothing but the extra vertices.\n\n"
+            "A range that does not start or end on a shape boundary snaps\n"
+            "outward to one; an incomplete trailing shape is not drawn."
+        )
+        _, state["loop_length"] = imgui.slider_int(
+            "loop length", state["loop_length"], MIN_CORNERS, MAX_CORNERS
+        )
+        imgui.set_item_tooltip(
+            "material.loop -- how many nodes the shader treats as one closed\n"
+            "shape, and equally how many corners each shape is generated\n"
+            "with. The one control that rebuilds the position buffer."
+        )
+
+        imgui.separator_text("The line")
+        _, state["opacity"] = imgui.slider_float("opacity", state["opacity"], 0.05, 1.0)
+        imgui.set_item_tooltip(
+            "Turn this down and zoom in on a shape. Every part of it is the\n"
+            "same darkness, seam included -- nothing is drawn twice."
+        )
+        _, state["thickness"] = imgui.slider_float(
+            "thickness", state["thickness"], 0.5, 40.0
+        )
+        _, state["nan_loop"] = imgui.checkbox("nan loop", state["nan_loop"])
+        imgui.set_item_tooltip(
+            "Draw the same shapes the classic way: a buffer with a nan-position\n"
+            "after each shape and material.loop = True.\n\n"
+            "The picture is the same. What differs is one extra node per shape,\n"
+            "and a scan of the positions to find the nans whenever they change\n"
+            "-- which is what the bake time below measures."
+        )
+
+        imgui.separator_text("Dashing")
+        _, state["dash_pattern"] = imgui.combo(
+            "dash_pattern",
+            state["dash_pattern"],
+            [name for name, _ in DASH_PATTERNS],
+            len(DASH_PATTERNS),
+        )
+        imgui.set_item_tooltip(
+            "Dashing needs a cumulative distance per node, which is baked on\n"
+            "the CPU. With loop=n it is baked in the shader's virtual node\n"
+            "space, one extra slot per shape, so each shape's dashes start\n"
+            "at zero and its closing segment measures its own length rather\n"
+            "than the whole perimeter.\n\n"
+            "With 'none' there is no bake at all: loop=n is then pure index\n"
+            "arithmetic in the vertex shader, and nothing runs per frame."
+        )
+        imgui.begin_disabled(not DASH_PATTERNS[state["dash_pattern"]][1])
+        _, state["dash_offset"] = imgui.slider_float(
+            "dash_offset", state["dash_offset"], 0.0, 4.0
+        )
+        imgui.set_item_tooltip(
+            "The phase to start each shape's pattern at. Every shape starts\n"
+            "from the same phase, because each one restarts its cumulative\n"
+            "distance at zero."
+        )
+        imgui.end_disabled()
+
+        imgui.separator_text("Camera")
+        _, state["camera_3d"] = imgui.checkbox("3D camera", state["camera_3d"])
+        imgui.set_item_tooltip(
+            "Switch between an orthographic camera with pan/zoom and a\n"
+            "perspective one with orbit, in place. Position, orientation and\n"
+            "framing are kept, so nothing changes size or moves off screen.\n\n"
+            "The shapes are scattered through a slab of depth and tilted at\n"
+            "random, so orbiting shows them edge-on as well as face-on."
+        )
+        imgui.begin_disabled(not state["camera_3d"])
+        _, state["fov"] = imgui.slider_float("fov", state["fov"], 5.0, 120.0)
+        imgui.end_disabled()
+
+        imgui.separator_text("Cost")
+        _, state["stream"] = imgui.checkbox(
+            "positions change each frame", state["stream"]
+        )
+        imgui.set_item_tooltip(
+            "Mark the position buffer dirty every frame, as an app streaming\n"
+            "new positions would.\n\n"
+            "The loop bake is cached against the buffer's revision, so this is\n"
+            "what makes it run. (A screen-space dash bake depends on the camera\n"
+            "instead, so that one runs every frame either way.)"
+        )
+        positions = line.geometry.positions
+        drawn = state["n_objects"] * (
+            state["loop_length"] + 1 if state["nan_loop"] else state["loop_length"]
+        )
+        imgui.text(f"drawn: {drawn} of {positions.nitems} nodes")
+        imgui.text(f"buffer: {positions.nbytes / 1e6:.2f} MB")
+        if len(_bake_history) < BAKE_SETTLE:
+            imgui.text("bake: measuring...")
+        else:
+            mean_ms = sum(_bake_history) / len(_bake_history)
+            imgui.text(f"bake: {mean_ms:.3f} ms/frame")
+            if mean_ms == 0.0:
+                imgui.text_wrapped(
+                    "Nothing to bake. Undashed, loop = n is pure index "
+                    "arithmetic in the vertex shader: no buffer, and no CPU "
+                    "work per frame however the positions change."
+                    if not state["nan_loop"]
+                    else "Nothing to bake -- the positions have not changed "
+                    "since the last one. Tick the box above."
+                )
+
+        imgui.pop_item_width()
+    imgui.end()
+
+
+gui_renderer.set_gui(draw_imgui)
+
+
+def animate():
+    apply_state()
+    if state["stream"]:
+        # What an app that moves its data every frame costs. The data does not
+        # actually change here; marking the buffer dirty is what re-triggers the
+        # upload and the bake, which is the part being measured.
+        line.geometry.positions.update_full()
+
+    width, height = canvas.get_logical_size()
+    view.rect = 0, 0, width - PANEL_WIDTH, height
+    _bake_ms[0] = 0.0
+    renderer.render(scene, camera, flush=False, rect=view.rect)
+    renderer.flush()
+
+    _bake_history.append(_bake_ms[0])
+    del _bake_history[:-BAKE_WINDOW]
+
+    gui_renderer.render()
+    canvas.request_draw()
+
+
+if __name__ == "__main__":
+    print(__doc__)
+    renderer.request_draw(animate)
+    loop.run()

--- a/examples/feature_demo/line_loop_interactive.py
+++ b/examples/feature_demo/line_loop_interactive.py
@@ -30,6 +30,13 @@ buffer.
 number of shapes are uploaded once, and the slider only moves
 ``geometry.positions.draw_range``. Ranges snap outward to whole shapes.
 
+**nan probability** scatters nans through the packed layout. A nan there is a
+hole in a ring, not a separator: the shape breaks open at that corner and the
+two ends get caps, while the closing segment survives as long as the first and
+last node do. That is different from what a nan means under **nan loop**, where
+it parts the buffer into pieces and each surviving run of three or more nodes
+becomes a loop of its own.
+
 **dash_pattern** puts the shapes on a dashed line. Each shape restarts its
 pattern from zero and its closing segment measures its own length, so the dashes
 run round a shape and meet themselves rather than arriving mid-period.
@@ -82,6 +89,7 @@ PANEL_WIDTH = 340
 LABEL_WIDTH = -150
 
 SEED = 7
+NAN_SEED = 11  # separate, so that poking nans does not re-roll the shapes
 MAX_OBJECTS = 4000
 MIN_CORNERS, MAX_CORNERS = 3, 16
 FIELD = 1000.0  # half-width of the field of shapes
@@ -156,22 +164,45 @@ def with_nans(positions, corners):
 
 
 _geometries = {}
+_clean_positions = {}
 
 
 def get_geometry(corners, nan):
     """The geometry for this corner count, in either layout, built once.
 
     Only the current corner count is kept; both layouts of it are built together
-    so that toggling `nan loop` does not rebuild anything.
+    so that toggling `nan loop` does not rebuild anything. A pristine copy of the
+    packed positions is kept alongside, because `poke_nans` writes over them.
     """
     if (corners, nan) not in _geometries:
         _geometries.clear()
+        _clean_positions.clear()
         positions = make_positions(corners)
+        _clean_positions[corners] = positions.copy()
         _geometries[corners, False] = gfx.Geometry(positions=positions)
         _geometries[corners, True] = gfx.Geometry(
             positions=with_nans(positions, corners)
         )
     return _geometries[corners, nan]
+
+
+def poke_nans(corners, probability):
+    """Make each corner of the packed layout a nan with the given probability.
+
+    Only the packed layout: under `nan loop` a nan already means something else,
+    namely the end of a piece. Here it is simply a node the shader cannot draw,
+    so the ring breaks open at that corner and the neighbours get caps.
+
+    Fixed seed, so the same corners are missing frame after frame rather than
+    flickering, and rewritten from the clean copy each time so that lowering the
+    slider brings the shapes back.
+    """
+    positions = _geometries[corners, False].positions
+    positions.data[:] = _clean_positions[corners]
+    if probability > 0:
+        rng = np.random.default_rng(NAN_SEED)
+        positions.data[rng.random(positions.nitems) < probability] = np.nan
+    positions.update_full()
 
 
 canvas = RenderCanvas(size=CANVAS_SIZE, title=TITLE)
@@ -270,6 +301,7 @@ state = {
     "loop_length": 4,
     "n_objects": 400,
     "nan_loop": False,
+    "nan_probability": 0.0,
     "stream": False,
     "dash_pattern": 0,
     "dash_offset": 0.0,
@@ -286,6 +318,10 @@ def apply_state():
         return
     corners = state["loop_length"]
     nan = state["nan_loop"]
+    repoke = (corners, state["nan_probability"]) != (
+        applied.get("loop_length"),
+        applied.get("nan_probability"),
+    )
     applied.clear()
     applied.update(state)
     # The timing below is a rolling mean, so it has to start over whenever a
@@ -297,6 +333,8 @@ def apply_state():
     geometry = get_geometry(corners, nan)
     if line.geometry is not geometry:
         line.geometry = geometry
+    if repoke:
+        poke_nans(corners, state["nan_probability"])
 
     # The object count is only a draw range: the positions for MAX_OBJECTS are
     # already on the GPU, and nothing is copied, re-baked or re-uploaded.
@@ -370,6 +408,24 @@ def draw_imgui():
             "and a scan of the positions to find the nans whenever they change\n"
             "-- which is what the bake time below measures."
         )
+        imgui.begin_disabled(state["nan_loop"])
+        _, state["nan_probability"] = imgui.slider_float(
+            "nan probability", state["nan_probability"], 0.0, 0.3
+        )
+        imgui.set_item_tooltip(
+            "Make each corner a nan with this probability, in the packed\n"
+            "layout.\n\n"
+            "A nan there is a hole in a ring rather than a separator: the shape\n"
+            "opens at that corner and both ends get caps, and the segment that\n"
+            "closes the ring still draws as long as the first and last node are\n"
+            "both finite. Nothing validates or scans -- the shader's ordinary\n"
+            "cap-on-a-non-finite-neighbour rule does all of it.\n\n"
+            "Under 'nan loop' a nan means the end of a piece instead, so this\n"
+            "is disabled there."
+        )
+        imgui.end_disabled()
+        if state["nan_loop"] and state["nan_probability"] > 0:
+            imgui.text_wrapped("Ignored: nans part the pieces in this layout.")
 
         imgui.separator_text("Dashing")
         _, state["dash_pattern"] = imgui.combo(

--- a/examples/validation/validate_line_loop_int.py
+++ b/examples/validation/validate_line_loop_int.py
@@ -1,0 +1,92 @@
+"""
+Line loops of fixed size
+========================
+
+Drawing many closed shapes with ``material.loop = n``, i.e. without having to
+separate (or close) the shapes with nan-positions.
+
+The top row uses ``loop=n``, with just the corners of each shape. The bottom row
+draws the same shapes the classic way: with an explicit nan-position between the
+shapes. The two rows should look identical.
+"""
+
+# sphinx_gallery_pygfx_docs = 'screenshot'
+# sphinx_gallery_pygfx_test = 'run'
+
+import numpy as np
+from rendercanvas.auto import RenderCanvas, loop
+import pygfx as gfx
+
+
+canvas = RenderCanvas(size=(800, 900))
+renderer = gfx.WgpuRenderer(canvas)
+scene = gfx.Scene()
+
+# The lines are semi-transparent, so that any overlap at the point that closes
+# the loop shows up as a brighter spot. Add a background to make that visible.
+scene.add(gfx.Background.from_color("#fff", "#000"))
+
+
+def shape(n, x, y):
+    """The n corners of a regular n-gon, without repeating the first one."""
+    t = np.linspace(0, 2 * np.pi, n, endpoint=False)
+    return np.stack([x + np.sin(t), y + np.cos(t), np.zeros_like(t)], axis=1)
+
+
+def shapes(n, y):
+    """A row of m shapes of n corners each, as one (m * n, 3) array."""
+    return np.concatenate([shape(n, 3 * i - 6, y) for i in range(5)], axis=0)
+
+
+nanpoint = np.full((1, 3), np.nan, dtype="f4")
+
+
+def with_nans(positions, n):
+    """The same positions, but with a nan-position between each shape."""
+    pieces = positions.reshape(-1, n, 3)
+    return np.concatenate(
+        [x for piece in pieces for x in (piece, nanpoint)], axis=0
+    ).astype("f4")
+
+
+for i, n in enumerate([3, 4, 5, 12]):
+    positions = shapes(n, -5.5 * i).astype("f4")
+
+    # Closed with loop=n: n positions per shape
+    material = gfx.LineMaterial(
+        thickness=12,
+        color="red",
+        alpha_mode="blend",
+        opacity=0.6,
+        loop=n,
+        aa=True,
+        dash_pattern=(2, 1) if i % 2 else (),
+    )
+    scene.add(gfx.Line(gfx.Geometry(positions=positions), material))
+
+    # Closed with loop=True: n + 1 positions per shape, the last one nan
+    material = gfx.LineMaterial(
+        thickness=12,
+        color="cyan",
+        alpha_mode="blend",
+        opacity=0.6,
+        loop=True,
+        aa=True,
+        dash_pattern=(2, 1) if i % 2 else (),
+    )
+    positions_nan = with_nans(positions, n)
+    positions_nan[:, 1] -= 2.5
+    scene.add(gfx.Line(gfx.Geometry(positions=positions_nan), material))
+
+
+camera = gfx.OrthographicCamera(500, 500)
+camera.show_object(scene, match_aspect=True, scale=1.1)
+controller = gfx.PanZoomController(camera, register_events=renderer)
+
+
+canvas.request_draw(lambda: renderer.render(scene, camera))
+
+
+if __name__ == "__main__":
+    print(__doc__)
+    loop.run()

--- a/pygfx/materials/_line.py
+++ b/pygfx/materials/_line.py
@@ -1,3 +1,5 @@
+import numbers
+
 from ._base import Material
 from ..resources import Texture, TextureMap
 from ..utils import unpack_bitfield, Color, assert_type
@@ -25,8 +27,9 @@ class LineMaterial(Material):
         The pattern of the dash, e.g. `[2, 3]`. See `dash_pattern` docs for details. Defaults to an empty tuple, i.e. no dashing.
     dash_offset : float
         The offset into the dash phase. Default 0.0.
-    loop : bool
-        Whether the line's end should be connected. Default False.
+    loop : bool | int
+        Whether the line's end should be connected. Can also be an int to draw a
+        series of closed shapes with that many nodes each. Default False.
     aa : bool
         Whether the line is anti-aliased in the shader. Default False.
     kwargs : Any
@@ -247,19 +250,33 @@ class LineMaterial(Material):
         self.uniform_buffer.update_full()
 
     @property
-    def loop(self) -> bool:
+    def loop(self) -> bool | int:
         """Whether the line's ends should be connected.
 
         If set to True, the end of the line is connected to its beginning, in
         such a way there is no overlap (which would otherwise be visible for
         semi-transparent lines). When the line consists of multiple pieces
         separated by nan-positions, each line-piece is considered a loop.
+
+        Can also be set to an int ``n`` (>= 3), meaning that the positions
+        represent a series of closed shapes of ``n`` nodes each: nodes 0..n-1
+        form the first shape, nodes n..2n-1 the second, etc. No nan-separators
+        (nor repeated end-points) are needed; e.g. a buffer of ``4 * m``
+        positions draws ``m`` quadrilaterals with ``loop=4``. Positions that do
+        not fill a complete shape (at the end of the draw range) are ignored.
+
+        Since a loop needs at least 3 nodes, smaller values cannot denote a
+        shape, and are interpreted as a bool (as they were before shape-sizes
+        were a thing).
         """
         return self._store.loop
 
     @loop.setter
-    def loop(self, loop: bool):
-        self._store.loop = bool(loop)
+    def loop(self, loop: bool | int):
+        if isinstance(loop, numbers.Integral) and not isinstance(loop, bool):
+            self._store.loop = int(loop) if loop >= 3 else bool(loop)
+        else:
+            self._store.loop = bool(loop)
 
 
 class LineDebugMaterial(LineMaterial):

--- a/pygfx/renderers/wgpu/shaders/lineshader.py
+++ b/pygfx/renderers/wgpu/shaders/lineshader.py
@@ -46,6 +46,7 @@ class LineShader(BaseShader):
         self["thickness_space"] = material.thickness_space
         self["aa"] = material._gfx_effective_aa
         self["loop"] = False
+        self["loop_size"] = 0
         self["debug"] = False
 
         # Handle color
@@ -98,11 +99,19 @@ class LineShader(BaseShader):
         # ):
         #     # self["line_type"] = "quickline"
 
-        # Handle looping. The line_loop_buffer is one larger to enable looping the last point.
+        # Handle looping.
         self._loop_ranges_hash = None
         self._loop_ranges = []
         self._baked_loop_ranges = None
-        if material.loop:
+        if material.loop is not True and material.loop:
+            # Fixed-size loops: the positions are a series of closed shapes of
+            # material.loop nodes each. The shader renders one extra (virtual)
+            # node per shape to close it, so all it takes is index arithmetic.
+            self["loop"] = True
+            self["loop_size"] = int(material.loop)
+        elif material.loop:
+            # Nan-separated loops. The line_loop_buffer is one larger to enable
+            # looping the last point.
             self["loop"] = True
             self.line_loop_buffer = Buffer(
                 np.zeros((geometry.positions.nitems + 1,), np.uint32)
@@ -120,14 +129,21 @@ class LineShader(BaseShader):
             if not isinstance(material, LineSegmentMaterial):
                 self.needs_bake_function = True
                 self._cumdist_hash = None
-                # Like the loop buffer, this buffer is one larger when looping, so
-                # that the node that closes a loop can store the cumulative distance
-                # of the full loop (see _bake_line_distance).
+                # This buffer has room for the nodes that close the loops; they
+                # store the cumulative distance of the full loop (see
+                # _bake_line_distance). For nan-separated loops that's one extra
+                # slot in total; for fixed-size loops it's one per shape, since
+                # the buffer is then indexed in virtual node space.
                 self.line_distance_buffer = Buffer(
-                    np.zeros(
-                        (geometry.positions.nitems + int(self["loop"]),), np.float32
-                    )
+                    np.zeros((self._get_n_cumdist(geometry.positions),), np.float32)
                 )
+
+    def _get_n_cumdist(self, positions):
+        """The number of slots that the cumdist buffer needs."""
+        if self["loop_size"]:
+            n = self["loop_size"]
+            return max(1, (positions.nitems // n) * (n + 1))
+        return positions.nitems + int(self["loop"])
 
     def bake_function(self, wobject, camera, logical_size):
         if hasattr(self, "line_loop_buffer"):
@@ -203,6 +219,12 @@ class LineShader(BaseShader):
         positions_buffer = wobject.geometry.positions
         r_offset, r_size = positions_buffer.draw_range
 
+        if self["loop_size"]:
+            # Snap the range to whole shapes; incomplete shapes are not drawn.
+            n = self["loop_size"]
+            first_loop, n_loops = self._get_loop_slice(positions_buffer)
+            r_offset, r_size = first_loop * n, n_loops * n
+
         # Prepare arrays
         positions_array = positions_buffer.data[r_offset : r_offset + r_size]
         distance_array = self.line_distance_buffer.data[r_offset : r_offset + r_size]
@@ -245,6 +267,9 @@ class LineShader(BaseShader):
                 vertex_array[finites] = vertex_array_sub
             else:
                 vertex_array = vertex_array_sub
+
+        if self["loop_size"]:
+            return self._bake_line_distance_fixed_loops(vertex_array, r_offset)
 
         # Calculate distances
         distances = np.linalg.norm(vertex_array[1:] - vertex_array[:-1], axis=1)
@@ -292,6 +317,31 @@ class LineShader(BaseShader):
 
         # Mark that the data has changed
         self.line_distance_buffer.update_range(r_offset, r_size)
+
+    def _bake_line_distance_fixed_loops(self, vertex_array, r_offset):
+        """Bake the cumulative distance for fixed-size loops.
+
+        The cumdist buffer is indexed in *virtual* node space: each shape of n
+        nodes occupies n + 1 slots, the last of which holds the length of the
+        full (closed) shape. That is exactly how the shader indexes it, and it
+        makes the closing segment measure its own length rather than the whole
+        loop (see gh-1103).
+        """
+        n = self["loop_size"]
+        nodes = vertex_array.reshape(-1, n, vertex_array.shape[1])
+        # The n segments of each shape, the last one closing it
+        distances = np.linalg.norm(np.roll(nodes, -1, axis=1) - nodes, axis=2)
+        distances[~np.isfinite(distances)] = 0.0
+        # Cumulative, with a leading zero, so each shape has n + 1 values
+        cumdist = np.zeros((len(nodes), n + 1), np.float32)
+        cumdist[:, 1:] = np.cumsum(distances, axis=1)
+        # Store, in virtual node space
+        v_offset = (r_offset // n) * (n + 1)
+        v_size = cumdist.size
+        self.line_distance_buffer.data[v_offset : v_offset + v_size] = cumdist.reshape(
+            -1
+        )
+        self.line_distance_buffer.update_range(v_offset, v_size)
 
     def get_bindings(self, wobject, shared, scene):
         material = wobject.material
@@ -372,7 +422,19 @@ class LineShader(BaseShader):
             "cull_mode": wgpu.CullMode.none,
         }
 
+    def _get_loop_slice(self, positions):
+        """The index of the first shape to draw, and the number of shapes, for fixed-size loops."""
+        n = self["loop_size"]
+        offset, size = positions.draw_range
+        first_loop = offset // n
+        return first_loop, max(0, (offset + size) // n - first_loop)
+
     def _get_n(self, positions):
+        if self["loop_size"]:
+            # Each shape of n nodes is drawn as n + 1 (virtual) nodes.
+            stride = self["loop_size"] + 1
+            first_loop, n_loops = self._get_loop_slice(positions)
+            return first_loop * stride * 6, n_loops * stride * 6
         offset, size = positions.draw_range
         if self["loop"]:
             size += 1

--- a/pygfx/renderers/wgpu/wgsl/line.wgsl
+++ b/pygfx/renderers/wgpu/wgsl/line.wgsl
@@ -182,7 +182,56 @@ fn vs_main(in: VertexInput) -> Varyings {
     $$ if loop
     var is_first_node_in_loop = false;
     var is_connecting_node_in_loop = false;
+    $$ endif
 
+    $$ if loop_size
+    // Fixed-size loops. The positions represent a series of closed shapes of
+    // {{ loop_size }} nodes each, without nan-separators. We render one extra
+    // (virtual) node per shape: the connecting node that closes the loop. So
+    // the node_index obtained from the vertex index above is a *virtual* index,
+    // that we map onto the actual position index here. The virtual index is
+    // also the index into the cumdist buffer (which is baked in virtual space),
+    // so the cumdist logic below is the same as for nan-separated loops.
+    {
+        let loop_node_count = {{ loop_size }};
+        let index_in_loop = node_index % (loop_node_count + 1);
+        let loop_first = (node_index / (loop_node_count + 1)) * loop_node_count;
+        face_index = loop_first + index_in_loop;
+        node_index = face_index;
+        node_index_prev = node_index - 1;
+        node_index_next = node_index + 1;
+        $$ if dashing and line_type == 'line'
+        // Undo the clamping that was applied in virtual index space.
+        cumdist_index_prev = cumdist_index - 1;
+        cumdist_index_next = cumdist_index + 1;
+        $$ endif
+        if (index_in_loop == 0) { // first node
+            is_first_node_in_loop = true;
+            node_index_prev = loop_first + (loop_node_count - 1);
+            // The first node of a loop is both the start and the end of the line.
+            // Vertex 1-3 face the closing segment, so they use the cumdist stored at
+            // the connecting node; vertex 4-6 face the first segment and start at zero.
+            // The join is made up of two triangles (1,2,3) and (4,5,6), so the two
+            // cumdist values never mix within a triangle.
+            $$ if dashing and line_type == 'line'
+            cumdist_index = select(cumdist_index, cumdist_index + loop_node_count, vertex_num <= 3);
+            $$ endif
+        } else if (index_in_loop == loop_node_count - 1) { // last node
+            node_index_next = loop_first;
+            $$ if dashing and line_type == 'line'
+            cumdist_index_next = cumdist_index + 1;  // i.e. the connecting node
+            $$ endif
+        } else if (index_in_loop == loop_node_count) { // connecting node
+            // Note that cumdist_index (and cumdist_index_prev) are already correct,
+            // because they are in virtual index space.
+            node_index = loop_first;
+            node_index_prev = loop_first + (loop_node_count - 1);
+            node_index_next = loop_first + 1;
+            is_connecting_node_in_loop = true;
+        }
+    }
+
+    $$ elif loop
     let loop_state: u32 = load_s_loop(node_index);
     if (loop_state > 0x0fffffffu) {
         let loop_node_kind = loop_state >> 28;

--- a/tests/renderers/test_line_dashing.py
+++ b/tests/renderers/test_line_dashing.py
@@ -123,6 +123,63 @@ def test_cumdist_honors_the_draw_range():
     assert np.allclose(cumdist[2 : 2 + n + 1], side * np.arange(n + 1))
 
 
+def test_cumdist_of_fixed_size_loops():
+    """With loop=n, the cumdist buffer is indexed in virtual node space.
+
+    Each shape of n nodes gets n + 1 slots, the last of which holds the length
+    of the closed shape, exactly like the nan-node does for loop=True.
+    """
+    n, r, n_shapes = 4, 10.0, 3
+    side = polygon_side_length(n, r)
+    positions = np.vstack(
+        [regular_polygon(n, x=30.0 * i, r=r) for i in range(n_shapes)]
+    ).astype(np.float32)
+    cumdist = bake(positions, loop=n)
+
+    assert len(cumdist) == n_shapes * (n + 1)
+    for i in range(n_shapes):
+        assert np.allclose(
+            cumdist[i * (n + 1) : (i + 1) * (n + 1)], side * np.arange(n + 1)
+        )
+
+
+def test_cumdist_of_fixed_size_loops_matches_nan_separated_loops():
+    """loop=n and loop=True describe the same shapes, so the cumdist matches."""
+    n, r, n_shapes = 5, 7.0, 3
+    shapes = [regular_polygon(n, x=30.0 * i, r=r) for i in range(n_shapes)]
+    cumdist_int = bake(np.vstack(shapes).astype(np.float32), loop=n)
+    cumdist_nan = bake(
+        np.vstack([x for s in shapes for x in (s, NAN)]).astype(np.float32), loop=True
+    )
+    # The nan-version has one trailing slot that the int-version does not need
+    assert np.allclose(cumdist_int, cumdist_nan[: len(cumdist_int)])
+
+
+def test_cumdist_of_fixed_size_loops_honors_the_draw_range():
+    """The draw range snaps to whole shapes; other shapes are left alone."""
+    n, r, n_shapes = 4, 10.0, 4
+    side = polygon_side_length(n, r)
+    positions = np.vstack(
+        [regular_polygon(n, x=30.0 * i, r=r) for i in range(n_shapes)]
+    ).astype(np.float32)
+    line = gfx.Line(
+        gfx.Geometry(positions=positions),
+        gfx.LineMaterial(
+            thickness=1, dash_pattern=[2, 2], loop=n, thickness_space="model"
+        ),
+    )
+    line.geometry.positions.draw_range = n, 2 * n  # the 2nd and 3rd shape
+    camera = gfx.OrthographicCamera(100, 100)
+    shader = LineShader(line)
+    shader.bake_function(line, camera, (100, 100))
+
+    cumdist = shader.line_distance_buffer.data
+    assert np.all(cumdist[: n + 1] == 0)  # untouched
+    assert np.allclose(cumdist[n + 1 : 2 * (n + 1)], side * np.arange(n + 1))
+    assert np.allclose(cumdist[2 * (n + 1) : 3 * (n + 1)], side * np.arange(n + 1))
+    assert np.all(cumdist[3 * (n + 1) :] == 0)  # untouched
+
+
 def test_cumdist_with_nonfinites_in_other_thickness_spaces():
     """Nans must not trip up the transform to world/screen space."""
     positions = np.vstack([regular_polygon(4, r=10.0), NAN]).astype(np.float32)

--- a/tests/renderers/test_line_loop.py
+++ b/tests/renderers/test_line_loop.py
@@ -1,0 +1,79 @@
+"""Test looping lines, in particular the fixed-size loops of ``material.loop = n``."""
+
+import numpy as np
+import pygfx as gfx
+from pygfx.renderers.wgpu.shaders.lineshader import LineShader
+
+
+def make_shader(n_nodes, loop, draw_range=None):
+    line = gfx.Line(
+        gfx.Geometry(positions=np.zeros((n_nodes, 3), np.float32)),
+        gfx.LineMaterial(loop=loop),
+    )
+    if draw_range is not None:
+        line.geometry.positions.draw_range = draw_range
+    return line, LineShader(line)
+
+
+def test_material_loop_accepts_bools_and_ints():
+    assert gfx.LineMaterial(loop=False).loop is False
+    assert gfx.LineMaterial(loop=True).loop is True
+    assert gfx.LineMaterial(loop=0).loop is False
+    assert gfx.LineMaterial(loop=4).loop == 4
+    assert gfx.LineMaterial(loop=np.int64(4)).loop == 4
+
+    # A loop needs at least 3 nodes, so values below that cannot denote a shape
+    # size, and keep their original boolean meaning.
+    for value in [1, 2, -3]:
+        assert gfx.LineMaterial(loop=value).loop is True
+
+
+def test_fixed_size_loops_need_no_extra_buffers():
+    """The whole point: no per-node buffer, and no baking, just index math."""
+    _, shader = make_shader(12, loop=4)
+    assert shader["loop"] is True
+    assert shader["loop_size"] == 4
+    assert not hasattr(shader, "line_loop_buffer")
+    assert not shader.needs_bake_function
+
+    # Whereas nan-separated loops do need a buffer
+    _, shader = make_shader(12, loop=True)
+    assert shader["loop_size"] == 0
+    assert hasattr(shader, "line_loop_buffer")
+
+
+def test_fixed_size_loops_draw_one_extra_node_per_shape():
+    """Each shape of n nodes is drawn as n + 1 (virtual) nodes, 6 vertices each."""
+    line, shader = make_shader(12, loop=4)
+    offset, size = shader._get_n(line.geometry.positions)
+    assert (offset, size) == (0, 3 * 5 * 6)
+
+
+def test_fixed_size_loops_ignore_an_incomplete_trailing_shape():
+    line, shader = make_shader(14, loop=4)  # 3 shapes and 2 spare nodes
+    offset, size = shader._get_n(line.geometry.positions)
+    assert (offset, size) == (0, 3 * 5 * 6)
+
+
+def test_fixed_size_loops_honor_the_draw_range():
+    # The 2nd and 3rd shape
+    line, shader = make_shader(20, loop=4, draw_range=(4, 8))
+    offset, size = shader._get_n(line.geometry.positions)
+    assert (offset, size) == (1 * 5 * 6, 2 * 5 * 6)
+
+    # A range that does not start on a shape boundary snaps back to one
+    line, shader = make_shader(20, loop=4, draw_range=(2, 8))
+    offset, size = shader._get_n(line.geometry.positions)
+    assert (offset, size) == (0, 2 * 5 * 6)
+
+    # A range that is too small for a single shape draws nothing
+    line, shader = make_shader(20, loop=4, draw_range=(4, 3))
+    offset, size = shader._get_n(line.geometry.positions)
+    assert size == 0
+
+
+if __name__ == "__main__":
+    for name, func in list(globals().items()):
+        if name.startswith("test_"):
+            print(name)
+            func()


### PR DESCRIPTION
This finally closes one of my "wishlist" items from https://github.com/pygfx/pygfx/issues/1047

The hidden advantages is that because one does NOT need to walk through the whole position array, bake is free for solid lines.

Still a WIP.

* 100% of the code you see here is generated by Claude with my prompting. 
* 569 / 846 of the newly added lines of code are for a validation example and an interactive example.

<img width="1412" height="960" alt="image" src="https://github.com/user-attachments/assets/c7fe7368-f932-4bfa-acd5-742a47dd6838" />


<details><summary>Initial prompt</summary>

❯ lines can have loops, with loop=True, however, we are forced to add a nan at the end of every loop. i'm wondering if there is a way to do so without this. my main idea is that i want a buffer of the corners of a bunch of squares, with the implicit "closing" so a quadralateral would have 4 corners, not 5, then i want to draw like 200 of them, without copying the 4 corners into a buffer with 5 corners (where the last one is always nan), so the idea would be to set loop=4, which would mean that we want a loop to be generated every "4th" corner, can we do this? do your changes locally, in a new branch called integer_loop, do not commit your work, i want to see the differences, my main goal is to hopefully not change the shader code too much, perhaps a few places that change some offset or something, fingers crossed, i believe you can find an elegant solution https://github.com/pygfx/pygfx/issues/1047

</details>

<!--
Please see the Contribution Guide:
https://github.com/pygfx/pygfx/blob/main/CONTRIBUTING.md
-->
